### PR TITLE
fix(goals): scope goal account lookup by member (IDOR)

### DIFF
--- a/backend/src/main/java/com/picsou/repository/AccountRepository.java
+++ b/backend/src/main/java/com/picsou/repository/AccountRepository.java
@@ -11,6 +11,13 @@ import java.util.Optional;
 public interface AccountRepository extends JpaRepository<Account, Long> {
     List<Account> findAllByMemberIdOrderByCreatedAtAsc(Long memberId);
     Optional<Account> findByIdAndMemberId(Long id, Long memberId);
+
+    /**
+     * Member-scoped batch lookup by id. Used when resolving a caller-supplied list of
+     * account ids (e.g. goal membership) so accounts belonging to another member are
+     * never returned — closing an IDOR where {@code findAllById} ignored ownership.
+     */
+    List<Account> findByIdInAndMemberId(List<Long> ids, Long memberId);
     Optional<Account> findByExternalAccountIdAndMemberId(String externalAccountId, Long memberId);
     List<Account> findByTickerIsNotNullAndMemberId(Long memberId);
 

--- a/backend/src/main/java/com/picsou/service/GoalService.java
+++ b/backend/src/main/java/com/picsou/service/GoalService.java
@@ -78,7 +78,10 @@ public class GoalService {
 
     @Transactional
     public GoalProgressResponse create(GoalRequest req, FamilyMember member) {
-        List<Account> accounts = accountRepository.findAllById(req.accountIds());
+        // Scope the lookup to the caller's member: a goal must never attach (and then
+        // expose the live balance of) another member's account. findByIdInAndMemberId
+        // returns only owned ids, so a foreign/nonexistent id fails the size check below.
+        List<Account> accounts = accountRepository.findByIdInAndMemberId(req.accountIds(), member.getId());
         if (accounts.size() != req.accountIds().size()) {
             throw new IllegalArgumentException("One or more account IDs not found");
         }
@@ -98,7 +101,8 @@ public class GoalService {
     public GoalProgressResponse update(Long id, GoalRequest req, Long memberId) {
         Goal goal = getOrThrow(id, memberId);
 
-        List<Account> accounts = accountRepository.findAllById(req.accountIds());
+        // Member-scoped (see create): never attach another member's account to this goal.
+        List<Account> accounts = accountRepository.findByIdInAndMemberId(req.accountIds(), memberId);
         if (accounts.size() != req.accountIds().size()) {
             throw new IllegalArgumentException("One or more account IDs not found");
         }

--- a/backend/src/test/java/com/picsou/service/GoalServiceTest.java
+++ b/backend/src/test/java/com/picsou/service/GoalServiceTest.java
@@ -1,8 +1,10 @@
 package com.picsou.service;
 
 import com.picsou.dto.GoalProgressResponse;
+import com.picsou.dto.GoalRequest;
 import com.picsou.model.Account;
 import com.picsou.model.AccountType;
+import com.picsou.model.FamilyMember;
 import com.picsou.model.Goal;
 import com.picsou.repository.AccountRepository;
 import com.picsou.repository.BalanceSnapshotRepository;
@@ -22,7 +24,11 @@ import java.time.LocalDate;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -86,6 +92,54 @@ class GoalServiceTest {
         assertThat(progress.monthlyNeeded()).isEqualByComparingTo(
             new BigDecimal("15000").divide(BigDecimal.valueOf(monthsLeft), 2, RoundingMode.HALF_UP));
         assertThat(progress.percentComplete()).isEqualByComparingTo("25.0000");
+    }
+
+    // ─── IDOR regression (GHSA security audit 2026-06-27) ──────────────────────
+    // A member must not attach (and thereby read the live balance of) another
+    // member's account. The account lookup must be member-scoped, never the
+    // inherited, unscoped findAllById.
+
+    @Test
+    void create_isMemberScoped_andRejectsForeignAccounts() {
+        FamilyMember member = FamilyMember.builder().id(42L).build();
+        GoalRequest req = new GoalRequest(
+            "Trip", new BigDecimal("1000"), LocalDate.now().plusMonths(3), List.of(1L, 2L));
+        // Account 2 belongs to someone else → the member-scoped finder returns only the owned one.
+        Account owned = Account.builder()
+            .id(1L).name("LEP").type(AccountType.LEP).currency("EUR")
+            .currentBalance(BigDecimal.ZERO).build();
+        when(accountRepository.findByIdInAndMemberId(List.of(1L, 2L), 42L))
+            .thenReturn(List.of(owned));
+
+        assertThatThrownBy(() -> goalService.create(req, member))
+            .isInstanceOf(IllegalArgumentException.class);
+
+        verify(accountRepository).findByIdInAndMemberId(List.of(1L, 2L), 42L);
+        verify(accountRepository, never()).findAllById(any());
+        verify(goalRepository, never()).save(any());
+    }
+
+    @Test
+    void update_isMemberScoped_andRejectsForeignAccounts() {
+        Goal goal = Goal.builder()
+            .id(5L).name("Trip").targetAmount(new BigDecimal("1000"))
+            .deadline(LocalDate.now().plusMonths(3))
+            .accounts(new java.util.ArrayList<>()).build();
+        when(goalRepository.findByIdAndMemberId(5L, 42L)).thenReturn(java.util.Optional.of(goal));
+        GoalRequest req = new GoalRequest(
+            "Trip", new BigDecimal("1000"), LocalDate.now().plusMonths(3), List.of(1L, 2L));
+        Account owned = Account.builder()
+            .id(1L).name("LEP").type(AccountType.LEP).currency("EUR")
+            .currentBalance(BigDecimal.ZERO).build();
+        when(accountRepository.findByIdInAndMemberId(List.of(1L, 2L), 42L))
+            .thenReturn(List.of(owned));
+
+        assertThatThrownBy(() -> goalService.update(5L, req, 42L))
+            .isInstanceOf(IllegalArgumentException.class);
+
+        verify(accountRepository).findByIdInAndMemberId(List.of(1L, 2L), 42L);
+        verify(accountRepository, never()).findAllById(any());
+        verify(goalRepository, never()).save(any());
     }
 
     @Test


### PR DESCRIPTION
## Security fix — High (from the 2026-06-27 audit)

**IDOR / Broken Object-Level Authorization (CWE-639, OWASP API1:2023).**

`GoalService.create` and `update` resolved the caller-supplied `accountIds` with the inherited, **un-scoped** `accountRepository.findAllById(...)`, guarded only by a size/existence check — not ownership. Account ids are a single global sequence, so an authenticated member could submit **another member's** account ids and have their `name`/`provider`/`currency`/**live balance** serialized back via `GoalProgressResponse` (and on every subsequent `GET /api/goals[/{id}]`, since the goal is owned by the attacker). Also reachable via MCP `create_goal`/`update_goal`. This breaks the privacy boundary between independent members.

## Fix
- Add `AccountRepository.findByIdInAndMemberId(List<Long>, Long)`.
- Use it in `create` (member id) and `update` (member id) instead of `findAllById`. The existing size check then rejects any foreign/nonexistent id with the same generic 400 (no information leak about which).

This mirrors the `findByIdAndMemberId` discipline used everywhere else in the codebase.

## Tests
`GoalServiceTest` adds `create_isMemberScoped_andRejectsForeignAccounts` and `update_isMemberScoped_andRejectsForeignAccounts`: both assert the member-scoped finder is used, `findAllById` is **never** called, and no goal is persisted when a foreign id is supplied.

`mvn -Dtest=GoalServiceTest test` → **Tests run: 13, Failures: 0, Errors: 0** · BUILD SUCCESS.

> Note: the same flaw exists on branch `1.1.0` (same code); it will be propagated there with the rest of the security work.