### PR TITLE
fix(auth): invalidate sessions on admin password reset; close pending-activation timing oracle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **Admin password reset now invalidates the member's existing sessions
+  (CWE-613/640).** `POST /api/auth/activate/{token}` is the shared sink for
+  new-member activation, admin-initiated password reset
+  (`FamilyService.resetPasswordToken`) and admin-recovery completion. It set the
+  new password hash but — unlike self-service `change-password` — never bumped
+  `tokenVersion` or revoked persistent sessions, so after an admin reset a
+  (possibly compromised) member's old access/refresh JWTs and Remember-Me cookies
+  stayed valid. `activate()` now bumps `tokenVersion` and calls
+  `PersistentSessionService.revokeAllForUser`, mirroring `change-password`.
+- **Closed a login timing oracle for pending-activation members (CWE-208).** An
+  invited-but-not-activated member has a blank `password_hash`, and
+  `passwordEncoder.matches(pw, "")` short-circuits without running bcrypt — making
+  that path measurably faster than the unknown-user and wrong-password paths and
+  letting an attacker tell a "pending-activation profile" apart from "no such
+  user". `POST /api/auth/login` now runs the same dummy-hash bcrypt round when the
+  stored hash is blank and fails exactly like a wrong password, so all three
+  failing paths are timing-indistinguishable. Behavior for activated users is
+  unchanged.
+
 ### Fixed
 
 - **Finary loan accounts are now imported (issue #11).** Loan/mortgage accounts

--- a/backend/src/main/java/com/picsou/controller/AuthController.java
+++ b/backend/src/main/java/com/picsou/controller/AuthController.java
@@ -123,7 +123,20 @@ public class AuthController {
             return ResponseEntity.status(HttpStatus.FORBIDDEN).body(problem);
         }
 
-        if (!passwordEncoder.matches(req.password(), user.getPasswordHash())) {
+        // A managed member that has only been issued an activation link still has a
+        // blank password hash (""). passwordEncoder.matches(pw, "") returns false
+        // *immediately* without running bcrypt, so this path would be measurably
+        // faster than both the unknown-user and the wrong-password paths — a timing
+        // oracle that lets an attacker distinguish "pending-activation profile" from
+        // "no such user" (CWE-208). Run the same dummy-hash bcrypt round and fail
+        // exactly like a wrong password so all three failing paths cost the same.
+        String storedHash = user.getPasswordHash();
+        if (storedHash == null || storedHash.isBlank()) {
+            boolean ignored = passwordEncoder.matches(req.password(), dummyPasswordHash);
+            throw new BadCredentialsException("Invalid credentials");
+        }
+
+        if (!passwordEncoder.matches(req.password(), storedHash)) {
             throw new BadCredentialsException("Invalid credentials");
         }
 
@@ -365,7 +378,18 @@ public class AuthController {
         user.setActivationTokenExpires(null);
         user.setActivated(true);
         user.setAcknowledgedWarning(true);
+        // This endpoint is the shared sink for new-member activation AND
+        // admin-initiated password resets (FamilyService.resetPasswordToken issues
+        // the token; the member then activates here) AND admin-recovery completion.
+        // A reset may be a response to a compromise, so — exactly like the
+        // self-service change-password flow — invalidate every outstanding session:
+        // bump tokenVersion to revoke all access/refresh JWTs, and wipe the user's
+        // Remember-Me persistent sessions. Without this, an attacker's pre-existing
+        // tokens/cookies would survive an admin password reset (CWE-613/640).
+        user.setTokenVersion(user.getTokenVersion() + 1);
         userRepository.save(user);
+
+        persistentSessionService.revokeAllForUser(user.getId());
 
         if (user.getRole() == UserRole.ADMIN) {
             auditService.record("admin.recovery.completed", user.getUsername(), httpReq, null);

--- a/backend/src/test/java/com/picsou/controller/AuthControllerTest.java
+++ b/backend/src/test/java/com/picsou/controller/AuthControllerTest.java
@@ -2,6 +2,7 @@ package com.picsou.controller;
 
 import com.picsou.config.AuthCookieWriter;
 import com.picsou.config.JwtUtil;
+import com.picsou.dto.ActivationRequest;
 import com.picsou.dto.LoginRequest;
 import com.picsou.model.AppUser;
 import com.picsou.model.FamilyMember;
@@ -29,6 +30,8 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 
 import jakarta.servlet.http.Cookie;
 
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -258,6 +261,77 @@ class AuthControllerTest {
 
         // ...and neither failing path leaks a session.
         verify(cookieWriter, never()).setAccessAndRefresh(any(), any(), any());
+    }
+
+    @Test
+    void login_pendingActivationMember_blankHash_paysOneRealBcryptRound_andReturns401() {
+        // Same real-encoder spy pattern as the timing test above. A managed member
+        // that has only been issued an activation link still has a BLANK password
+        // hash; matches(pw, "") would return false instantly without bcrypt, leaking
+        // "this profile exists, pending activation" by latency (CWE-208). The fix
+        // runs the dummy-hash bcrypt round and fails like a wrong password instead.
+        PasswordEncoder realEncoder = spy(new BCryptPasswordEncoder(12));
+        AuthController timingController = new AuthController(
+            userRepository, realEncoder, jwtUtil,
+            loginBuckets, mfaVerifyBuckets, cookieWriter,
+            mfaService, persistentSessionService, auditService, false);
+
+        AppUser pending = AppUser.builder()
+            .id(11L).username("bob")
+            .role(UserRole.MEMBER)
+            .passwordHash("")          // invited but not yet activated
+            .activated(false)
+            .tokenVersion(0L)
+            .member(FamilyMember.builder().id(50L).displayName("Bob").build())
+            .build();
+        when(userRepository.findByUsernameWithMember("bob")).thenReturn(Optional.of(pending));
+
+        assertThatThrownBy(() -> timingController.login(
+                new LoginRequest("bob", "pw", false), httpReq, httpRes))
+            .isInstanceOf(BadCredentialsException.class)
+            .hasMessage("Invalid credentials");
+
+        // Exactly ONE real bcrypt comparison, run against the constructor's $2a$12$
+        // dummy hash — same cost as the unknown-user and wrong-password paths, so a
+        // pending-activation profile is indistinguishable from "no such user".
+        ArgumentCaptor<String> hashUsed = ArgumentCaptor.forClass(String.class);
+        verify(realEncoder, times(1)).matches(eq("pw"), hashUsed.capture());
+        assertThat(hashUsed.getValue()).startsWith("$2a$12$");
+
+        // No session is established, and a credential-less profile never reaches MFA.
+        verify(cookieWriter, never()).setAccessAndRefresh(any(), any(), any());
+        verify(mfaService, never()).isEnabled(any());
+    }
+
+    // ─── activate ────────────────────────────────────────────────────────
+
+    @Test
+    void activate_bumpsTokenVersion_andRevokesPersistentSessions() {
+        // M2: activate() is the shared sink for new-member activation, admin-initiated
+        // password reset, and admin-recovery completion. Like change-password, it must
+        // invalidate every pre-existing session so a compromised member's old JWTs and
+        // Remember-Me cookies don't survive the reset (CWE-613/640).
+        AppUser member = AppUser.builder()
+            .id(11L).username("bob")
+            .role(UserRole.MEMBER)
+            .passwordHash("")
+            .activated(false)
+            .tokenVersion(5L)
+            .activationToken("tok")
+            .activationTokenExpires(Instant.now().plus(1, ChronoUnit.HOURS))
+            .member(FamilyMember.builder().id(50L).displayName("Bob").build())
+            .build();
+        when(userRepository.findByActivationToken("tok")).thenReturn(Optional.of(member));
+
+        ResponseEntity<?> res = controller.activate(
+            "tok", new ActivationRequest("new-password-123", true), httpReq);
+
+        assertThat(res.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(member.isActivated()).isTrue();
+        // tokenVersion bumped 5 -> 6 invalidates every outstanding access/refresh JWT.
+        assertThat(member.getTokenVersion()).isEqualTo(6L);
+        // ...and every Remember-Me persistent session for this user is wiped.
+        verify(persistentSessionService).revokeAllForUser(11L);
     }
 
     // ─── mfa/verify ──────────────────────────────────────────────────────

--- a/docs/features/admin-recovery.md
+++ b/docs/features/admin-recovery.md
@@ -46,6 +46,8 @@ operator: opens URL in browser
 POST /api/auth/activate/{token}
   ├─ user.passwordHash = bcrypt(newPassword)
   ├─ user.activated = true
+  ├─ user.tokenVersion++  (revokes any access/refresh JWT minted before the reset)
+  ├─ persistentSessionService.revokeAllForUser(user.id)  (wipes Remember-Me cookies)
   └─ audit "admin.recovery.completed"  (only if user.role == ADMIN)
    ↓
 operator: set ADMIN_RECOVERY_ENABLED=false, restart
@@ -73,7 +75,7 @@ operator: set ADMIN_RECOVERY_ENABLED=false, restart
 
 ## Tests
 
-- Automated: `AuthControllerTest` (Mockito) — login with a deactivated account ⇒ `403` and no cookies set; login while the recovery flag is on ⇒ `403` whose detail points to the console link and the disable-the-flag reminder, before any password check; refresh with a deactivated account (matching `tv`) ⇒ `401` + cookies cleared; the activated happy paths still issue/rotate tokens.
+- Automated: `AuthControllerTest` (Mockito) — login with a deactivated account ⇒ `403` and no cookies set; login while the recovery flag is on ⇒ `403` whose detail points to the console link and the disable-the-flag reminder, before any password check; refresh with a deactivated account (matching `tv`) ⇒ `401` + cookies cleared; the activated happy paths still issue/rotate tokens; `activate()` bumps `tokenVersion` and calls `PersistentSessionService.revokeAllForUser` so completing a reset/recovery invalidates every pre-existing session (CWE-613/640).
 - Manual:
   1. Set `ADMIN_RECOVERY_ENABLED=true`, boot → expect WARN banner with valid URL.
   2. Before activating, try to log in with the old password **or a wrong one** → expect `403` pointing to the console reset link and the "set `ADMIN_RECOVERY_ENABLED=false`" reminder; no infinite loop.

--- a/docs/features/mfa-and-remember-me.md
+++ b/docs/features/mfa-and-remember-me.md
@@ -173,6 +173,7 @@ The reauth check is a `passwordEncoder.matches(request.currentPassword, user.pas
 | Trigger | Effect |
 |---|---|
 | `POST /api/auth/change-password` | Revoke all persistent sessions of the user, clear cookies. User must log in again on every device. |
+| `POST /api/auth/activate/{token}` (activation / admin reset / admin recovery) | Bump `tokenVersion` (revokes all access/refresh JWTs) and revoke all persistent sessions of the user. Mirrors `change-password` so an admin-initiated reset invalidates any pre-existing session. |
 | Enable 2FA | Revoke all persistent sessions (no inheritance of "trusted_for_2fa" from before enrollment). |
 | Disable 2FA | Revoke all persistent sessions (paranoid wipe — even non-trusted ones, in case the disable was a recovery action). |
 | Regenerate recovery codes | No session impact (only revokes the codes themselves). |
@@ -394,6 +395,8 @@ All UIs are mobile-responsive (per repo convention).
 | Brute-force TOTP | Rate limit 5/15 min per uid + ±1 tolerance window only |
 | Brute-force recovery codes | bcrypt cost 12 (~250 ms/check) + same rate limit |
 | User reactivates after admin force-disable | Admin disable wipes persistent sessions; user must log in fresh and re-enroll |
+| Admin resets a (possibly compromised) member's password | `AuthController.activate` — the shared sink for new-member activation, admin-initiated password reset (`FamilyService.resetPasswordToken`) and admin-recovery completion — bumps `tokenVersion` and calls `PersistentSessionService.revokeAllForUser`, exactly like self-service `change-password`. The member's pre-existing access/refresh JWTs and Remember-Me cookies are all invalidated (CWE-613/640). |
+| Account enumeration via login timing on pending-activation members | An invited-but-not-activated member has a blank `password_hash`; `passwordEncoder.matches(pw, "")` short-circuits without bcrypt. `AuthController.login` now runs the same dummy-hash bcrypt round for a blank stored hash and fails like a wrong password, so the unknown-user, wrong-password and pending-activation paths are timing-indistinguishable (CWE-208). |
 
 ## Gotchas / Pitfalls
 


### PR DESCRIPTION
Fixes two auth security findings.

## M2 (Medium, CWE-613/640) — admin reset/activation must invalidate existing sessions

`AuthController.activate()` is the shared sink for new-member activation, admin-initiated password reset (`FamilyService.resetPasswordToken` issues the token; the member then activates), and admin-recovery completion. It set the new password hash but — unlike self-service `change-password` — never bumped `tokenVersion` and never revoked persistent sessions. So after an admin reset a (possibly compromised) member's password, that member's existing access/refresh JWTs and Remember-Me cookies stayed valid.

**Fix:** `activate()` now mirrors `change-password` — `user.setTokenVersion(user.getTokenVersion() + 1)` and `persistentSessionService.revokeAllForUser(user.getId())`. This single sink covers the activation, admin-reset and admin-recovery completion paths (all three funnel through `POST /api/auth/activate/{token}`).

## L5 (Low, CWE-208) — timing oracle for pending-activation members

An invited-but-not-activated member has a blank `password_hash`. `passwordEncoder.matches(pw, "")` returns immediately without running bcrypt, so the response was measurably faster than both the real-user and the existing decoy-hash paths — letting an attacker distinguish "pending-activation profile" from "no such user".

**Fix:** in `login()`, when the matched user's stored hash is blank/empty, run the decoy comparison against `dummyPasswordHash` and then fail exactly like a wrong password (`BadCredentialsException("Invalid credentials")`), so timing matches the unknown-user and wrong-password paths. Behavior for activated users is unchanged.

## Tests

`AuthControllerTest` (Mockito):
- `activate_bumpsTokenVersion_andRevokesPersistentSessions` — asserts `activate()` bumps `tokenVersion` and calls `revokeAllForUser(...)`.
- `login_pendingActivationMember_blankHash_paysOneRealBcryptRound_andReturns401` — spied real `BCryptPasswordEncoder(12)` confirms a blank-hash user triggers exactly one real bcrypt `matches()` against the `$2a$12$` dummy hash and returns 401, matching the other failing paths.

```
Tests run: 13, Failures: 0, Errors: 0, Skipped: 0 -- AuthControllerTest
BUILD SUCCESS (mvn compile)
```

## Docs
- `docs/features/mfa-and-remember-me.md` — threat-model rows + cascading-invalidations table.
- `docs/features/admin-recovery.md` — activation flow + tests notes.
- `CHANGELOG.md` — `[Unreleased] → Security`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JkJRNCWp4aUNkPaMLKBy3M