### PR TITLE
fix(finary): import loan accounts from the Finary /loans endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to Picsou are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Finary loan accounts are now imported (issue #11).** Loan/mortgage accounts
+  are exposed by Finary through a dedicated `/loans` endpoint, not the portfolio
+  `credits`/`credit_accounts` categories that the API sync queried — so they
+  never appeared in the import preview and were never synced. The sync now also
+  calls `FinaryApiClient.fetchLoans()` and adapts each entry to the common
+  account shape under a synthetic `loans` category, so loans flow through the
+  normal preview/mapping/execute pipeline and map to `AccountType.LOAN`. The
+  outstanding amount is stored as a negative balance (a loan is a liability).
+
 ## [1.0.7] — 2026-06-04
 
 Patch release: renumbers the new `transaction.name` migration so it no longer

--- a/backend/src/main/java/com/picsou/finary/FinaryApiSyncService.java
+++ b/backend/src/main/java/com/picsou/finary/FinaryApiSyncService.java
@@ -7,6 +7,7 @@ import com.picsou.exception.SyncException;
 import com.picsou.exception.TotpRequiredException;
 import com.picsou.finary.client.FinaryApiClient;
 import com.picsou.finary.dto.FinaryAccountDto;
+import com.picsou.finary.dto.FinaryLoanDto;
 import com.picsou.finary.dto.FinaryTransactionDto;
 import com.picsou.model.Account;
 import com.picsou.model.FamilyMember;
@@ -43,6 +44,11 @@ public class FinaryApiSyncService {
         "checkings", "savings", "investments", "real_estates", "cryptos",
         "fonds_euro", "commodities", "credits", "other_assets", "startups"
     );
+    /**
+     * Synthetic category for loan/mortgage accounts. Loans are not part of the portfolio
+     * categories above; they come from the dedicated {@code /loans} endpoint (issue #11).
+     */
+    private static final String LOANS_CATEGORY = "loans";
     private static final List<String> TRANSACTION_CATEGORIES = List.of(
         "checkings", "savings", "investments", "credits"
     );
@@ -159,6 +165,18 @@ public class FinaryApiSyncService {
                     log.error("Failed to fetch accounts from category {}: {}", category, e.getMessage());
                     throw new SyncException("Failed to fetch accounts from " + category, e);
                 }
+            }
+
+            // Loans live on a dedicated endpoint, not in the portfolio categories above.
+            try {
+                List<FinaryLoanDto> loans = finaryApiClient.fetchLoans(jwt);
+                log.info("Fetched {} entries from loans endpoint", loans.size());
+                for (FinaryLoanDto loan : loans) {
+                    allAccounts.add(new CategorizedFinaryAccount(LOANS_CATEGORY, toLoanAccountDto(loan)));
+                }
+            } catch (Exception e) {
+                log.error("Failed to fetch loans: {}", e.getMessage());
+                throw new SyncException("Failed to fetch loans", e);
             }
 
             // Fetch all transactions across categories
@@ -452,6 +470,31 @@ public class FinaryApiSyncService {
 
     private String buildAccountKey(String category, String finaryId) {
         return category + "::" + finaryId;
+    }
+
+    /**
+     * Adapt a Finary loan entry to the common {@link FinaryAccountDto} so loans flow through
+     * the existing preview/execute pipeline (mapping, auto-mapping, account creation).
+     *
+     * <p>A loan is a liability, so the outstanding amount is stored as a NEGATIVE balance,
+     * mirroring how LOAN accounts are persisted elsewhere ({@code liveBalanceEur} returns a
+     * negative remaining capital). Only the outstanding balance is carried over; the original
+     * principal, interest rate and amortization details are not exposed by the loans payload,
+     * so no {@code Debt} is created here — the user can add those later for the amortization view.
+     */
+    private FinaryAccountDto toLoanAccountDto(FinaryLoanDto loan) {
+        Double outstanding = loan.outstandingAmount();
+        Double balance = outstanding != null ? -outstanding : null;
+        return new FinaryAccountDto(
+            loan.id(),
+            loan.name(),
+            null,
+            balance,
+            balance,
+            loan.institution(),
+            loan.currency(),
+            false
+        );
     }
 
     /**

--- a/backend/src/main/java/com/picsou/finary/FinaryPersistenceHelper.java
+++ b/backend/src/main/java/com/picsou/finary/FinaryPersistenceHelper.java
@@ -238,6 +238,7 @@ public class FinaryPersistenceHelper {
             case "investments" -> AccountType.COMPTE_TITRES;
             case "cryptos" -> AccountType.CRYPTO;
             case "fonds_euro" -> AccountType.SAVINGS;
+            case "loans" -> AccountType.LOAN;
             case "credits" -> AccountType.OTHER;
             case "real_estates", "commodities", "other_assets", "startups" -> AccountType.OTHER;
             default -> AccountType.OTHER;

--- a/backend/src/main/java/com/picsou/finary/client/FinaryApiClient.java
+++ b/backend/src/main/java/com/picsou/finary/client/FinaryApiClient.java
@@ -338,6 +338,29 @@ public class FinaryApiClient {
     }
 
     /**
+     * Fetch loan / mortgage accounts from Finary's dedicated {@code /loans} endpoint.
+     *
+     * <p>Loans are not part of the portfolio {@code credits} category, so they have to be
+     * fetched separately (issue #11). The endpoint path is best-effort: it mirrors the
+     * other {@code /users/me/*} resources (e.g. {@code /users/me/organizations}).
+     */
+    public List<FinaryLoanDto> fetchLoans(String jwt) {
+        try {
+            String response = finaryGet(jwt, "/users/me/loans");
+
+            FinaryEnvelope<List<FinaryLoanDto>> envelope =
+                objectMapper.readValue(response, objectMapper.getTypeFactory()
+                    .constructParametricType(FinaryEnvelope.class,
+                        objectMapper.getTypeFactory().constructCollectionType(List.class, FinaryLoanDto.class)));
+
+            return envelope.result() != null ? envelope.result() : List.of();
+
+        } catch (IOException e) {
+            throw new SyncException("Failed to fetch loans: " + e.getMessage(), e);
+        }
+    }
+
+    /**
      * Fetch transactions for a specific category (paginated)
      */
     public List<FinaryTransactionDto> fetchCategoryTransactions(String jwt, OrgContext ctx, String category, int page, int perPage) {

--- a/backend/src/main/java/com/picsou/finary/dto/FinaryLoanDto.java
+++ b/backend/src/main/java/com/picsou/finary/dto/FinaryLoanDto.java
@@ -1,0 +1,31 @@
+package com.picsou.finary.dto;
+
+import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * A loan / mortgage entry returned by Finary's dedicated {@code /loans} endpoint.
+ *
+ * <p>Loans are <strong>not</strong> exposed through the portfolio
+ * {@code credits}/{@code credit_accounts} categories, so they have to be fetched
+ * separately (see issue #11).
+ *
+ * <p>Field names are best-effort from the sample payload reported in issue #11
+ * ({@code type}, {@code name}, {@code outstanding_amount}, {@code monthly_repayment},
+ * {@code start_date}, {@code end_date}). The snake_case keys are mapped explicitly via
+ * {@link JsonProperty}; camelCase aliases are accepted as a fallback because the rest of
+ * the Finary API returns camelCase. Unknown fields are ignored.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record FinaryLoanDto(
+    String id,
+    String type,
+    String name,
+    @JsonProperty("outstanding_amount") @JsonAlias("outstandingAmount") Double outstandingAmount,
+    @JsonProperty("monthly_repayment") @JsonAlias("monthlyRepayment") Double monthlyRepayment,
+    @JsonProperty("start_date") @JsonAlias("startDate") String startDate,
+    @JsonProperty("end_date") @JsonAlias("endDate") String endDate,
+    FinaryAccountCurrency currency,
+    FinaryAccountInstitution institution
+) {}

--- a/backend/src/test/java/com/picsou/finary/dto/FinaryLoanDtoTest.java
+++ b/backend/src/test/java/com/picsou/finary/dto/FinaryLoanDtoTest.java
@@ -1,0 +1,78 @@
+package com.picsou.finary.dto;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies that the JSON returned by Finary's {@code /loans} endpoint parses into
+ * {@link FinaryLoanDto} records (issue #11). No network: pure Jackson deserialization.
+ */
+class FinaryLoanDtoTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    void loansEnvelope_parsesSnakeCaseLoanEntries() throws Exception {
+        // Best-effort shape from issue #11's sample payload.
+        String json = """
+            {
+              "result": [
+                {
+                  "id": "loan-1",
+                  "type": "loan",
+                  "name": "PRET CONSO Auto",
+                  "outstanding_amount": 12345.67,
+                  "monthly_repayment": 250.00,
+                  "start_date": "2023-01-01",
+                  "end_date": "2028-01-01",
+                  "currency": { "code": "EUR", "symbol": "€" },
+                  "institution": { "id": "bank-1", "name": "Boursorama", "slug": "bourso" }
+                }
+              ]
+            }
+            """;
+
+        FinaryEnvelope<List<FinaryLoanDto>> envelope = objectMapper.readValue(json,
+            objectMapper.getTypeFactory().constructParametricType(
+                FinaryEnvelope.class,
+                objectMapper.getTypeFactory().constructCollectionType(List.class, FinaryLoanDto.class)));
+
+        assertThat(envelope.result()).hasSize(1);
+        FinaryLoanDto loan = envelope.result().get(0);
+        assertThat(loan.id()).isEqualTo("loan-1");
+        assertThat(loan.type()).isEqualTo("loan");
+        assertThat(loan.name()).isEqualTo("PRET CONSO Auto");
+        assertThat(loan.outstandingAmount()).isEqualTo(12345.67);
+        assertThat(loan.monthlyRepayment()).isEqualTo(250.00);
+        assertThat(loan.startDate()).isEqualTo("2023-01-01");
+        assertThat(loan.endDate()).isEqualTo("2028-01-01");
+        assertThat(loan.currency().code()).isEqualTo("EUR");
+        assertThat(loan.institution().name()).isEqualTo("Boursorama");
+    }
+
+    @Test
+    void loanEntry_acceptsCamelCaseAliasesAsFallback() throws Exception {
+        String json = """
+            {
+              "id": "loan-2",
+              "type": "loan",
+              "name": "Mortgage",
+              "outstandingAmount": 99000.0,
+              "monthlyRepayment": 800.0,
+              "startDate": "2020-06-01",
+              "endDate": "2045-06-01"
+            }
+            """;
+
+        FinaryLoanDto loan = objectMapper.readValue(json, FinaryLoanDto.class);
+
+        assertThat(loan.outstandingAmount()).isEqualTo(99000.0);
+        assertThat(loan.monthlyRepayment()).isEqualTo(800.0);
+        assertThat(loan.startDate()).isEqualTo("2020-06-01");
+        assertThat(loan.endDate()).isEqualTo("2045-06-01");
+    }
+}

--- a/backend/src/test/java/com/picsou/service/FinaryApiSyncServiceTest.java
+++ b/backend/src/test/java/com/picsou/service/FinaryApiSyncServiceTest.java
@@ -1,11 +1,22 @@
 package com.picsou.service;
 
 import com.picsou.config.CryptoEncryption;
+import com.picsou.dto.FinaryAccountMapping;
+import com.picsou.dto.FinaryAccountPreview;
 import com.picsou.dto.FinaryCheckTotpResponse;
+import com.picsou.dto.FinaryImportResultResponse;
+import com.picsou.dto.FinaryMappingAction;
+import com.picsou.dto.FinaryPreviewResponse;
+import com.picsou.dto.NewAccountDetails;
 import com.picsou.exception.ResourceNotFoundException;
 import com.picsou.finary.FinaryApiSyncService;
 import com.picsou.finary.FinaryPersistenceHelper;
 import com.picsou.finary.client.FinaryApiClient;
+import com.picsou.finary.dto.FinaryAccountCurrency;
+import com.picsou.finary.dto.FinaryAccountDto;
+import com.picsou.finary.dto.FinaryLoanDto;
+import com.picsou.model.Account;
+import com.picsou.model.AccountType;
 import com.picsou.model.FamilyMember;
 import com.picsou.model.FinarySession;
 import com.picsou.repository.AccountRepository;
@@ -13,14 +24,20 @@ import com.picsou.repository.FamilyMemberRepository;
 import com.picsou.repository.FinarySessionRepository;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -77,5 +94,98 @@ class FinaryApiSyncServiceTest {
 
         assertThatThrownBy(() -> service.checkTotp(99L))
             .isInstanceOf(ResourceNotFoundException.class);
+    }
+
+    // ---------------------------------------------------------------------------
+    // Loans from the dedicated /loans endpoint (issue #11)
+    // ---------------------------------------------------------------------------
+
+    private FinarySession connectedSession() {
+        return FinarySession.builder()
+            .member(FamilyMember.builder().id(1L).build())
+            .email("enc-email")
+            .password("enc-pass")
+            .status("CONNECTED")
+            .build();
+    }
+
+    private void stubPreviewFlow(FinaryAccountDto checking, FinaryLoanDto loan) {
+        when(finarySessionRepository.findByMemberId(1L)).thenReturn(Optional.of(connectedSession()));
+        when(encryption.decrypt("enc-email")).thenReturn("user@example.com");
+        when(encryption.decrypt("enc-pass")).thenReturn("secret");
+        when(finaryApiClient.authenticate("user@example.com", "secret", null)).thenReturn("jwt");
+        when(finaryApiClient.fetchOrganizationContext("jwt"))
+            .thenReturn(new FinaryApiClient.OrgContext("org", "mem"));
+        when(finaryApiClient.fetchCategoryAccounts(eq("jwt"), any(), anyString()))
+            .thenAnswer(inv -> "checkings".equals(inv.getArgument(2)) ? List.of(checking) : List.of());
+        when(finaryApiClient.fetchLoans("jwt")).thenReturn(List.of(loan));
+        when(finaryApiClient.fetchCategoryTransactions(any(), any(), anyString(), anyInt(), anyInt()))
+            .thenReturn(List.of());
+        when(accountRepository.findAllByMemberIdOrderByCreatedAtAsc(1L)).thenReturn(List.of());
+        when(accountRepository.findByExternalAccountIdAndMemberId(anyString(), eq(1L)))
+            .thenReturn(Optional.empty());
+    }
+
+    @Test
+    void preview_includesLoanAccountsFromLoansEndpoint() {
+        FinaryAccountDto checking = new FinaryAccountDto(
+            "chk-1", "Checking", null, 1000.0, 1000.0, null,
+            new FinaryAccountCurrency("EUR", "€"), false);
+        FinaryLoanDto loan = new FinaryLoanDto(
+            "loan-1", "loan", "PRET CONSO Auto", 12345.67, 250.0,
+            "2023-01-01", "2028-01-01", new FinaryAccountCurrency("EUR", "€"), null);
+
+        stubPreviewFlow(checking, loan);
+
+        FinaryPreviewResponse response = service.preview(null, 1L);
+
+        // Both the non-loan account and the loan show up in the preview.
+        assertThat(response.accounts()).hasSize(2);
+
+        FinaryAccountPreview loanPreview = response.accounts().stream()
+            .filter(a -> "loans".equals(a.finaryCategory()))
+            .findFirst()
+            .orElseThrow();
+        assertThat(loanPreview.finaryId()).isEqualTo("loan-1");
+        assertThat(loanPreview.finaryName()).isEqualTo("PRET CONSO Auto");
+        assertThat(loanPreview.suggestedType()).isEqualTo(AccountType.LOAN);
+        // A loan is a liability: outstanding amount becomes a negative balance.
+        assertThat(loanPreview.currentBalance()).isEqualTo(-12345.67);
+
+        assertThat(response.accounts())
+            .anyMatch(a -> "checkings".equals(a.finaryCategory()));
+    }
+
+    @Test
+    void execute_createsLoanAccount_fromLoanMapping() {
+        FinaryAccountDto checking = new FinaryAccountDto(
+            "chk-1", "Checking", null, 1000.0, 1000.0, null,
+            new FinaryAccountCurrency("EUR", "€"), false);
+        FinaryLoanDto loan = new FinaryLoanDto(
+            "loan-1", "loan", "PRET CONSO Auto", 12345.67, 250.0,
+            "2023-01-01", "2028-01-01", new FinaryAccountCurrency("EUR", "€"), null);
+
+        stubPreviewFlow(checking, loan);
+        when(familyMemberRepository.findById(1L))
+            .thenReturn(Optional.of(FamilyMember.builder().id(1L).build()));
+        when(accountRepository.save(any(Account.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        FinaryPreviewResponse preview = service.preview(null, 1L);
+
+        FinaryAccountMapping loanMapping = new FinaryAccountMapping(
+            "loan-1", "PRET CONSO Auto", "loans", FinaryMappingAction.CREATE_NEW, null,
+            new NewAccountDetails("PRET CONSO Auto", AccountType.LOAN, "Finary", "EUR", "#6366f1"));
+
+        FinaryImportResultResponse result =
+            service.execute(preview.fileToken(), List.of(loanMapping), 1L);
+
+        assertThat(result.accountsCreated()).isEqualTo(1);
+
+        ArgumentCaptor<Account> captor = ArgumentCaptor.forClass(Account.class);
+        org.mockito.Mockito.verify(accountRepository).save(captor.capture());
+        Account saved = captor.getValue();
+        assertThat(saved.getType()).isEqualTo(AccountType.LOAN);
+        assertThat(saved.getExternalAccountId()).isEqualTo("finary_loans_loan-1");
+        assertThat(saved.getCurrentBalance()).isEqualByComparingTo("-12345.67");
     }
 }

--- a/docs/features/finary-import.md
+++ b/docs/features/finary-import.md
@@ -23,7 +23,7 @@ Authenticates directly with Finary via Clerk (their auth provider) and fetches a
 
 - **Authentication**: `FinaryApiClient.authenticate()` performs a 6-step Clerk OAuth flow: GET environment, GET client, POST sign_ins, (optionally POST TOTP), POST session touch, POST tokens. Returns a JWT for API calls.
 - **TOTP/2FA handling**: When Clerk returns `needs_second_factor`, the backend throws `TotpRequiredException` → HTTP 403. The frontend detects 403 on the preview mutation, shows a TOTP input field, then retries with `?totp={code}` as query parameter.
-- **Preview**: `preview(totp)` authenticates, fetches accounts from all 10 categories, fetches transactions (paginated, 200 per page), caches everything with a `syncToken`, returns previews.
+- **Preview**: `preview(totp)` authenticates, fetches accounts from all 10 portfolio categories **plus the dedicated `/loans` endpoint** (loans are not exposed as a portfolio category), fetches transactions (paginated, 200 per page), caches everything with a `syncToken`, returns previews.
 - **Execute**: `execute(syncToken, mappings)` retrieves cached data, applies user mappings, creates/updates accounts, imports transactions.
 
 ### Account mapping
@@ -63,12 +63,13 @@ Possible status values: `OK`, `NEEDS_MAPPING`, `TOTP_REQUIRED`, `NOT_CONNECTED`.
 
 - `service/FinaryImportService.java` -- XLSX file import (Apache POI parsing, two-phase flow)
 - `finary/FinaryApiSyncService.java` -- Direct API sync (Clerk auth, two-phase flow, cache, `autoSync()`)
-- `finary/client/FinaryApiClient.java` -- Finary/Clerk HTTP client (6-step auth, TOTP, pagination)
+- `finary/client/FinaryApiClient.java` -- Finary/Clerk HTTP client (6-step auth, TOTP, pagination, `fetchLoans()`)
+- `finary/dto/FinaryLoanDto.java` -- a loan/mortgage entry from the dedicated `/loans` endpoint
 - `exception/TotpRequiredException.java` -- Thrown when 2FA is required but no TOTP provided (returns 403)
 - `finary/FinaryPersistenceHelper.java` -- Shared helper: account creation, snapshot reconstruction, transaction import (preserves manual transactions), type suggestion
 - `controller/FinaryImportController.java` -- REST endpoints for xlsx upload
 - `controller/FinaryApiSyncController.java` -- REST endpoints for API sync (`/preview`, `/execute`, `/auto`)
-- `finary/dto/` -- 13 DTOs for Finary API responses
+- `finary/dto/` -- 14 DTOs for Finary API responses (incl. `FinaryLoanDto`)
 - `finary/SyncSessionData.java` -- Cache record for API sync session
 - `dto/FinaryAutoSyncResponse.java` -- Response DTO for `/api/finary/api-sync/auto`
 
@@ -124,6 +125,7 @@ POST /api/finary/api-sync/preview?totp={code}
         |
         +-- Clerk completes second factor with TOTP
         +-- Fetch accounts from all 10 categories
+        +-- Fetch loans from the dedicated /loans endpoint  -> LOAN accounts
         +-- Fetch transactions (paginated, 200/page)
         +-- Cache with syncToken (10-min TTL)
         +-- Return: account previews + existing Picsou accounts
@@ -179,11 +181,13 @@ POST /api/finary/api-sync/auto
 - **Account name matching is case-insensitive but exact**: Auto-mapping matches Finary account name to Picsou account name. If the user renamed an account in Picsou, it won't match.
 - **Transactions are per-category**: API sync fetches transactions only from checkings, savings, investments, and credits categories. Other categories (real estate, cryptos) do not have a transactions endpoint.
 - **External IDs use Finary category + ID**: Format is `finary_{category}_{finaryId}`. This means the same Finary account always maps to the same external ID, preventing duplicates across imports.
+- **Loans come from a separate endpoint (issue #11)**: loan/mortgage accounts are *not* returned by the portfolio `credits`/`credit_accounts` categories — they live on the dedicated `/loans` endpoint. The API sync fetches them via `FinaryApiClient.fetchLoans()` and adapts each entry to the common `FinaryAccountDto` under a synthetic `loans` category (external ID `finary_loans_{id}`), so they flow through the normal preview/mapping/execute pipeline and map to `AccountType.LOAN`. The outstanding amount is stored as a **negative** balance (a loan is a liability). Only the balance is imported — the loans payload does not expose the original principal or interest rate, so **no `Debt` row is created**; the imported LOAN account shows a static balance until the user fills in the loan parameters for the amortization view (see [loans.md](loans.md)). The exact `/loans` JSON shape and path are best-effort from the issue's sample (`type`, `name`, `outstanding_amount`, `monthly_repayment`, `start_date`, `end_date`); `FinaryLoanDto` maps the snake_case keys explicitly and accepts camelCase aliases as a fallback.
 
 ## Tests
 
 - `FinaryImportServiceTest` -- unit tests for xlsx parsing, type suggestion, mapping
-- `FinaryApiSyncServiceTest` -- unit tests for API sync flow
+- `FinaryApiSyncServiceTest` -- unit tests for API sync flow, incl. loans appearing in the preview and being created as LOAN accounts on execute
+- `FinaryLoanDtoTest` -- unit tests for parsing the `/loans` payload (snake_case + camelCase aliases)
 - Manual integration testing with real Finary accounts
 
 ## Links

--- a/docs/features/loans.md
+++ b/docs/features/loans.md
@@ -103,6 +103,13 @@ BalanceSnapshot persisted  →  historical balance chart steps down monthly
   standard formula `M = P · r / (1 − (1 + r)^-n)`.
 - **Holdings, transactions, and the manual snapshot history dialog are hidden** for LOAN
   accounts in `AccountDetailPage` — the loan section is the canonical view.
+- **Finary-imported loans have no `Debt` row.** The Finary API sync imports loan/mortgage
+  accounts from the dedicated `/loans` endpoint (see [finary-import.md](finary-import.md), issue #11)
+  as `LOAN` accounts with the outstanding amount stored as a negative `currentBalance`. The
+  loans payload does not expose the original principal or interest rate, so no `Debt` is
+  created — `liveBalanceEur` gracefully falls back to the stored balance when no `Debt` exists,
+  and the rich amortization view only appears once the user fills in the loan parameters via
+  `PUT /api/accounts/{id}/debt`.
 
 ## Tests
 


### PR DESCRIPTION
## Root cause

Finary exposes loan/mortgage accounts through a **dedicated `/loans` endpoint**, not the portfolio `credits` / `credit_accounts` categories. `FinaryApiSyncService` only queried the portfolio categories, so loan accounts never appeared in the import preview and were never synced.

Diagnostics from the reporter (test instance) confirmed this:
- `Fetched 0 accounts from category: credits`
- `fetched 0 accounts from category: credit_accounts`
- `fetched 3 entries from loans endpoint` (`type=loan`, `name=PRET CONSO ...`, `outstanding_amount`, `monthly_repayment`, `start_date`, `end_date`)

## Fix

- **`FinaryApiClient.fetchLoans(jwt)`** — fetches loans from the dedicated `/loans` endpoint and parses them into the new `FinaryLoanDto`.
- **`FinaryApiSyncService.preview()`** — after the portfolio categories, also fetches loans and adapts each entry to the common `FinaryAccountDto` under a synthetic `loans` category. Loans then flow through the existing preview / mapping / execute pipeline unchanged (external ID `finary_loans_{id}`).
- **`FinaryPersistenceHelper.suggestTypeFromApiCategory()`** — maps `loans` → `AccountType.LOAN`.
- The outstanding amount is stored as a **negative** balance (a loan is a liability), mirroring how LOAN accounts are persisted elsewhere. No `Debt` row is created — the payload does not expose the original principal or interest rate, and `liveBalanceEur` already falls back to the stored balance when no `Debt` exists. The user can later add loan parameters for the amortization view.
- Diagnostic logging is consistent with the existing per-category logs: `Fetched N entries from loans endpoint`.

No DTO shape change, so no frontend changes are required (the mapping UI already renders any category and `AccountType.LOAN` already exists).

## Tests

- `FinaryLoanDtoTest` — parses the `/loans` payload (snake_case keys + camelCase aliases).
- `FinaryApiSyncServiceTest` — loans appear in the preview alongside non-loan accounts as `LOAN` type with a negative balance; a loan mapping creates a `LOAN` account with external ID `finary_loans_{id}` and a negative balance on execute.

```
mvn -Dtest='*Finary*' test
Tests run: 7, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

`mvn compile` is clean.

## Assumptions (best-effort from issue #11's sample)

- **Endpoint path** `/users/me/loans` — modeled on the other `/users/me/*` resources; the issue did not specify the exact path. Mapping logic is path-agnostic and fully unit-tested.
- **Payload shape** — `FinaryLoanDto` maps `type`, `name`, `outstanding_amount`, `monthly_repayment`, `start_date`, `end_date` (snake_case, with camelCase `@JsonAlias` fallbacks) and assumes an `id`, optional `currency`, and `institution`, matching the rest of the Finary API. Unknown fields are ignored. A code comment marks these as best-effort.
- Only the outstanding balance is imported; amortization details are out of scope.

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)