### PR TITLE
Fix Finary account identity collisions during sync

### DIFF
--- a/backend/src/main/java/com/picsou/dto/FinaryAccountMapping.java
+++ b/backend/src/main/java/com/picsou/dto/FinaryAccountMapping.java
@@ -3,6 +3,7 @@ package com.picsou.dto;
 import com.picsou.model.AccountType;
 
 public record FinaryAccountMapping(
+    String finaryId,
     String finaryName,
     String finaryCategory,
     FinaryMappingAction action,

--- a/backend/src/main/java/com/picsou/dto/FinaryAccountPreview.java
+++ b/backend/src/main/java/com/picsou/dto/FinaryAccountPreview.java
@@ -3,6 +3,7 @@ package com.picsou.dto;
 import com.picsou.model.AccountType;
 
 public record FinaryAccountPreview(
+    String finaryId,
     String finaryName,
     String finaryInstitution,
     String finaryCategory,

--- a/backend/src/main/java/com/picsou/finary/CategorizedFinaryAccount.java
+++ b/backend/src/main/java/com/picsou/finary/CategorizedFinaryAccount.java
@@ -1,0 +1,12 @@
+package com.picsou.finary;
+
+import com.picsou.finary.dto.FinaryAccountDto;
+
+/**
+ * Keeps the original Finary category attached to an account payload so we don't
+ * have to guess it later from a possibly non-unique account id.
+ */
+public record CategorizedFinaryAccount(
+    String category,
+    FinaryAccountDto account
+) {}

--- a/backend/src/main/java/com/picsou/finary/FinaryApiSyncService.java
+++ b/backend/src/main/java/com/picsou/finary/FinaryApiSyncService.java
@@ -146,16 +146,14 @@ public class FinaryApiSyncService {
 
             // Fetch all accounts across categories
             log.info("Fetching accounts from all categories");
-            List<FinaryAccountDto> allAccounts = new ArrayList<>();
-            Map<String, String> externalIdToCategory = new HashMap<>();
+            List<CategorizedFinaryAccount> allAccounts = new ArrayList<>();
 
             for (String category : ACCOUNT_CATEGORIES) {
                 try {
                     List<FinaryAccountDto> accounts = finaryApiClient.fetchCategoryAccounts(jwt, ctx, category);
                     log.info("Fetched {} accounts from category: {}", accounts.size(), category);
                     for (FinaryAccountDto acc : accounts) {
-                        allAccounts.add(acc);
-                        externalIdToCategory.put("finary_" + category + "_" + acc.id(), category);
+                        allAccounts.add(new CategorizedFinaryAccount(category, acc));
                     }
                 } catch (Exception e) {
                     log.error("Failed to fetch accounts from category {}: {}", category, e.getMessage());
@@ -183,7 +181,7 @@ public class FinaryApiSyncService {
             // Cache everything with a sync token
             String syncToken = UUID.randomUUID().toString();
             SyncSessionData sessionData = new SyncSessionData(
-                allAccounts, transactionsByCategory, externalIdToCategory, Instant.now()
+                allAccounts, transactionsByCategory, Instant.now()
             );
             cache.put(syncToken, sessionData);
 
@@ -196,13 +194,15 @@ public class FinaryApiSyncService {
             }
 
             List<FinaryAccountPreview> previews = allAccounts.stream()
-                .map(acc -> {
-                    String category = externalIdToCategory.get("finary_" + findCategoryForAccount(acc, allAccounts, externalIdToCategory) + "_" + acc.id());
+                .map(categorizedAcc -> {
+                    FinaryAccountDto acc = categorizedAcc.account();
+                    String category = categorizedAcc.category();
                     return new FinaryAccountPreview(
+                        acc.id(),
                         acc.name(),
                         acc.institution() != null ? acc.institution().name() : "Finary",
-                        findCategoryForAccount(acc, allAccounts, externalIdToCategory),
-                        FinaryPersistenceHelper.suggestTypeFromApiCategory(findCategoryForAccount(acc, allAccounts, externalIdToCategory)),
+                        category,
+                        FinaryPersistenceHelper.suggestTypeFromApiCategory(category),
                         acc.balance() != null ? acc.balance() : 0,
                         acc.currency() != null ? acc.currency().code() : "EUR",
                         txCountByAccountId.getOrDefault(acc.id(), 0)
@@ -219,14 +219,15 @@ public class FinaryApiSyncService {
             boolean allAutoMapped = true;
             List<FinaryAccountMapping> suggestedMappings = new ArrayList<>();
 
-            for (FinaryAccountDto acc : allAccounts) {
-                String category = findCategoryForAccount(acc, allAccounts, externalIdToCategory);
+            for (CategorizedFinaryAccount categorizedAcc : allAccounts) {
+                FinaryAccountDto acc = categorizedAcc.account();
+                String category = categorizedAcc.category();
                 String externalId = "finary_" + category + "_" + acc.id();
 
                 Optional<Account> existingAccount = accountRepository.findByExternalAccountIdAndMemberId(externalId, memberId);
                 if (existingAccount.isPresent()) {
                     suggestedMappings.add(new FinaryAccountMapping(
-                        acc.name(), category, FinaryMappingAction.MAP_EXISTING,
+                        acc.id(), acc.name(), category, FinaryMappingAction.MAP_EXISTING,
                         existingAccount.get().getId(), null
                     ));
                 } else {
@@ -276,16 +277,18 @@ public class FinaryApiSyncService {
         int transactionsImported = 0;
         List<ImportedAccountSummary> imported = new ArrayList<>();
 
-        // Map finaryName -> FinaryAccountDto (we need to find by name since that's what mappings use)
-        Map<String, FinaryAccountDto> finaryByName = session.allAccounts().stream()
-            .collect(Collectors.toMap(FinaryAccountDto::name, a -> a, (a, b) -> a));
+        Map<String, FinaryAccountDto> finaryByKey = session.allAccounts().stream()
+            .collect(Collectors.toMap(
+                categorizedAcc -> buildAccountKey(categorizedAcc.category(), categorizedAcc.account().id()),
+                CategorizedFinaryAccount::account,
+                (a, b) -> a
+            ));
 
         for (FinaryAccountMapping mapping : mappings) {
-            FinaryAccountDto finaryAcc = finaryByName.get(mapping.finaryName());
+            FinaryAccountDto finaryAcc = finaryByKey.get(buildAccountKey(mapping.finaryCategory(), mapping.finaryId()));
             if (finaryAcc == null) continue;
 
-            String cat = session.externalIdToCategory().get("finary_" + mapping.finaryCategory() + "_" + finaryAcc.id());
-            String category = cat != null ? cat : mapping.finaryCategory();
+            String category = mapping.finaryCategory();
             String externalId = "finary_" + category + "_" + finaryAcc.id();
 
             Account account = null;
@@ -447,17 +450,8 @@ public class FinaryApiSyncService {
         return allTx;
     }
 
-    /**
-     * Find the category for a given account by looking up its external ID in the map
-     */
-    private String findCategoryForAccount(FinaryAccountDto acc, List<FinaryAccountDto> allAccounts,
-                                           Map<String, String> externalIdToCategory) {
-        for (Map.Entry<String, String> entry : externalIdToCategory.entrySet()) {
-            if (entry.getKey().endsWith("_" + acc.id())) {
-                return entry.getValue();
-            }
-        }
-        return "other_assets";
+    private String buildAccountKey(String category, String finaryId) {
+        return category + "::" + finaryId;
     }
 
     /**

--- a/backend/src/main/java/com/picsou/finary/SyncSessionData.java
+++ b/backend/src/main/java/com/picsou/finary/SyncSessionData.java
@@ -13,8 +13,7 @@ import java.util.Map;
  * Cached in memory with a UUID key (syncToken) until execute is called or timeout.
  */
 public record SyncSessionData(
-    List<FinaryAccountDto> allAccounts,
+    List<CategorizedFinaryAccount> allAccounts,
     Map<String, List<FinaryTransactionDto>> transactionsByCategory,
-    Map<String, String> externalIdToCategory,
     Instant createdAt
 ) {}

--- a/backend/src/main/java/com/picsou/service/FinaryImportService.java
+++ b/backend/src/main/java/com/picsou/service/FinaryImportService.java
@@ -67,6 +67,7 @@ public class FinaryImportService {
 
             List<FinaryAccountPreview> previews = parsed.accounts.stream()
                 .map(acc -> new FinaryAccountPreview(
+                    slugify(acc.category() + "_" + acc.name()),
                     acc.name(),
                     acc.institution(),
                     acc.category(),
@@ -112,12 +113,19 @@ public class FinaryImportService {
         int transactionsImported = 0;
         List<ImportedAccountSummary> imported = new ArrayList<>();
 
-        // Map finaryName -> parsed account
-        Map<String, FinaryPersistenceHelper.ParsedFinaryAccount> finaryByName = parsed.accounts.stream()
-            .collect(Collectors.toMap(FinaryPersistenceHelper.ParsedFinaryAccount::name, a -> a));
+        Map<String, FinaryPersistenceHelper.ParsedFinaryAccount> finaryByKey = parsed.accounts.stream()
+            .collect(Collectors.toMap(
+                acc -> buildParsedAccountKey(acc.category(), acc.name()),
+                a -> a,
+                (a, b) -> a
+            ));
 
         for (FinaryAccountMapping mapping : req.mappings()) {
-            FinaryPersistenceHelper.ParsedFinaryAccount finaryAcc = finaryByName.get(mapping.finaryName());
+            FinaryPersistenceHelper.ParsedFinaryAccount finaryAcc = finaryByKey.get(
+                mapping.finaryId() != null
+                    ? mapping.finaryId()
+                    : buildParsedAccountKey(mapping.finaryCategory(), mapping.finaryName())
+            );
             if (finaryAcc == null) continue;
 
             Account account = null;
@@ -264,6 +272,10 @@ public class FinaryImportService {
             case NUMERIC -> String.valueOf((long) cell.getNumericCellValue());
             default -> null;
         };
+    }
+
+    private String buildParsedAccountKey(String category, String name) {
+        return slugify(category + "_" + name);
     }
 
     private BigDecimal cellNumeric(Row row, int col) {

--- a/frontend/src/components/shared/AddAccountModal.tsx
+++ b/frontend/src/components/shared/AddAccountModal.tsx
@@ -869,6 +869,7 @@ function FinaryWizard({ onDone, onBack }: { onDone: () => void; onBack: () => vo
 
   function initMappings(preview: FinaryPreviewResponse) {
     setMappings(preview.accounts.map((account, i) => ({
+      finaryId: account.finaryId,
       finaryName: account.finaryName,
       finaryCategory: account.finaryCategory,
       action: 'CREATE_NEW' as FinaryMappingAction,
@@ -1082,7 +1083,7 @@ function FinaryWizard({ onDone, onBack }: { onDone: () => void; onBack: () => vo
 
           <div className="space-y-3 max-h-80 overflow-y-auto">
             {previewData.accounts.map((account, index) => (
-              <div key={account.finaryName + account.finaryCategory} className="rounded-lg border p-3 space-y-2">
+              <div key={account.finaryCategory + account.finaryId} className="rounded-lg border p-3 space-y-2">
                 <div className="flex items-center justify-between">
                   <div className="min-w-0">
                     <p className="truncate text-sm font-medium">{account.finaryName}</p>

--- a/frontend/src/demo/index.ts
+++ b/frontend/src/demo/index.ts
@@ -278,8 +278,8 @@ handlers.set(key('GET', '/finary/configured'), () => true)
 // Finary - preview file
 handlers.set(key('POST', '/finary/preview'), () => ({
   accounts: [
-    { finaryName: 'Compte Courant', finaryInstitution: 'BoursoBank', finaryCategory: 'checking', suggestedType: 'CHECKING' as const, currentBalance: 2500, nativeCurrency: 'EUR', transactionCount: 42 },
-    { finaryName: 'PEA', finaryInstitution: 'BoursoBank', finaryCategory: 'pea', suggestedType: 'PEA' as const, currentBalance: 8000, nativeCurrency: 'EUR', transactionCount: 15 },
+    { finaryId: 'checking-1', finaryName: 'Compte Courant', finaryInstitution: 'BoursoBank', finaryCategory: 'checking', suggestedType: 'CHECKING' as const, currentBalance: 2500, nativeCurrency: 'EUR', transactionCount: 42 },
+    { finaryId: 'pea-1', finaryName: 'PEA', finaryInstitution: 'BoursoBank', finaryCategory: 'pea', suggestedType: 'PEA' as const, currentBalance: 8000, nativeCurrency: 'EUR', transactionCount: 15 },
   ],
   existingPicsouAccounts: [],
   totalTransactionCount: 57,
@@ -301,7 +301,7 @@ handlers.set(key('POST', '/finary/import'), () => ({
 // Finary - API sync preview
 handlers.set(key('POST', '/finary/api-sync/preview'), () => ({
   accounts: [
-    { finaryName: 'Compte Courant', finaryInstitution: 'BoursoBank', finaryCategory: 'checking', suggestedType: 'CHECKING' as const, currentBalance: 2500, nativeCurrency: 'EUR', transactionCount: 42 },
+    { finaryId: 'checking-1', finaryName: 'Compte Courant', finaryInstitution: 'BoursoBank', finaryCategory: 'checking', suggestedType: 'CHECKING' as const, currentBalance: 2500, nativeCurrency: 'EUR', transactionCount: 42 },
   ],
   existingPicsouAccounts: [],
   totalTransactionCount: 42,

--- a/frontend/src/pages/sync/FinaryTab.tsx
+++ b/frontend/src/pages/sync/FinaryTab.tsx
@@ -263,6 +263,7 @@ export function FinaryTab() {
 
   function initMappings(preview: FinaryPreviewResponse) {
     const initialMappings: FinaryAccountMapping[] = preview.accounts.map((account) => ({
+      finaryId: account.finaryId,
       finaryName: account.finaryName,
       finaryCategory: account.finaryCategory,
       action: 'CREATE_NEW' as FinaryMappingAction,
@@ -544,7 +545,7 @@ export function FinaryTab() {
           <div className="space-y-3">
             {previewData.accounts.map((account, index) => (
               <MappingCard
-                key={account.finaryName + account.finaryCategory}
+                key={account.finaryCategory + account.finaryId}
                 account={account}
                 mapping={mappings[index]}
                 existingAccounts={previewData.existingPicsouAccounts}

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -256,6 +256,7 @@ export interface BoursoAuthInitResponse {
 }
 
 export interface FinaryAccountPreview {
+  finaryId: string
   finaryName: string
   finaryInstitution: string
   finaryCategory: string
@@ -291,6 +292,7 @@ export interface NewAccountDetails {
 }
 
 export interface FinaryAccountMapping {
+  finaryId: string
   finaryName: string
   finaryCategory: string
   action: FinaryMappingAction
@@ -337,7 +339,6 @@ export interface Transaction {
   isManual: boolean
   txType: 'DEPOSIT' | 'WITHDRAWAL' | 'BUY' | 'SELL' | 'DIVIDEND' | 'FEE' | null
   ticker: string | null
-  name: string | null
   quantity: number | null
   pricePerUnit: number | null
 }
@@ -348,7 +349,6 @@ export interface TransactionRequest {
   amount: number        // signed: positive=deposit, negative=withdrawal
   txType: 'DEPOSIT' | 'WITHDRAWAL' | 'BUY' | 'SELL' | 'DIVIDEND' | 'FEE' | null
   ticker?: string
-  name?: string
   quantity?: number
   pricePerUnit?: number
   currency?: string


### PR DESCRIPTION
## Summary
- carry a stable `finaryId` through the preview/mapping flow
- preserve the original Finary category instead of re-deriving it from account ids
- use stable preview keys in the frontend to avoid account collisions in the mapping UI

## Bug
Importing/syncing Finary accounts could drop one assurance-vie sub-account when Finary exposed both `investments` and `fonds_euro` views for the same contract.

In practice, the preview showed 4 accounts, but the execution phase only persisted 3 because Picsou:
1. matched API-sync mappings by account name
2. then still re-derived the source category from a possibly non-unique Finary account id

If Finary reused the same id across category views, `fonds_euro` could be merged into `investments` during execution.

## Fix
- add `finaryId` to `FinaryAccountPreview` and `FinaryAccountMapping`
- key API-sync execution by `category + finaryId` instead of account name
- keep fetched API accounts wrapped with their original category in `SyncSessionData`
- update the xlsx import path to use a stable synthetic id too
- make frontend mapping keys/category handling use `finaryId`

## Validation
- backend package built successfully with Maven
- bug reproduced on a live instance before the fix, then resolved after applying the backend patch
- full frontend Docker rebuild was memory-constrained on the small test VM, but the frontend changes are limited to type plumbing and stable list keys