### PR TITLE
fix(docker): mark env_file as optional so zero-config works without .env

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -10,7 +10,9 @@ services:
     restart: unless-stopped
     ports:
       - "8080:8080"
-    env_file: .env
+    env_file:
+      - path: .env
+        required: false
     volumes:
       # /data holds auto-generated secrets, Enable Banking keys, and the
       # wizard's crypto key. Mounted named volume so they persist across
@@ -40,7 +42,9 @@ services:
   db:
     image: postgres:16-alpine
     restart: unless-stopped
-    env_file: .env
+    env_file:
+      - path: .env
+        required: false
     environment:
       POSTGRES_DB: ${POSTGRES_DB:-picsou}
       POSTGRES_USER: ${POSTGRES_USER:-picsou}


### PR DESCRIPTION
Fixes #28

 failed on fresh clones because  didn't exist — only  was present.

Both  references in  (services `app` and `db`) are now `required: false`, so the stack boots cleanly using the existing `${VAR:-default}` fallbacks in the `environment:` blocks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Made the app and database services more flexible by allowing them to start even when a local `.env` file is not present.
  * Environment values now fall back gracefully when optional configuration is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->