### PR TITLE
docs(security): 1.0.8 changelog + security audit notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.8] — 2026-06-27
+
+Security release: remediations from a 2026-06-27 security audit, the login
+username-enumeration fix, and import/build fixes.
+
+### Security
+
+- **Login no longer leaks which usernames exist (GHSA-ww5m-pxgq-8qq6, CWE-208).**
+  An unknown username now runs a decoy bcrypt comparison so its response latency
+  matches a wrong-password attempt, closing the enumeration timing oracle.
+  Pending-activation members (blank password hash) take the same decoy path.
+- **Goals can no longer read another member's accounts (IDOR, CWE-639).**
+  `GoalService.create`/`update` resolve account ids through a member-scoped
+  finder instead of the unscoped `findAllById`, so a member cannot attach — and
+  read the live balance of — accounts they do not own.
+- **Admin password reset now terminates the target's sessions (CWE-613).**
+  `activate()` bumps the token version and revokes persistent ("Remember Me")
+  sessions, matching the self-service password change.
+- **MCP scope enforcement runs with the caller's identity on the tool thread.**
+  The `SecurityContext` is propagated to the Reactor scheduler thread via a
+  self-clearing accessor, so scoped MCP tools enforce correctly with no
+  cross-request identity bleed.
+- **Static assets keep their security headers.** The nginx cache block no longer
+  drops `nosniff`/CSP/`X-Frame-Options`/HSTS for `.js`/`.css` responses.
+
 ### Fixed
 
 - **Finary loan accounts are now imported (issue #11).** Loan/mortgage accounts
@@ -17,6 +42,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   account shape under a synthetic `loans` category, so loans flow through the
   normal preview/mapping/execute pipeline and map to `AccountType.LOAN`. The
   outstanding amount is stored as a negative balance (a loan is a liability).
+- **Frontend `Transaction` types declare the `name` field (#12).** A `name`
+  field added to transactions wasn't declared on the TypeScript interfaces,
+  breaking `tsc -b` (and the Docker image build) on `main`.
 
 ## [1.0.7] — 2026-06-04
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -75,7 +75,14 @@
 | Frontend error display (`extractErrorMessage`) | 2026-05-31 | [frontend-error-display.md](./features/frontend-error-display.md) |
 | Loan accounts (LOAN type, amortization view) | 2026-04-26 | [loans.md](./features/loans.md) |
 | 2FA (TOTP) and Remember Me | 2026-06-01 | [mfa-and-remember-me.md](./features/mfa-and-remember-me.md) |
+| Login timing equalization (username-enumeration defense, GHSA-ww5m-pxgq-8qq6) | 2026-06-27 | [login-timing-attack.md](./features/login-timing-attack.md) |
 | GDPR data export (JSON + CSV) | 2026-04-26 | [data-export.md](./features/data-export.md) |
+
+## Lessons
+
+| Lesson | Recorded | Note |
+|--------|----------|------|
+| Test a constant-time fix by counting crypto ops, not wall-clock time | 2026-06-27 | [timing-attack-test-by-op-count.md](./lessons/timing-attack-test-by-op-count.md) |
 
 ## Conventions
 

--- a/docs/features/goals.md
+++ b/docs/features/goals.md
@@ -121,6 +121,7 @@ GoalService.setMonthOverride(goalId, yearMonth, amount)
 - **Override does not recalculate monthlyNeeded**: Setting a month override changes the display value for that month but does not affect the computed `monthlyNeeded`. The auto-computed objective is always based on `(target - current) / monthsLeft`.
 - **Effective-start to deadline range**: `getMonthlyEntries()` iterates from the effective start month (`min(createdAt, historyStartMonth)`) to the deadline month. If the goal was created mid-month, the first month's actual may be partial. Backfilled months (before `createdAt`) never have snapshot data.
 - **`findAllWithAccounts()` uses a custom query**: Goals are fetched with their accounts eagerly loaded to avoid N+1 queries during progress calculation.
+- **Account membership is member-scoped (IDOR guard)**: `create`/`update` resolve `accountIds` via `accountRepository.findByIdInAndMemberId(...)`, never the inherited `findAllById`. A caller can only attach accounts they own; a foreign/nonexistent id fails the size check with a generic 400. Do **not** revert this to `findAllById` — that re-opens a cross-member balance-disclosure IDOR (security audit 2026-06-27, CWE-639).
 
 ## Tests
 

--- a/docs/features/login-timing-attack.md
+++ b/docs/features/login-timing-attack.md
@@ -1,0 +1,102 @@
+# Feature: Login timing equalization (username-enumeration defense)
+
+> Last updated: 2026-06-27
+
+## Context
+
+`POST /api/auth/login` returned a generic `401` for both a wrong password and an
+unknown username — but the two paths did **unequal work**. An existing user paid a
+full bcrypt comparison (~300–450 ms); an unknown username failed in ~15–25 ms (no
+stored hash to check). That stable ~20× latency gap let an unauthenticated caller
+enumerate valid usernames by timing alone, despite identical status code and body
+(CWE-208, observable timing discrepancy). Reported as **GHSA-ww5m-pxgq-8qq6**.
+
+## How it works
+
+`AuthController` precomputes one throwaway bcrypt hash at construction
+(`dummyPasswordHash = passwordEncoder.encode("login-timing-equalizer")`), using the
+same `PasswordEncoder` bean — and therefore the same cost factor — as real password
+hashes.
+
+In `login()`, when the username is **not found**, the controller still runs a real
+`passwordEncoder.matches(req.password(), dummyPasswordHash)` before throwing
+`BadCredentialsException`. Both failure paths — unknown user and wrong password —
+now perform exactly one bcrypt comparison of identical cost, so response latency no
+longer distinguishes "no such user" from "wrong password".
+
+### Key files
+
+- `controller/AuthController.java` — the `dummyPasswordHash` field (built in the
+  constructor) and the unknown-user branch in `login()` that runs the decoy
+  `passwordEncoder.matches(...)` before throwing.
+
+### Flow
+
+```
+POST /api/auth/login
+  → rate-limit check (5 / 15 min per IP, bucket consumed BEFORE the lookup)
+  → findByUsernameWithMember(username)
+      ├─ absent  → passwordEncoder.matches(password, dummyPasswordHash)   ← decoy bcrypt
+      │             → throw BadCredentialsException → 401
+      └─ present → [recovery / activation gates] → passwordEncoder.matches(password, user.hash)
+                    → false → throw BadCredentialsException → 401
+  (both 401 paths now cost exactly one bcrypt round → no timing oracle)
+```
+
+## Technical choices
+
+| Choice | Why | Rejected alternative |
+|--------|-----|----------------------|
+| Precompute one dummy hash in the constructor | A valid same-cost `$2a$…$` hash is needed only once; encoding per request would add bcrypt **encode** cost (not the **matches** cost we want to mirror) and waste CPU | Encode a constant on every unknown-user request |
+| Run `matches()` and discard the result | We want only the constant-time work; the decoy can never match | A fixed `Thread.sleep` delay — fragile, leaks through variance, and not tied to the real bcrypt cost |
+| Equalize timing, don't change the response | The response was already identical (same generic 401); only latency leaked | Returning a different/earlier error, which would create new oracles |
+
+## Gotchas / Pitfalls
+
+- **The `boolean ignored = passwordEncoder.matches(...)` assignment is intentional.**
+  The result is never read; it exists solely to force the bcrypt work. Do not "clean
+  it up" by deleting the call — that re-opens the oracle.
+- **The cost factor must track the real encoder.** The decoy is encoded with the same
+  `PasswordEncoder` bean, so a change to the bcrypt strength is mirrored automatically.
+  Never hardcode a `$2a$12$…` literal as the dummy hash.
+- **Rate limiting is the first line of defense, not this fix.** Login is capped at
+  5 attempts / 15 min per IP (`loginBuckets`) and the bucket is consumed *before* the
+  user lookup, so each timing probe still costs a token. The decoy closes the residual
+  oracle that remained within that budget.
+- **The other early-return branches are deliberately oracle-free.** The admin-recovery
+  branch returns the same `403` regardless of password (see
+  [admin-recovery.md](./admin-recovery.md)); the not-activated branch runs *after* the
+  password check, so it contributes no extra timing signal.
+
+## Tests
+
+- `AuthControllerTest.login_unknownUserAndWrongPassword_payIdenticalBcryptCost_soLatencyRevealsNothing`
+  — drives the controller with a real spied `BCryptPasswordEncoder(12)`. Asserts that
+  both the unknown-user and wrong-password paths throw the same
+  `BadCredentialsException`, call `matches()` **exactly twice** in total (one round
+  each, no short-circuit) against `$2a$12$` hashes with the submitted password, and
+  issue no session. It proves the oracle stays closed **without** measuring (inherently
+  flaky) wall-clock time.
+
+## Security advisory / CVE
+
+- **Advisory:** GHSA-ww5m-pxgq-8qq6 (GitHub draft at time of writing).
+- **Class:** CWE-208 (Observable Timing Discrepancy) → user enumeration.
+- **Severity:** CVSS 3.1 = 5.3 (`AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N`). Real-world
+  impact is **Low** on a self-hosted deployment (tiny user set, often LAN-only, login
+  rate-limited) — but the leak is observable and the fix is trivial.
+- **Affected:** ≥ 1.1.0.
+- **Fixed by:** commit `877ac0f` (+ test `ae1607b`), merged to `main`. Pending
+  propagation to the `1.1.0` release line and a tagged patched release; update the
+  advisory's "patched versions" to that release before publishing the CVE.
+- **Reporter & fix author:** Romain ([@Aguix](https://github.com/Aguix)) — contributed
+  the fix and test via the advisory's private fork.
+
+## Links
+
+- Lesson: [Test a constant-time fix by counting crypto ops, not wall-clock time](../lessons/timing-attack-test-by-op-count.md).
+- Related: [2FA (TOTP) and Remember Me](./mfa-and-remember-me.md) — documents the login
+  endpoint, its cookies, and the login threat model.
+- Related: [Admin recovery (lost-admin console reset)](./admin-recovery.md) — the
+  oracle-free admin-recovery branch in the same `login()` method.
+- Related: [CORS & cookie security](./security-cors-cookies.md).

--- a/docs/features/mfa-and-remember-me.md
+++ b/docs/features/mfa-and-remember-me.md
@@ -394,6 +394,7 @@ All UIs are mobile-responsive (per repo convention).
 | Brute-force TOTP | Rate limit 5/15 min per uid + ±1 tolerance window only |
 | Brute-force recovery codes | bcrypt cost 12 (~250 ms/check) + same rate limit |
 | User reactivates after admin force-disable | Admin disable wipes persistent sessions; user must log in fresh and re-enroll |
+| Username enumeration via login timing (CWE-208, GHSA-ww5m-pxgq-8qq6) | Unknown-user path runs a decoy bcrypt `matches()` so it costs the same as a wrong-password attempt — see [login-timing-attack.md](./login-timing-attack.md) |
 
 ## Gotchas / Pitfalls
 

--- a/docs/lessons/timing-attack-test-by-op-count.md
+++ b/docs/lessons/timing-attack-test-by-op-count.md
@@ -1,0 +1,59 @@
+# Lesson: test a constant-time fix by counting crypto ops, not wall-clock time
+
+> Recorded: 2026-06-27 · Module: backend (auth — `AuthController.login`)
+
+## What happened
+
+`POST /api/auth/login` leaked which usernames existed via response latency: an unknown
+username failed instantly while a known username paid a full bcrypt comparison
+(CWE-208, GHSA-ww5m-pxgq-8qq6). The fix equalizes the work — the unknown-user path now
+runs a decoy `passwordEncoder.matches(password, dummyPasswordHash)` before throwing, so
+both `401` paths cost one bcrypt round.
+
+The tempting way to test this is to **measure both paths and assert their durations are
+close**. That test is inherently flaky: bcrypt timing varies with CI load, scheduler
+jitter, JIT warmup, and GC, so it needs tolerances so wide they prove nothing — and it
+fails randomly, which gets it quarantined or deleted, silently removing the protection.
+
+Instead, the regression test
+(`AuthControllerTest.login_unknownUserAndWrongPassword_payIdenticalBcryptCost_soLatencyRevealsNothing`)
+drives the controller with a **real spied `BCryptPasswordEncoder(12)`** and asserts a
+**structural** invariant: both the unknown-user and wrong-password paths call `matches()`
+**exactly twice in total** (one round each, no short-circuit), against `$2a$12$` hashes,
+with the submitted password — and issue no session. Same operations ⇒ same time, proven
+without ever looking at a clock.
+
+## What we learned
+
+- A timing-attack fix is fundamentally about equalizing **operations**, so the testable
+  invariant is "the same crypto work happened on both paths" — not "the elapsed time was
+  similar". Op-count is deterministic; wall-clock is not.
+- The encoder must be a **real `BCryptPasswordEncoder`, spied** — not a Mockito mock. A
+  mock's `matches()` returns instantly, so the test would pass even if the decoy did no
+  real work or used the wrong cost factor. The spy both lets you count calls **and**
+  guarantees genuine bcrypt cost; asserting the hash starts with `$2a$12$` pins the cost
+  factor.
+- Asserting **"no short-circuit"** (exact call count, not "≥ 1") is what actually catches
+  a regression that re-introduces the early `throw` before the decoy.
+
+## Why it matters
+
+Username enumeration is low-severity here, but the same op-equalization pattern guards
+any future constant-time path — password-reset token lookup, MFA code verification,
+API-key (`psk_`) comparison. If each is tested by timing, the tests rot; if tested by
+op-count, they stay green and meaningful. This makes the *technique* reusable, not just
+this one fix.
+
+## Takeaway
+
+- To test a constant-time / op-equalization fix: **spy the real crypto primitive, assert
+  the exact call count across both branches, and assert the operand shape** (e.g. cost
+  factor via the `$2a$12$` prefix). Never assert elapsed time in a unit test.
+- Use the real algorithm (spied), never a mock, when the property under test *is* that
+  the algorithm runs and how much it costs.
+
+## Links
+
+- Feature note: [login-timing-attack.md](../features/login-timing-attack.md)
+- Advisory: GHSA-ww5m-pxgq-8qq6 (CWE-208)
+- Related login security: [mfa-and-remember-me.md](../features/mfa-and-remember-me.md) (threat model)


### PR DESCRIPTION
## What

Release documentation for **1.0.8** (the security pass) + the supporting feature/lesson notes.

- **CHANGELOG** — cut the `[1.0.8] — 2026-06-27` section:
  - **Security:** login username-enumeration fix (GHSA-ww5m-pxgq-8qq6, CWE-208), Goals IDOR (#14), admin-reset session invalidation + pending-activation timing (#15), MCP `SecurityContext` propagation (#16), nginx static-asset headers (#19).
  - **Fixed:** Finary loan import (#11/#13), frontend `Transaction.name` types (#12).
- **New** `docs/features/login-timing-attack.md` — the decoy-hash mitigation.
- **New** `docs/lessons/timing-attack-test-by-op-count.md` — test constant-time fixes by op-count, not wall-clock (adds a Lessons section to INDEX).
- **`goals.md`** — documents the member-scoping (IDOR) guard.
- **`mfa-and-remember-me.md`** — threat-model row for the timing oracle.

## Note on ordering
The `[1.0.8]` Security entries for the IDOR/auth/MCP/nginx fixes correspond to **PRs #14, #15, #16, #19**, which are not yet merged. Merge those for 1.0.8 to actually contain them. PRs #15/#16 also carry their own `[Unreleased]` CHANGELOG stubs — fold those into this `[1.0.8]` section (or drop them) when merging to avoid a duplicate entry.

Docs only — no code. The `security-report.md` audit file is intentionally **not** committed (it documents still-open findings M1/L10).