### PR TITLE
feat(accounts): first-class STOCKS/ETF account types + manual price r…

### DIFF
--- a/backend/src/main/java/com/picsou/adapter/CoinGeckoPriceProvider.java
+++ b/backend/src/main/java/com/picsou/adapter/CoinGeckoPriceProvider.java
@@ -22,17 +22,29 @@ public class CoinGeckoPriceProvider implements PriceProviderPort {
     private static final Duration TIMEOUT = Duration.ofSeconds(10);
 
     // Map from ticker (uppercase) → CoinGecko coin ID
-    private static final Map<String, String> TICKER_TO_ID = Map.of(
-        "BTC", "bitcoin",
-        "ETH", "ethereum",
-        "SOL", "solana",
-        "BNB", "binancecoin",
-        "ADA", "cardano",
-        "XRP", "ripple",
-        "DOGE", "dogecoin",
-        "DOT", "polkadot",
-        "MATIC", "matic-network",
-        "AVAX", "avalanche-2"
+    private static final Map<String, String> TICKER_TO_ID = Map.ofEntries(
+        Map.entry("BTC", "bitcoin"),
+        Map.entry("ETH", "ethereum"),
+        Map.entry("SOL", "solana"),
+        Map.entry("BNB", "binancecoin"),
+        Map.entry("ADA", "cardano"),
+        Map.entry("XRP", "ripple"),
+        Map.entry("DOGE", "dogecoin"),
+        Map.entry("DOT", "polkadot"),
+        Map.entry("MATIC", "matic-network"),
+        Map.entry("AVAX", "avalanche-2"),
+        Map.entry("LTC", "litecoin"),
+        Map.entry("LINK", "chainlink"),
+        Map.entry("UNI", "uniswap"),
+        Map.entry("ATOM", "cosmos"),
+        Map.entry("NEAR", "near"),
+        Map.entry("ARB", "arbitrum"),
+        Map.entry("OP", "optimism"),
+        Map.entry("TRX", "tron"),
+        Map.entry("SHIB", "shiba-inu"),
+        Map.entry("USDT", "tether"),
+        Map.entry("USDC", "usd-coin"),
+        Map.entry("DAI", "dai")
     );
 
     private final WebClient webClient;

--- a/backend/src/main/java/com/picsou/adapter/YahooFinancePriceProvider.java
+++ b/backend/src/main/java/com/picsou/adapter/YahooFinancePriceProvider.java
@@ -8,28 +8,40 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.time.Duration;
+import java.time.Instant;
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 /**
  * Fetches stock/ETF prices from Yahoo Finance (unofficial, no API key needed).
- * Used for PEA/Compte-Titres positions with tickers like "IWDA.AS", "MC.PA", etc.
+ * Used for PEA/Compte-Titres/Stocks/ETF positions with tickers like
+ * "IWDA.AS", "MC.PA", "AAPL", etc.
  *
- * Note: This is an unofficial API. For production use consider Alpha Vantage or similar.
+ * Prices are normalized to EUR: if the quoted currency is not EUR, an FX
+ * rate is fetched from Yahoo (e.g. "EURUSD=X") and applied. FX rates are
+ * cached for 15 minutes.
+ *
+ * Note: this is an unofficial API; for production consider Alpha Vantage.
  */
 @Component
 public class YahooFinancePriceProvider implements PriceProviderPort {
 
     private static final Logger log = LoggerFactory.getLogger(YahooFinancePriceProvider.class);
     private static final Duration TIMEOUT = Duration.ofSeconds(10);
+    private static final long FX_CACHE_TTL_SECONDS = 900; // 15 minutes
 
     // Tickers that are handled by CoinGecko — we skip those
     private static final Set<String> CRYPTO_TICKERS = Set.of(
-        "BTC", "ETH", "SOL", "BNB", "ADA", "XRP", "DOGE", "DOT", "MATIC", "AVAX"
+        "BTC", "ETH", "SOL", "BNB", "ADA", "XRP", "DOGE", "DOT", "MATIC", "AVAX",
+        "LTC", "LINK", "UNI", "ATOM", "NEAR", "ARB", "OP", "TRX", "SHIB",
+        "USDT", "USDC", "DAI"
     );
 
     private final WebClient webClient;
+    private final Map<String, CachedFx> fxCache = new ConcurrentHashMap<>();
 
     public YahooFinancePriceProvider() {
         this.webClient = WebClient.builder()
@@ -57,7 +69,7 @@ public class YahooFinancePriceProvider implements PriceProviderPort {
         // Yahoo Finance is fetched per-ticker (no batch endpoint for EUR conversion)
         for (String ticker : supported) {
             try {
-                BigDecimal price = fetchSinglePrice(ticker);
+                BigDecimal price = fetchEurPrice(ticker);
                 if (price != null) result.put(ticker.toUpperCase(), price);
             } catch (Exception ex) {
                 log.warn("Yahoo Finance price fetch failed for {}: {}", ticker, ex.getMessage());
@@ -67,7 +79,7 @@ public class YahooFinancePriceProvider implements PriceProviderPort {
         return result;
     }
 
-    private BigDecimal fetchSinglePrice(String ticker) {
+    private BigDecimal fetchEurPrice(String ticker) {
         YahooResponse response = webClient.get()
             .uri("/v8/finance/chart/{ticker}?range=1d&interval=1d", ticker)
             .retrieve()
@@ -86,9 +98,63 @@ public class YahooFinancePriceProvider implements PriceProviderPort {
         double price = result.meta().regularMarketPrice();
         if (price <= 0) return null;
 
-        // If ticker already includes EUR currency (e.g. .PA, .AS), price is in EUR
-        // If it's a USD-denominated asset, we'd need FX conversion (simplified: use as-is for now)
-        return BigDecimal.valueOf(price);
+        BigDecimal value = BigDecimal.valueOf(price);
+        String currency = result.meta().currency();
+
+        // Yahoo sometimes quotes UK stocks in pence (GBp) — divide by 100 to get GBP
+        if ("GBp".equalsIgnoreCase(currency) || "GBX".equalsIgnoreCase(currency)) {
+            value = value.divide(BigDecimal.valueOf(100), 8, RoundingMode.HALF_UP);
+            currency = "GBP";
+        }
+
+        if (currency == null || currency.isBlank() || "EUR".equalsIgnoreCase(currency)) {
+            return value;
+        }
+
+        BigDecimal fxRate = getEurFxRate(currency);
+        if (fxRate == null) {
+            log.warn("No FX rate available for {} → EUR, returning unconverted price for {}", currency, ticker);
+            return value;
+        }
+
+        // fxRate = how many <currency> per 1 EUR. To convert <currency> → EUR, divide.
+        return value.divide(fxRate, 8, RoundingMode.HALF_UP);
+    }
+
+    /**
+     * Fetches EUR<CCY>=X from Yahoo. Returns the number of <CCY> per 1 EUR
+     * (e.g. EURUSD=X ≈ 1.08 means 1 EUR = 1.08 USD).
+     */
+    private BigDecimal getEurFxRate(String currency) {
+        String upper = currency.toUpperCase();
+        CachedFx cached = fxCache.get(upper);
+        if (cached != null && !cached.isExpired()) {
+            return cached.rate();
+        }
+
+        try {
+            YahooResponse response = webClient.get()
+                .uri("/v8/finance/chart/EUR{ccy}=X?range=1d&interval=1d", upper)
+                .retrieve()
+                .bodyToMono(YahooResponse.class)
+                .timeout(TIMEOUT)
+                .block();
+
+            if (response == null || response.chart() == null || response.chart().result() == null
+                || response.chart().result().isEmpty()) {
+                return null;
+            }
+
+            var meta = response.chart().result().get(0).meta();
+            if (meta == null || meta.regularMarketPrice() <= 0) return null;
+
+            BigDecimal rate = BigDecimal.valueOf(meta.regularMarketPrice());
+            fxCache.put(upper, new CachedFx(rate, Instant.now()));
+            return rate;
+        } catch (Exception ex) {
+            log.warn("Failed to fetch EUR{}=X FX rate: {}", upper, ex.getMessage());
+            return null;
+        }
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -102,4 +168,10 @@ public class YahooFinancePriceProvider implements PriceProviderPort {
 
     @JsonIgnoreProperties(ignoreUnknown = true)
     record Meta(double regularMarketPrice, String currency) {}
+
+    private record CachedFx(BigDecimal rate, Instant cachedAt) {
+        boolean isExpired() {
+            return Instant.now().isAfter(cachedAt.plusSeconds(FX_CACHE_TTL_SECONDS));
+        }
+    }
 }

--- a/backend/src/main/java/com/picsou/controller/PriceController.java
+++ b/backend/src/main/java/com/picsou/controller/PriceController.java
@@ -1,12 +1,16 @@
 package com.picsou.controller;
 
+import com.picsou.model.Account;
+import com.picsou.repository.AccountRepository;
 import com.picsou.service.PriceService;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.math.BigDecimal;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Set;
@@ -17,9 +21,11 @@ import java.util.stream.Collectors;
 public class PriceController {
 
     private final PriceService priceService;
+    private final AccountRepository accountRepository;
 
-    public PriceController(PriceService priceService) {
+    public PriceController(PriceService priceService, AccountRepository accountRepository) {
         this.priceService = priceService;
+        this.accountRepository = accountRepository;
     }
 
     @GetMapping
@@ -31,4 +37,26 @@ public class PriceController {
 
         return priceService.refreshPrices(tickerSet);
     }
+
+    /**
+     * Force-refresh prices for every account that has a ticker.
+     * Bypasses the 15-minute cache by overwriting cached entries.
+     */
+    @PostMapping("/refresh")
+    public RefreshResponse refreshAll() {
+        Set<String> tickers = accountRepository.findByTickerIsNotNull().stream()
+            .map(Account::getTicker)
+            .filter(t -> t != null && !t.isBlank())
+            .collect(Collectors.toSet());
+
+        Map<String, BigDecimal> prices = priceService.refreshPrices(tickers);
+        return new RefreshResponse(prices.size(), tickers.size(), prices, Instant.now());
+    }
+
+    public record RefreshResponse(
+        int refreshed,
+        int requested,
+        Map<String, BigDecimal> prices,
+        Instant refreshedAt
+    ) {}
 }

--- a/backend/src/main/java/com/picsou/model/AccountType.java
+++ b/backend/src/main/java/com/picsou/model/AccountType.java
@@ -5,6 +5,8 @@ public enum AccountType {
     PEA,
     COMPTE_TITRES,
     CRYPTO,
+    STOCKS,
+    ETF,
     CHECKING,
     SAVINGS,
     OTHER

--- a/backend/src/main/resources/db/migration/V8__add_stocks_etf_account_types.sql
+++ b/backend/src/main/resources/db/migration/V8__add_stocks_etf_account_types.sql
@@ -1,0 +1,6 @@
+-- V8: Add STOCKS and ETF values to the account_type enum so users can track
+-- equities and exchange-traded funds as first-class account categories
+-- (distinct from generic COMPTE_TITRES brokerage accounts).
+
+ALTER TYPE account_type ADD VALUE IF NOT EXISTS 'STOCKS';
+ALTER TYPE account_type ADD VALUE IF NOT EXISTS 'ETF';

--- a/backend/src/main/resources/db/migration/V8__add_stocks_etf_account_types.sql.conf
+++ b/backend/src/main/resources/db/migration/V8__add_stocks_etf_account_types.sql.conf
@@ -1,0 +1,1 @@
+executeInTransaction=false

--- a/frontend/src/hooks/useAccounts.ts
+++ b/frontend/src/hooks/useAccounts.ts
@@ -1,5 +1,5 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { accountsApi, type AccountRequest } from '../lib/api'
+import { accountsApi, pricesApi, type AccountRequest } from '../lib/api'
 
 export const ACCOUNTS_KEY = ['accounts'] as const
 
@@ -48,6 +48,17 @@ export function useDeleteAccount() {
   const qc = useQueryClient()
   return useMutation({
     mutationFn: (id: number) => accountsApi.delete(id),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ACCOUNTS_KEY })
+      qc.invalidateQueries({ queryKey: ['dashboard'] })
+    },
+  })
+}
+
+export function useRefreshPrices() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: () => pricesApi.refreshAll(),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ACCOUNTS_KEY })
       qc.invalidateQueries({ queryKey: ['dashboard'] })

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -73,7 +73,7 @@ export interface Account {
 }
 
 export type AccountType =
-  | 'LEP' | 'PEA' | 'COMPTE_TITRES' | 'CRYPTO' | 'CHECKING' | 'SAVINGS' | 'OTHER'
+  | 'LEP' | 'PEA' | 'COMPTE_TITRES' | 'CRYPTO' | 'STOCKS' | 'ETF' | 'CHECKING' | 'SAVINGS' | 'OTHER'
 
 export interface AccountRequest {
   name: string
@@ -191,6 +191,18 @@ export const syncApi = {
     ).then(r => r.data),
   retry: (id: number) => api.post<Account[]>(`/sync/${id}/retry`).then(r => r.data),
   delete: (id: number) => api.delete(`/sync/${id}`),
+}
+
+// Prices
+export interface PriceRefreshResponse {
+  refreshed: number
+  requested: number
+  prices: Record<string, number>
+  refreshedAt: string
+}
+
+export const pricesApi = {
+  refreshAll: () => api.post<PriceRefreshResponse>('/prices/refresh').then(r => r.data),
 }
 
 // Auth

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -51,11 +51,22 @@ export function accountTypeLabel(type: string): string {
     PEA: 'PEA',
     COMPTE_TITRES: 'Compte-titres',
     CRYPTO: 'Crypto',
+    STOCKS: 'Actions',
+    ETF: 'ETF',
     CHECKING: 'Compte courant',
     SAVINGS: 'Épargne',
     OTHER: 'Autre',
   }
   return labels[type] ?? type
+}
+
+/**
+ * Whether an account type is expected to have a ticker (so we can prompt
+ * the user / track its live price). Crypto, single stocks, and ETFs need
+ * a symbol; brokerage accounts (PEA, Compte-titres) may have one too.
+ */
+export function accountTypeNeedsTicker(type: string): boolean {
+  return type === 'CRYPTO' || type === 'STOCKS' || type === 'ETF'
 }
 
 export function clamp(value: number, min: number, max: number): number {

--- a/frontend/src/pages/accounts/AccountsPage.tsx
+++ b/frontend/src/pages/accounts/AccountsPage.tsx
@@ -1,13 +1,13 @@
 import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { motion, AnimatePresence } from 'motion/react'
-import { Plus, Wallet, X, Loader2, Pencil } from 'lucide-react'
-import { useAccounts, useCreateAccount, useDeleteAccount, useUpdateAccount } from '../../hooks/useAccounts'
+import { Plus, Wallet, X, Loader2, Pencil, RefreshCw } from 'lucide-react'
+import { useAccounts, useCreateAccount, useDeleteAccount, useUpdateAccount, useRefreshPrices } from '../../hooks/useAccounts'
 import { GlassCard, GlowBackground, PageHeader } from '../../components/shared'
-import { formatEur, accountTypeLabel } from '../../lib/utils'
+import { formatEur, accountTypeLabel, accountTypeNeedsTicker } from '../../lib/utils'
 import type { Account, AccountType } from '../../lib/api'
 
-const ACCOUNT_TYPES: AccountType[] = ['LEP', 'PEA', 'COMPTE_TITRES', 'CRYPTO', 'CHECKING', 'SAVINGS', 'OTHER']
+const ACCOUNT_TYPES: AccountType[] = ['LEP', 'PEA', 'COMPTE_TITRES', 'CRYPTO', 'STOCKS', 'ETF', 'CHECKING', 'SAVINGS', 'OTHER']
 const COLORS = ['#6366f1', '#10b981', '#f59e0b', '#ef4444', '#8b5cf6', '#06b6d4', '#f97316', '#84cc16']
 
 export function AccountsPage() {
@@ -15,7 +15,9 @@ export function AccountsPage() {
   const createAccount = useCreateAccount()
   const updateAccount = useUpdateAccount()
   const deleteAccount = useDeleteAccount()
+  const refreshPrices = useRefreshPrices()
   const navigate = useNavigate()
+  const hasTrackedAssets = (accounts ?? []).some(a => a.ticker)
   const [showForm, setShowForm] = useState(false)
   const [editingAccount, setEditingAccount] = useState<Account | null>(null)
   const [form, setForm] = useState({
@@ -73,14 +75,29 @@ export function AccountsPage() {
         surtitle="Portefeuille"
         title="Comptes"
         actions={
-          <motion.button
-            whileTap={{ scale: 0.96 }}
-            onClick={openCreate}
-            className="flex items-center gap-1.5 h-8 px-3 bg-gray-900 text-white rounded-[10px]"
-            style={{ fontSize: 12, fontWeight: 600 }}
-          >
-            <Plus size={14} /> Ajouter
-          </motion.button>
+          <div className="flex items-center gap-2">
+            {hasTrackedAssets && (
+              <motion.button
+                whileTap={{ scale: 0.96 }}
+                onClick={() => refreshPrices.mutate()}
+                disabled={refreshPrices.isPending}
+                title="Rafraîchir les cours crypto / actions / ETF"
+                className="flex items-center gap-1.5 h-8 px-3 bg-white/70 text-gray-700 rounded-[10px] disabled:opacity-60"
+                style={{ fontSize: 12, fontWeight: 600 }}
+              >
+                <RefreshCw size={13} className={refreshPrices.isPending ? 'animate-spin' : ''} />
+                {refreshPrices.isPending ? 'Mise à jour…' : 'Rafraîchir les cours'}
+              </motion.button>
+            )}
+            <motion.button
+              whileTap={{ scale: 0.96 }}
+              onClick={openCreate}
+              className="flex items-center gap-1.5 h-8 px-3 bg-gray-900 text-white rounded-[10px]"
+              style={{ fontSize: 12, fontWeight: 600 }}
+            >
+              <Plus size={14} /> Ajouter
+            </motion.button>
+          </div>
         }
       />
 
@@ -242,11 +259,16 @@ export function AccountsPage() {
                         className="h-8 px-3 w-full rounded-[10px] bg-black/[0.03] text-[13px] border-none outline-none focus:ring-2 focus:ring-gray-900/10"
                       />
                     </Field>
-                    <Field label="Ticker (optionnel)">
+                    <Field label={accountTypeNeedsTicker(form.type) ? 'Ticker (cours suivi)' : 'Ticker (optionnel)'}>
                       <input
                         value={form.ticker}
                         onChange={e => setForm(f => ({ ...f, ticker: e.target.value.toUpperCase() }))}
-                        placeholder="BTC, IWDA.AS"
+                        placeholder={
+                          form.type === 'CRYPTO' ? 'BTC, ETH, SOL…' :
+                          form.type === 'ETF' ? 'IWDA.AS, CW8.PA…' :
+                          form.type === 'STOCKS' ? 'AAPL, MC.PA, ASML.AS…' :
+                          'BTC, IWDA.AS'
+                        }
                         maxLength={20}
                         className="h-8 px-3 w-full rounded-[10px] bg-black/[0.03] text-[13px] border-none outline-none focus:ring-2 focus:ring-gray-900/10"
                       />


### PR DESCRIPTION
…efresh

Adds dedicated STOCKS and ETF entries to the account_type enum (alongside the existing CRYPTO) so equity and ETF holdings can be tracked distinctly from generic brokerage accounts. The Yahoo Finance adapter now converts non-EUR quotes (USD, GBP, GBp/pence) to EUR via a cached EUR<CCY>=X FX rate — previously USD-quoted tickers like AAPL were returned as raw USD, producing wrong EUR balances. CoinGecko coverage is extended to cover 22 common tickers.

A POST /api/prices/refresh endpoint plus a "Rafraîchir les cours" button on the Accounts page lets the user force-refresh prices without waiting for the hourly scheduler. The ticker field's label and placeholder adapt to the selected account type to make it clear when a symbol is expected (BTC, AAPL, IWDA.AS…).