### PR TITLE
fix(mcp): propagate SecurityContext to the tool thread (self-clearing accessor)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Scoped MCP tools work again — the security context now survives the
+  servlet→tool thread hop.** Spring AI runs `@Tool` methods on a Reactor
+  scheduler thread, but `AccessKeyAuthFilter` authenticates the `psk_` key on the
+  Tomcat servlet thread by setting `SecurityContextHolder` (a `ThreadLocal`). The
+  tool thread therefore saw no `Authentication`, so `ScopeEnforcementAspect`
+  found no scopes and every scoped `tools/call` failed closed with "missing
+  scope" — even for keys that held the scope. A `SecurityContextThreadLocalAccessor`
+  is now registered with the Micrometer `ContextRegistry` and Reactor's automatic
+  context propagation is enabled (`McpSecurityContextPropagationConfig`), so the
+  context is captured at subscription and re-installed around tool execution. The
+  accessor self-clears on every reset/close path, so a pooled scheduler thread
+  never leaks one request's identity into the next. See
+  [docs/lessons/thread-local-context-across-async-hop.md](docs/lessons/thread-local-context-across-async-hop.md).
 - **Finary loan accounts are now imported (issue #11).** Loan/mortgage accounts
   are exposed by Finary through a dedicated `/loans` endpoint, not the portfolio
   `credits`/`credit_accounts` categories that the API sync queried — so they

--- a/backend/src/main/java/com/picsou/config/McpSecurityContextPropagationConfig.java
+++ b/backend/src/main/java/com/picsou/config/McpSecurityContextPropagationConfig.java
@@ -1,0 +1,37 @@
+package com.picsou.config;
+
+import io.micrometer.context.ContextRegistry;
+import jakarta.annotation.PostConstruct;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Configuration;
+import reactor.core.publisher.Hooks;
+
+/**
+ * Makes Spring Security's {@link org.springframework.security.core.context.SecurityContext} survive the
+ * servlet→Reactor thread hop that Spring AI's MCP server performs when invoking {@code @Tool} methods.
+ *
+ * <p>Registers {@link SecurityContextThreadLocalAccessor} with the global {@link ContextRegistry} and
+ * turns on Reactor's automatic context propagation. With both in place, the {@code Authentication} that
+ * {@code AccessKeyAuthFilter} set on the request thread is captured into the Reactor context at
+ * subscription and re-installed on the scheduler thread that runs the tool, so
+ * {@link com.picsou.mcp.ScopeEnforcementAspect} and {@code UserContext} resolve scopes and member as
+ * intended.
+ *
+ * <p>Gated on the MCP server being enabled so a deployment with {@code MCP_ENABLED=false} keeps the
+ * default (no global Reactor hook). The hook is process-global and idempotent.
+ */
+@Configuration
+@ConditionalOnProperty(name = "spring.ai.mcp.server.enabled", havingValue = "true", matchIfMissing = true)
+public class McpSecurityContextPropagationConfig {
+
+    private static final Logger log = LoggerFactory.getLogger(McpSecurityContextPropagationConfig.class);
+
+    @PostConstruct
+    void enableSecurityContextPropagation() {
+        ContextRegistry.getInstance().registerThreadLocalAccessor(new SecurityContextThreadLocalAccessor());
+        Hooks.enableAutomaticContextPropagation();
+        log.info("MCP: enabled Reactor automatic context propagation for the security context");
+    }
+}

--- a/backend/src/main/java/com/picsou/config/SecurityContextThreadLocalAccessor.java
+++ b/backend/src/main/java/com/picsou/config/SecurityContextThreadLocalAccessor.java
@@ -1,0 +1,68 @@
+package com.picsou.config;
+
+import io.micrometer.context.ThreadLocalAccessor;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+/**
+ * Bridges Spring Security's thread-bound {@link SecurityContextHolder} into Micrometer/Reactor
+ * context propagation.
+ *
+ * <p><b>Why this exists.</b> The embedded MCP server (Spring AI, WebMvc+SSE) executes {@code @Tool}
+ * methods on a Reactor scheduler thread, <em>not</em> the servlet thread that {@code AccessKeyAuthFilter}
+ * authenticated. Because {@link SecurityContextHolder} defaults to a plain {@code ThreadLocal}, the
+ * tool thread sees no {@code Authentication}, so {@link com.picsou.mcp.ScopeEnforcementAspect} (and
+ * {@code UserContext}) would find no scopes — every scoped tool call failed with "missing scope".
+ *
+ * <p>Registered with the {@link io.micrometer.context.ContextRegistry} and activated via
+ * {@code Hooks.enableAutomaticContextPropagation()} (see {@link McpSecurityContextPropagationConfig}),
+ * this accessor lets Reactor capture the {@link SecurityContext} at subscription time and restore it
+ * around tool execution, so the authority-based scope check works across the thread hop.
+ *
+ * <p><b>Null-safety.</b> Reactor calls {@link #restore(SecurityContext)} with the value the target
+ * thread held <em>before</em> the snapshot was applied; that prior value is {@code null} for a fresh
+ * scheduler thread. {@code SecurityContextHolder.setContext(null)} throws, so every setter clears the
+ * holder instead of forwarding a {@code null}.
+ */
+public class SecurityContextThreadLocalAccessor implements ThreadLocalAccessor<SecurityContext> {
+
+    /** Stable key under which the security context travels in a Reactor context snapshot. */
+    public static final String KEY = "com.picsou.security.context";
+
+    @Override
+    public Object key() {
+        return KEY;
+    }
+
+    /** Only a populated context is worth propagating — an empty holder returns {@code null} (skipped). */
+    @Override
+    public SecurityContext getValue() {
+        SecurityContext context = SecurityContextHolder.getContext();
+        return context.getAuthentication() != null ? context : null;
+    }
+
+    @Override
+    public void setValue(SecurityContext value) {
+        if (value == null) {
+            SecurityContextHolder.clearContext();
+        } else {
+            SecurityContextHolder.setContext(value);
+        }
+    }
+
+    /** Reactor 1.0-era no-arg reset: clear the holder on this thread. */
+    @Override
+    public void setValue() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Override
+    public void restore(SecurityContext previousValue) {
+        setValue(previousValue);
+    }
+
+    @Override
+    public void restore() {
+        SecurityContextHolder.clearContext();
+    }
+}

--- a/backend/src/test/java/com/picsou/config/SecurityContextThreadLocalAccessorTest.java
+++ b/backend/src/test/java/com/picsou/config/SecurityContextThreadLocalAccessorTest.java
@@ -1,0 +1,125 @@
+package com.picsou.config;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+/**
+ * Unit coverage for the Reactor↔Spring-Security bridge that survives the MCP servlet→tool thread hop.
+ *
+ * <p>The accessor must (a) only export a populated context, (b) re-install a captured context on the
+ * target thread, and (c) <em>self-clear</em> on every reset/close path so a pooled scheduler thread
+ * never leaks one request's {@code Authentication} into the next. These are the exact behaviours that
+ * single-thread unit tests on the aspect could not catch, so they are pinned here directly.
+ */
+class SecurityContextThreadLocalAccessorTest {
+
+    private final SecurityContextThreadLocalAccessor accessor = new SecurityContextThreadLocalAccessor();
+
+    @AfterEach
+    void clearHolder() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void key_isStable() {
+        assertThat(accessor.key()).isEqualTo(SecurityContextThreadLocalAccessor.KEY);
+    }
+
+    @Test
+    void getValue_emptyHolder_returnsNull() {
+        SecurityContextHolder.clearContext();
+        assertThat(accessor.getValue()).isNull();
+    }
+
+    @Test
+    void getValue_populatedHolder_returnsContext() {
+        SecurityContext context = newContextWith(authentication());
+        SecurityContextHolder.setContext(context);
+
+        assertThat(accessor.getValue()).isSameAs(context);
+    }
+
+    @Test
+    void setValue_nonNull_installsContext() {
+        SecurityContext context = newContextWith(authentication());
+
+        accessor.setValue(context);
+
+        assertThat(SecurityContextHolder.getContext()).isSameAs(context);
+    }
+
+    @Test
+    void setValue_null_clearsHolderWithoutThrowing() {
+        SecurityContextHolder.setContext(newContextWith(authentication()));
+
+        // SecurityContextHolder.setContext(null) throws — the accessor must clear instead.
+        assertThatCode(() -> accessor.setValue(null)).doesNotThrowAnyException();
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+    }
+
+    @Test
+    void setValue_noArg_clearsHolder() {
+        SecurityContextHolder.setContext(newContextWith(authentication()));
+
+        accessor.setValue();
+
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+    }
+
+    @Test
+    void restore_previousValue_reinstallsIt() {
+        SecurityContext previous = newContextWith(authentication());
+
+        accessor.restore(previous);
+
+        assertThat(SecurityContextHolder.getContext()).isSameAs(previous);
+    }
+
+    @Test
+    void restore_nullPrevious_clearsHolderWithoutThrowing() {
+        // Fresh scheduler thread held nothing before the snapshot — Reactor restores null.
+        SecurityContextHolder.setContext(newContextWith(authentication()));
+
+        assertThatCode(() -> accessor.restore(null)).doesNotThrowAnyException();
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+    }
+
+    @Test
+    void restore_noArg_clearsHolder() {
+        SecurityContextHolder.setContext(newContextWith(authentication()));
+
+        accessor.restore();
+
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+    }
+
+    @Test
+    void fullCycle_setThenRestoreNull_leavesNoBleed() {
+        // Mimic the tool thread: install the captured context, run, then close → must end clean
+        // so the next request scheduled onto the same pooled thread starts with an empty holder.
+        SecurityContext captured = newContextWith(authentication());
+
+        accessor.setValue(captured);
+        assertThat(SecurityContextHolder.getContext()).isSameAs(captured);
+
+        accessor.restore(null);
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+    }
+
+    private static Authentication authentication() {
+        return new UsernamePasswordAuthenticationToken("psk-owner", "n/a", java.util.List.of());
+    }
+
+    private static SecurityContext newContextWith(Authentication authentication) {
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+        context.setAuthentication(authentication);
+        return context;
+    }
+}

--- a/docs/lessons/thread-local-context-across-async-hop.md
+++ b/docs/lessons/thread-local-context-across-async-hop.md
@@ -1,0 +1,48 @@
+# Lesson: thread-bound context is lost across a framework's async thread hop
+
+> Recorded: 2026-06-26 · Module: backend (Spring Security × Spring AI MCP)
+
+## What happened
+
+The embedded MCP server (Spring AI 1.0.3, WebMvc+SSE) authenticated each `psk_` access-key on the
+Tomcat **servlet thread** — `AccessKeyAuthFilter` sets `SecurityContextHolder`. But Spring AI runs
+`@Tool` methods on a **Reactor scheduler thread**. `ScopeEnforcementAspect` reads the authentication
+from `SecurityContextHolder` (a `ThreadLocal`), so on the tool thread it saw *nothing*. Every scoped
+`tools/call` failed with `Missing required scope` — **even for a key that held the scope** — so the
+whole MCP feature was non-functional, in production, while the entire test suite was green.
+
+The bug was invisible to unit tests and only surfaced by driving the real SSE transport end to end
+(`GET /mcp` → `initialize` → `tools/call list_accounts` → "missing scope"). Fixed by propagating the
+context across the hop: register `SecurityContextThreadLocalAccessor` with the Micrometer
+`ContextRegistry` and call `Hooks.enableAutomaticContextPropagation()` (`McpSecurityContextPropagationConfig`).
+Clean A/B — the *only* change was the propagation; before → "missing scope", after → the owner's real data.
+
+## What we learned
+
+- `SecurityContextHolder` — and any `ThreadLocal` (MDC, `@Transactional`, request scope) — does **not**
+  cross a reactive/async thread boundary. Authorization at the servlet filter layer can pass while an
+  in-handler thread-local check fails, because they execute on **different threads**.
+- Spring AI tool execution is reactive **even for the `SYNC` server type** — tools run off the request thread.
+- Single-threaded unit tests **structurally cannot** catch this: they set the context on the test thread
+  and call the aspect directly, so they stay green regardless. Green tests were false confidence.
+
+## Why it matters
+
+The feature shipped and reached a public production deploy completely broken, with a fully passing test
+suite. The failure mode is invisible to the existing (Mockito, single-thread) test strategy, so any
+future thread-local check on a reactive/async path will silently break the same way without warning.
+
+## Takeaway
+
+- When a check reads a `ThreadLocal` and the framework may run the work on another thread (Reactor,
+  `@Async`, executor pools), **propagate the context explicitly**. For Reactor: a `ThreadLocalAccessor`
+  + `Hooks.enableAutomaticContextPropagation()`. Do **not** rely on `MODE_INHERITABLETHREADLOCAL` — it
+  only covers threads spawned from the current one, not pooled scheduler threads.
+- **Verify auth/context behavior by driving the real transport**, not same-thread unit tests. Picsou MCP
+  smoke: open `GET /mcp`, read the `endpoint` event, `POST /mcp/message` an `initialize` then a
+  `tools/call`, and assert a scoped tool returns the owner's data — run it against `:8080` and the public origin.
+
+## Links
+
+- Feature note: [mcp-server.md](../features/mcp-server.md) (Gotchas + Tests)
+- ADR: [Access-key auth + embedded MCP server](../decisions/2026-06-05-access-key-auth-and-embedded-mcp.md)


### PR DESCRIPTION
## What

Ports the MCP SecurityContext propagation fix from branch `1.1.0` to `main`.

On `main`, Spring AI runs `@Tool` methods on a Reactor `boundedElastic` scheduler thread, but `AccessKeyAuthFilter` authenticates the `psk_` access key on the Tomcat **servlet** thread by setting `SecurityContextHolder` (a `ThreadLocal`). The tool thread therefore saw no `Authentication`, so `ScopeEnforcementAspect`/`UserContext` resolved no scopes and **every scoped `tools/call` failed closed with "missing scope"** — even for keys that held the scope. The whole scoped-MCP surface was broken in production while the unit suite stayed green (single-thread tests set the context on the test thread).

## How

- **`SecurityContextThreadLocalAccessor`** — a Micrometer `ThreadLocalAccessor<SecurityContext>` bridging `SecurityContextHolder` into Reactor context propagation. Only exports a populated context; **self-clears** on every reset/close path (`setValue()`, `restore()`, and `setValue(null)`/`restore(null)`), so a pooled scheduler thread never leaks one request's identity into the next, and it never forwards a `null` to `SecurityContextHolder.setContext` (which throws).
- **`McpSecurityContextPropagationConfig`** — registers the accessor with the global `ContextRegistry` and calls `Hooks.enableAutomaticContextPropagation()` in `@PostConstruct`. Gated on `spring.ai.mcp.server.enabled` (`matchIfMissing = true`).

## Notes on the port

- **No new pom dependency:** `io.micrometer:context-propagation:1.1.3` is already on `main`'s classpath transitively via `spring-ai-starter-mcp-server-webmvc`. (The full `pom.xml` diff in `1.1.0` carries unrelated AI-module / Testcontainers changes — none of those were pulled.)
- **No `application.yml` change:** the Reactor hook is enabled programmatically; `1.1.0`'s yml diff was unrelated (AI `spring.ai.model.*` config). Not pulled.
- **Test:** `1.1.0` has no concurrent two-key `/mcp` e2e test, so per the brief a focused unit test was added instead — `SecurityContextThreadLocalAccessorTest` pins get/set/reset/close behaviour including null-safety and the no-bleed full cycle (10 tests).
- Added the rationale lesson doc `docs/lessons/thread-local-context-across-async-hop.md` and a CHANGELOG `[Unreleased]` entry.

## Tests

`mvn -Dtest='*Mcp*,*Scope*,*AccessKey*,SecurityContextThreadLocalAccessorTest' test` → **72 run, 0 failures, 0 errors, 0 skipped**. `mvn -q compile` → success.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JkJRNCWp4aUNkPaMLKBy3M