### PR TITLE
fix(nginx): keep security headers on static assets (L8)

### DIFF
--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -51,6 +51,15 @@ server {
     location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
         expires 1y;
         add_header Cache-Control "public, immutable";
+        # Defining add_header in this block drops the server-level security headers
+        # (nginx add_header inheritance), so re-declare them here — otherwise .js/.css
+        # would be served without nosniff/CSP/etc. Keep in sync with the server block.
+        add_header X-Frame-Options "DENY" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; connect-src 'self'; frame-ancestors 'none'" always;
+        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+        add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
     }
 
     # Security headers

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -49,6 +49,14 @@ server {
     location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
         expires 1y;
         add_header Cache-Control "public, immutable";
+        # Defining add_header in this block drops the server-level security headers
+        # (nginx add_header inheritance), so re-declare them here — otherwise .js/.css
+        # would be served without nosniff/CSP/etc. Keep in sync with the server block.
+        add_header X-Frame-Options "DENY" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self'; frame-ancestors 'none'" always;
+        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
     }
 
     # Security headers


### PR DESCRIPTION
## Security fix — Low (audit 2026-06-27, L8, CWE-693)

The static-asset `location ~* \.(js|css|...)` block declared its own `add_header Cache-Control`. Per nginx's `add_header` **inheritance rule**, declaring *any* `add_header` in a block discards all `add_header` directives from the enclosing scope — so `.js/.css/.svg/woff/...` responses were served **without** the server-level security headers (`X-Content-Type-Options: nosniff`, CSP, `X-Frame-Options`, `Referrer-Policy`, HSTS, `Permissions-Policy`). Active content (scripts/styles) without `nosniff`/CSP is the concrete risk.

## Fix
Re-declare the security headers inside the static-asset block in both `docker/nginx.conf` and `frontend/nginx.conf` (mirroring each file's existing server-level set). Self-contained — no Dockerfile/include changes.

Validated by CI's image build. (M1 — running the all-in-one image as non-root — is intentionally **not** in this PR; it rewrites the Dockerfile/supervisord/permissions and needs a dedicated `docker build`+run verification.)