### PR TITLE
fix(trade-republic): use compactPortfolio with secAccNo for portfolio sync

### DIFF
--- a/backend/src/main/java/com/picsou/adapter/TradeRepublicAdapter.java
+++ b/backend/src/main/java/com/picsou/adapter/TradeRepublicAdapter.java
@@ -14,14 +14,17 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
 import org.springframework.web.reactive.socket.client.ReactorNettyWebSocketClient;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.net.URI;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -36,10 +39,11 @@ import java.util.concurrent.atomic.AtomicReference;
  * Protocol version: 31. Session token is passed in each subscription payload.
  *
  * WebSocket subscriptions used:
- *   - availableCash  → cash balance (array response)
- *   - portfolioStatus (attempted) → per sub-account breakdown (PEA, CTO, etc.)
+ *   - availableCash      → cash balance
+ *   - compactPortfolio   → list of positions (instrumentId, netSize, averageBuyIn)
+ *   - ticker             → current price per instrument (subscribed dynamically)
  *
- * All raw WebSocket messages are logged at INFO level for debugging.
+ * Portfolio value = sum(ticker.last.price × position.netSize) for each position.
  */
 @Component
 public class TradeRepublicAdapter implements TradeRepublicPort {
@@ -150,17 +154,23 @@ public class TradeRepublicAdapter implements TradeRepublicPort {
     public List<TrAccountData> fetchAccounts(String sessionToken) {
         log.info("Fetching TR portfolio via WebSocket (protocol v{})", WS_VERSION);
 
-        AtomicReference<List<TrAccountData>> result = new AtomicReference<>();
-        AtomicInteger subId = new AtomicInteger(0);
+        List<String> secAccNos = extractSecAccountNumbers(sessionToken);
+        log.info("TR JWT sec accounts: {}", secAccNos);
 
-        // Cash response (array) and portfolio response (object)
-        AtomicReference<String> cashJson      = new AtomicReference<>();
-        AtomicReference<String> portfolioJson = new AtomicReference<>();
+        AtomicReference<String> cashJson = new AtomicReference<>();
+        ConcurrentHashMap<String, JsonNode> positionsByIsin = new ConcurrentHashMap<>();
+        ConcurrentHashMap<String, BigDecimal> tickerPrices = new ConcurrentHashMap<>();
+        ConcurrentHashMap<Integer, String> tickerSubToIsin = new ConcurrentHashMap<>();
+        ConcurrentHashMap<Integer, String> portfolioSubIds = new ConcurrentHashMap<>();
         AtomicBoolean authExpired = new AtomicBoolean(false);
+        AtomicInteger subIdCounter = new AtomicInteger(0);
+        AtomicInteger expectedTickers = new AtomicInteger(-1);
+        AtomicInteger receivedTickers = new AtomicInteger(0);
+        AtomicInteger receivedPortfolios = new AtomicInteger(0);
+        int totalPortfolioSubs = Math.max(secAccNos.size(), 1);
 
         HttpHeaders headers = new HttpHeaders();
         headers.set("Origin", "https://app.traderepublic.com");
-
         String connectMsg = buildConnectMessage();
 
         new ReactorNettyWebSocketClient()
@@ -169,58 +179,169 @@ public class TradeRepublicAdapter implements TradeRepublicPort {
                     .thenMany(
                         session.receive()
                             .map(msg -> msg.getPayloadAsText())
-                            .flatMap(text -> {
-                                log.debug("TR WS <-- {}", text.length() > 500 ? text.substring(0, 500) + "…" : text);
+                            .concatMap(text -> {
+                                log.info("TR WS <-- {}", text.length() > 500
+                                        ? text.substring(0, 500) + "…" : text);
 
                                 if ("connected".equals(text.trim())) {
-                                    int id1 = subId.incrementAndGet();
-                                    int id2 = subId.incrementAndGet();
-                                    String subCash      = sub(id1, "availableCash",   sessionToken);
-                                    String subPortfolio = sub(id2, "portfolioStatus", sessionToken);
-                                    log.debug("TR WS --> {}", subCash);
-                                    log.debug("TR WS --> {}", subPortfolio);
-                                    return session.send(Mono.just(session.textMessage(subCash)))
-                                        .then(session.send(Mono.just(session.textMessage(subPortfolio))))
-                                        .thenReturn(text);
+                                    int id1 = subIdCounter.incrementAndGet();
+                                    List<String> msgs = new ArrayList<>();
+                                    msgs.add(sub(id1, "availableCash", sessionToken));
+                                    log.info("TR WS --> sub {} availableCash", id1);
+
+                                    if (secAccNos.isEmpty()) {
+                                        int id2 = subIdCounter.incrementAndGet();
+                                        portfolioSubIds.put(id2, "default");
+                                        msgs.add(sub(id2, "compactPortfolio", sessionToken));
+                                        log.info("TR WS --> sub {} compactPortfolio (no secAccNo)", id2);
+                                    } else {
+                                        for (String accNo : secAccNos) {
+                                            int id = subIdCounter.incrementAndGet();
+                                            portfolioSubIds.put(id, accNo);
+                                            msgs.add(subCompactPortfolio(id, accNo, sessionToken));
+                                            log.info("TR WS --> sub {} compactPortfolio secAccNo={}", id, accNo);
+                                        }
+                                    }
+
+                                    return session.send(
+                                        Flux.fromIterable(msgs).map(session::textMessage)
+                                    ).thenReturn(text);
                                 }
 
-                                // WS message format: "{id} {type} {json}"
-                                // e.g. "1 A [...]" — strip id + single-char type
+                                int wsId = extractWsId(text);
                                 String payload = extractWsPayload(text);
+
                                 if (isAuthError(payload)) {
                                     log.warn("TR WS: session expired (AUTHENTICATION_ERROR)");
                                     authExpired.set(true);
-                                } else if (text.startsWith("1 ")) {
+                                    return Mono.just(text);
+                                }
+
+                                if (wsId == 1) {
                                     cashJson.set(payload);
-                                } else if (text.startsWith("2 ")) {
-                                    portfolioJson.set(payload);
-                                } else if (!"connected".equals(text.trim())) {
-                                    log.debug("TR WS <-- (unmatched) {}", text.length() > 400 ? text.substring(0, 400) + "…" : text);
+
+                                } else if (portfolioSubIds.containsKey(wsId)) {
+                                    String accNo = portfolioSubIds.get(wsId);
+                                    receivedPortfolios.incrementAndGet();
+                                    log.info("TR compactPortfolio [{}] raw: {}", accNo,
+                                             payload.length() > 2000
+                                                     ? payload.substring(0, 2000) + "…" : payload);
+                                    try {
+                                        JsonNode root = objectMapper.readTree(payload);
+                                        JsonNode posArray = root.isArray() ? root : root.path("positions");
+
+                                        if (posArray.isArray() && posArray.size() > 0) {
+                                            List<String> tickerMsgs = new ArrayList<>();
+                                            for (JsonNode pos : posArray) {
+                                                String isin = pos.path("instrumentId").asText("");
+                                                if (!isin.isEmpty()) {
+                                                    positionsByIsin.put(isin, pos);
+                                                    int tid = subIdCounter.incrementAndGet();
+                                                    tickerSubToIsin.put(tid, isin);
+                                                    tickerMsgs.add(subWithId(tid, "ticker",
+                                                            isin + ".LSX", sessionToken));
+                                                }
+                                            }
+                                            int prev = expectedTickers.get();
+                                            expectedTickers.set((prev < 0 ? 0 : prev) + tickerMsgs.size());
+                                            log.info("TR compactPortfolio [{}]: {} positions, subscribing to {} tickers",
+                                                     accNo, posArray.size(), tickerMsgs.size());
+
+                                            if (!tickerMsgs.isEmpty()) {
+                                                return session.send(
+                                                    Flux.fromIterable(tickerMsgs)
+                                                        .map(session::textMessage)
+                                                ).thenReturn(text);
+                                            }
+                                        } else {
+                                            int prev = expectedTickers.get();
+                                            expectedTickers.compareAndSet(-1, 0);
+                                            log.info("TR compactPortfolio [{}]: no positions found", accNo);
+                                        }
+                                    } catch (Exception ex) {
+                                        log.error("Failed to parse compactPortfolio [{}]: {}", accNo, payload, ex);
+                                        expectedTickers.compareAndSet(-1, 0);
+                                    }
+
+                                } else if (tickerSubToIsin.containsKey(wsId)) {
+                                    String isin = tickerSubToIsin.get(wsId);
+                                    receivedTickers.incrementAndGet();
+                                    try {
+                                        JsonNode tickerRoot = objectMapper.readTree(payload);
+                                        String priceStr = tickerRoot.path("last").path("price").asText(null);
+                                        if (priceStr != null) {
+                                            tickerPrices.put(isin, new BigDecimal(priceStr));
+                                        } else {
+                                            log.warn("TR ticker for {} — no last.price in: {}", isin,
+                                                     payload.length() > 300 ? payload.substring(0, 300) : payload);
+                                        }
+                                    } catch (Exception ex) {
+                                        log.warn("Failed to parse ticker for {}: {}", isin, payload);
+                                    }
                                 }
 
                                 return Mono.just(text);
                             })
-                            .takeUntil(text -> authExpired.get()
-                                    || (cashJson.get() != null && portfolioJson.get() != null))
-                            .timeout(Duration.ofSeconds(10))
+                            .takeUntil(text -> {
+                                if (authExpired.get()) return true;
+                                boolean cashDone = cashJson.get() != null;
+                                boolean allPortfoliosIn = receivedPortfolios.get() >= totalPortfolioSubs;
+                                int exp = expectedTickers.get();
+                                boolean tickersDone = allPortfoliosIn
+                                        && exp >= 0
+                                        && receivedTickers.get() >= exp;
+                                return cashDone && tickersDone;
+                            })
+                            .timeout(Duration.ofSeconds(30))
                             .onErrorReturn("timeout")
                     )
                     .then()
             )
-            .timeout(Duration.ofSeconds(30))
+            .timeout(Duration.ofSeconds(45))
             .block();
 
         if (authExpired.get()) {
             throw new SyncException("SESSION_EXPIRED");
         }
 
+        // ─── Build accounts from collected data ──────────────────────────────
+
         List<TrAccountData> accounts = new ArrayList<>();
 
-        if (portfolioJson.get() != null) {
-            accounts.addAll(parsePortfolioJson(portfolioJson.get()));
+        BigDecimal totalPortfolioValue = BigDecimal.ZERO;
+        int priced = 0;
+        for (var entry : positionsByIsin.entrySet()) {
+            String isin = entry.getKey();
+            JsonNode pos = entry.getValue();
+            BigDecimal size = new BigDecimal(pos.path("netSize").asText("0"));
+            BigDecimal price = tickerPrices.get(isin);
+
+            if (size.compareTo(BigDecimal.ZERO) <= 0) continue;
+
+            if (price != null && price.compareTo(BigDecimal.ZERO) > 0) {
+                totalPortfolioValue = totalPortfolioValue.add(
+                        price.multiply(size).setScale(2, RoundingMode.HALF_UP));
+                priced++;
+            } else {
+                BigDecimal avgBuyIn = new BigDecimal(pos.path("averageBuyIn").asText("0"));
+                if (avgBuyIn.compareTo(BigDecimal.ZERO) > 0) {
+                    totalPortfolioValue = totalPortfolioValue.add(
+                            avgBuyIn.multiply(size).setScale(2, RoundingMode.HALF_UP));
+                    log.warn("TR ticker price missing for {}, using averageBuyIn as fallback", isin);
+                }
+            }
         }
 
-        if (cashJson.get() != null && accounts.stream().noneMatch(a -> "tr_cash".equals(a.externalId()))) {
+        log.info("TR portfolio: {} positions, {} with live prices, total value: {}",
+                 positionsByIsin.size(), priced, totalPortfolioValue);
+
+        if (totalPortfolioValue.compareTo(BigDecimal.ZERO) > 0) {
+            accounts.add(new TrAccountData(
+                    "tr_securities", "TR Titres", AccountType.COMPTE_TITRES, totalPortfolioValue));
+        }
+
+        if (cashJson.get() != null
+                && accounts.stream().noneMatch(a -> "tr_cash".equals(a.externalId()))) {
             accounts.addAll(parseCashJson(cashJson.get()));
         }
 
@@ -239,9 +360,17 @@ public class TradeRepublicAdapter implements TradeRepublicPort {
         return payload != null && payload.contains("AUTHENTICATION_ERROR");
     }
 
-    /** Strips "{id} {type} " prefix from a WS message, returning just the JSON payload. */
+    private int extractWsId(String text) {
+        int space = text.indexOf(' ');
+        if (space <= 0) return -1;
+        try {
+            return Integer.parseInt(text.substring(0, space));
+        } catch (NumberFormatException e) {
+            return -1;
+        }
+    }
+
     private String extractWsPayload(String text) {
-        // Format: "1 A {...}" → skip past first space (id), then past second space (type char)
         int first = text.indexOf(' ');
         if (first < 0) return text;
         int second = text.indexOf(' ', first + 1);
@@ -266,24 +395,59 @@ public class TradeRepublicAdapter implements TradeRepublicPort {
 
     private String sub(int id, String type, String token) {
         try {
-            return "sub " + id + " " + objectMapper.writeValueAsString(Map.of("type", type, "token", token));
+            return "sub " + id + " " + objectMapper.writeValueAsString(
+                    Map.of("type", type, "token", token));
         } catch (Exception ex) {
             throw new SyncException("Failed to build subscription message: " + ex.getMessage());
         }
     }
 
-    /**
-     * Parses `availableCash` response (JSON array).
-     * Each element may represent a sub-account balance.
-     * Raw structure logged at INFO for debugging since format is undocumented.
-     */
+    private String subWithId(int id, String type, String idParam, String token) {
+        try {
+            return "sub " + id + " " + objectMapper.writeValueAsString(
+                    Map.of("type", type, "id", idParam, "token", token));
+        } catch (Exception ex) {
+            throw new SyncException("Failed to build subscription message: " + ex.getMessage());
+        }
+    }
+
+    private String subCompactPortfolio(int id, String secAccNo, String token) {
+        try {
+            Map<String, Object> payload = new java.util.LinkedHashMap<>();
+            payload.put("type", "compactPortfolio");
+            payload.put("secAccNo", secAccNo);
+            payload.put("token", token);
+            return "sub " + id + " " + objectMapper.writeValueAsString(payload);
+        } catch (Exception ex) {
+            throw new SyncException("Failed to build subscription message: " + ex.getMessage());
+        }
+    }
+
+    private List<String> extractSecAccountNumbers(String sessionToken) {
+        try {
+            String[] parts = sessionToken.split("\\.");
+            if (parts.length < 2) return List.of();
+            String payload = new String(java.util.Base64.getUrlDecoder().decode(parts[1]));
+            JsonNode root = objectMapper.readTree(payload);
+            JsonNode secAccounts = root.path("act").path("acc").path("owner").path("default").path("sec");
+            if (secAccounts.isArray()) {
+                List<String> result = new ArrayList<>();
+                for (JsonNode acc : secAccounts) {
+                    result.add(acc.asText());
+                }
+                return result;
+            }
+        } catch (Exception ex) {
+            log.warn("Failed to extract sec account numbers from JWT: {}", ex.getMessage());
+        }
+        return List.of();
+    }
+
     private List<TrAccountData> parseCashJson(String json) {
-        log.debug("TR availableCash raw: {}", json);
+        log.info("TR availableCash raw: {}", json);
         List<TrAccountData> accounts = new ArrayList<>();
         try {
             JsonNode root = objectMapper.readTree(json);
-
-            // Find JSON array in response (may be wrapped)
             JsonNode array = root.isArray() ? root : root.path("availableCash");
             if (array.isMissingNode()) array = root;
 
@@ -292,7 +456,7 @@ public class TradeRepublicAdapter implements TradeRepublicPort {
                     BigDecimal value = extractValue(item);
                     if (value.compareTo(BigDecimal.ZERO) >= 0) {
                         accounts.add(new TrAccountData("tr_cash", "TR Cash", AccountType.CHECKING, value));
-                        break; // take first entry
+                        break;
                     }
                 }
             } else if (array.isObject()) {
@@ -307,75 +471,11 @@ public class TradeRepublicAdapter implements TradeRepublicPort {
         return accounts;
     }
 
-    /**
-     * Parses `portfolioStatus` response.
-     * Expected shape (best-effort — structure varies by TR version):
-     * { "portfolioStatus": { "netValue": {...}, "subPortfolios": [...], "cashAccount": {...} } }
-     */
-    private List<TrAccountData> parsePortfolioJson(String json) {
-        log.debug("TR portfolioStatus raw: {}", json);
-        List<TrAccountData> accounts = new ArrayList<>();
-        try {
-            JsonNode root = objectMapper.readTree(json);
-            JsonNode data = root.has("portfolioStatus") ? root.get("portfolioStatus") : root;
-
-            JsonNode subs = data.path("subPortfolios");
-            if (!subs.isMissingNode() && subs.isArray()) {
-                for (JsonNode sub : subs) {
-                    String type  = sub.path("type").asText("");
-                    BigDecimal v = extractValue(sub.path("netValue"));
-                    if (v.compareTo(BigDecimal.ZERO) > 0) {
-                        accounts.add(new TrAccountData(
-                            "tr_" + type.toLowerCase(), labelFor(type), accountTypeFor(type), v));
-                    }
-                }
-            }
-
-            JsonNode cash = data.path("cashAccount");
-            if (!cash.isMissingNode()) {
-                BigDecimal v = extractValue(cash.path("netValue"));
-                if (v.compareTo(BigDecimal.ZERO) >= 0) {
-                    accounts.add(new TrAccountData("tr_cash", "TR Cash", AccountType.CHECKING, v));
-                }
-            }
-
-            if (accounts.isEmpty()) {
-                BigDecimal total = extractValue(data.path("netValue"));
-                if (total.compareTo(BigDecimal.ZERO) > 0) {
-                    log.warn("TR: sub-portfolios not found, using total net value as single account");
-                    accounts.add(new TrAccountData("tr_total", "Trade Republic", AccountType.COMPTE_TITRES, total));
-                }
-            }
-        } catch (Exception ex) {
-            log.error("Failed to parse TR portfolioStatus: {}", json, ex);
-        }
-        return accounts;
-    }
-
     private BigDecimal extractValue(JsonNode node) {
         if (node == null || node.isMissingNode()) return BigDecimal.ZERO;
         if (node.has("value"))   return new BigDecimal(node.get("value").asText("0"));
         if (node.has("amount"))  return new BigDecimal(node.get("amount").asText("0"));
         if (node.isNumber())     return node.decimalValue();
         return BigDecimal.ZERO;
-    }
-
-    private String labelFor(String t) {
-        return switch (t.toUpperCase()) {
-            case "PEA"          -> "TR PEA";
-            case "SECURITIES"   -> "TR CTO";
-            case "CRYPTO"       -> "TR Crypto";
-            case "SAVINGS_PLAN" -> "TR Plan d'épargne";
-            default             -> "TR " + t;
-        };
-    }
-
-    private AccountType accountTypeFor(String t) {
-        return switch (t.toUpperCase()) {
-            case "PEA"          -> AccountType.PEA;
-            case "CRYPTO"       -> AccountType.CRYPTO;
-            case "SAVINGS_PLAN" -> AccountType.SAVINGS;
-            default             -> AccountType.COMPTE_TITRES;
-        };
     }
 }


### PR DESCRIPTION
**Problème**
La sync Trade Republic n'importait que le cash (compte CHECKING), pas les positions/titres.

**Cause**
portfolioStatus ne retourne que des métadonnées de compte ({"status":"CREATED","hasInvested":true,...}), pas les positions
compactPortfolio nécessite le paramètre secAccNo (extrait du JWT) sinon il retourne {"positions":[]}
**Fix**
Remplace portfolioStatus par compactPortfolio avec secAccNo extrait du JWT session token
Souscrit dynamiquement aux ticker (LSX) pour chaque position afin d'obtenir les prix de marché en temps réel
Calcule la valeur totale : prix_actuel × quantité par position
Crée un compte "TR Titres" (COMPTE_TITRES) avec la valeur agrégée
Testé
Sync avec un vrai compte TR France : 2 comptes importés (cash + titres) au lieu de 1