### PR TITLE
fix(transactions): declare name field on frontend Transaction types

### DIFF
--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -339,6 +339,7 @@ export interface Transaction {
   isManual: boolean
   txType: 'DEPOSIT' | 'WITHDRAWAL' | 'BUY' | 'SELL' | 'DIVIDEND' | 'FEE' | null
   ticker: string | null
+  name: string | null
   quantity: number | null
   pricePerUnit: number | null
 }
@@ -349,6 +350,7 @@ export interface TransactionRequest {
   amount: number        // signed: positive=deposit, negative=withdrawal
   txType: 'DEPOSIT' | 'WITHDRAWAL' | 'BUY' | 'SELL' | 'DIVIDEND' | 'FEE' | null
   ticker?: string
+  name?: string
   quantity?: number
   pricePerUnit?: number
   currency?: string


### PR DESCRIPTION
## Why

`main`'s build/Docker pipeline has been **red since 2026-06-20** (PR #10, finary sync). That change added a `name` field to transactions in the backend DTOs (`TransactionResponse.name`, `TransactionRequest.name`) and used it in the runtime frontend, but never declared it on the TypeScript interfaces. `tsc -b` (run by `bun run build` in `docker/Dockerfile`) failed on five usages:

```
AddTransactionModal.tsx(90,76)  Property 'name' does not exist on type 'InitialValues'
AddTransactionModal.tsx(123,9)  'name' does not exist in type 'TransactionRequest'
demo/data/transactions.ts(8,3)  'name' does not exist in type 'Transaction'
AccountDetailPage.tsx(268,13)   'name' does not exist in type 'InitialValues'
AccountDetailPage.tsx(268,29)   Property 'name' does not exist on type 'Transaction'
```

The recent security merge (#GHSA-ww5m-pxgq-8qq6) is **not** the cause — it's backend-only Java; it merely re-triggered CI and re-surfaced this pre-existing break.

## What

Two field additions in `frontend/src/types/api.ts`:

- `Transaction.name: string | null` — mirrors `TransactionResponse.name`
- `TransactionRequest.name?: string` — mirrors `TransactionRequest.name`

`InitialValues` is `TransactionRequest & { id?: number }`, so it inherits the field — this clears all five errors with no usage changes. The typing matches what branch `1.1.0` already carries.

## Verification

`bun run build` (`tsc -b && vite build`) in a clean worktree at `main` HEAD:
- before: `tsc` exit 2 (5 errors)
- after: ✓ built, exit 0