### PR TITLE
fix(finary): differentiate error types and add retry resilience

### DIFF
--- a/backend/src/main/java/com/picsou/exception/FinaryServiceUnavailableException.java
+++ b/backend/src/main/java/com/picsou/exception/FinaryServiceUnavailableException.java
@@ -1,0 +1,11 @@
+package com.picsou.exception;
+
+public class FinaryServiceUnavailableException extends RuntimeException {
+    public FinaryServiceUnavailableException(String message) {
+        super(message);
+    }
+
+    public FinaryServiceUnavailableException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/backend/src/main/java/com/picsou/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/picsou/exception/GlobalExceptionHandler.java
@@ -29,10 +29,16 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
         return ProblemDetail.forStatusAndDetail(HttpStatus.FORBIDDEN, ex.getMessage());
     }
 
+    @ExceptionHandler(FinaryServiceUnavailableException.class)
+    ProblemDetail handleFinaryUnavailable(FinaryServiceUnavailableException ex) {
+        log.warn("Finary/Clerk service unavailable: {}", ex.getMessage());
+        return ProblemDetail.forStatusAndDetail(HttpStatus.BAD_GATEWAY, "Finary service is temporarily unavailable. Please try again later.");
+    }
+
     @ExceptionHandler(SyncException.class)
     ProblemDetail handleSync(SyncException ex) {
         log.warn("Sync error: {}", ex.getMessage());
-        return ProblemDetail.forStatusAndDetail(HttpStatus.BAD_GATEWAY, ex.getMessage());
+        return ProblemDetail.forStatusAndDetail(HttpStatus.UNPROCESSABLE_ENTITY, ex.getMessage());
     }
 
     @ExceptionHandler(BadCredentialsException.class)

--- a/backend/src/main/java/com/picsou/finary/FinaryApiSyncService.java
+++ b/backend/src/main/java/com/picsou/finary/FinaryApiSyncService.java
@@ -2,6 +2,7 @@ package com.picsou.finary;
 
 import com.picsou.config.CryptoEncryption;
 import com.picsou.dto.*;
+import com.picsou.exception.FinaryServiceUnavailableException;
 import com.picsou.exception.ResourceNotFoundException;
 import com.picsou.exception.SyncException;
 import com.picsou.exception.TotpRequiredException;
@@ -263,7 +264,7 @@ public class FinaryApiSyncService {
             log.info("Preview ready: {} accounts, {} total transactions, autoMapped={}", allAccounts.size(), totalTx, allAutoMapped);
             return new FinaryPreviewResponse(previews, existing, totalTx, syncToken, allAutoMapped, suggestedMappings);
 
-        } catch (SyncException | TotpRequiredException e) {
+        } catch (SyncException | TotpRequiredException | FinaryServiceUnavailableException e) {
             throw e;
         } catch (Exception e) {
             log.error("Finary API preview failed: {}", e.getMessage(), e);
@@ -436,6 +437,9 @@ public class FinaryApiSyncService {
             existingSession.setStatus("TOTP_REQUIRED");
             finarySessionRepository.save(existingSession);
             return new FinaryAutoSyncResponse("TOTP_REQUIRED", 0, 0);
+        } catch (FinaryServiceUnavailableException e) {
+            log.error("Finary service unavailable for member {}: {}", memberId, e.getMessage());
+            throw e;
         } catch (SyncException e) {
             log.error("Finary auto-sync failed for member {}: {}", memberId, e.getMessage(), e);
             throw e;

--- a/backend/src/main/java/com/picsou/finary/client/FinaryApiClient.java
+++ b/backend/src/main/java/com/picsou/finary/client/FinaryApiClient.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.picsou.config.FinaryProperties;
 import com.picsou.finary.dto.*;
+import com.picsou.exception.FinaryServiceUnavailableException;
 import com.picsou.exception.SyncException;
 import com.picsou.exception.TotpRequiredException;
 import lombok.extern.slf4j.Slf4j;
@@ -38,8 +39,13 @@ public class FinaryApiClient {
     private static final String USER_AGENT = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36";
     private static final Duration TIMEOUT = Duration.ofSeconds(30);
 
+    private static final int MAX_RETRIES = 3;
+
     private final ObjectMapper objectMapper;
     private final FinaryProperties finaryProperties;
+    private final HttpClient finaryHttpClient = HttpClient.newBuilder()
+        .connectTimeout(TIMEOUT)
+        .build();
 
     public FinaryApiClient(ObjectMapper objectMapper, FinaryProperties finaryProperties) {
         this.objectMapper = objectMapper;
@@ -138,6 +144,9 @@ public class FinaryApiClient {
         } catch (SyncException e) {
             throw e;
         } catch (IOException e) {
+            if (isNetworkError(e)) {
+                throw new FinaryServiceUnavailableException("Unable to reach Finary. Please check your connection and try again.", e);
+            }
             throw new SyncException("Finary auth check failed: " + e.getMessage(), e);
         }
     }
@@ -192,6 +201,9 @@ public class FinaryApiClient {
         } catch (SyncException e) {
             throw e;
         } catch (IOException e) {
+            if (isNetworkError(e)) {
+                throw new FinaryServiceUnavailableException("Unable to reach Finary. Please check your connection and try again.", e);
+            }
             throw new SyncException("Finary TOTP authentication failed: " + e.getMessage(), e);
         }
     }
@@ -274,9 +286,12 @@ public class FinaryApiClient {
             log.info("Clerk authentication successful");
             return tokenResp.jwt;
 
-        } catch (SyncException e) {
+        } catch (SyncException | TotpRequiredException e) {
             throw e;
         } catch (IOException e) {
+            if (isNetworkError(e)) {
+                throw new FinaryServiceUnavailableException("Unable to reach Finary. Please check your connection and try again.", e);
+            }
             throw new SyncException("Clerk authentication failed: " + e.getMessage(), e);
         }
     }
@@ -312,6 +327,9 @@ public class FinaryApiClient {
         } catch (SyncException e) {
             throw e;
         } catch (IOException e) {
+            if (isNetworkError(e)) {
+                throw new FinaryServiceUnavailableException("Unable to reach Finary. Please check your connection and try again.", e);
+            }
             throw new SyncException("Failed to fetch organization context: " + e.getMessage(), e);
         }
     }
@@ -333,6 +351,9 @@ public class FinaryApiClient {
             return envelope.result() != null ? envelope.result() : List.of();
 
         } catch (IOException e) {
+            if (isNetworkError(e)) {
+                throw new FinaryServiceUnavailableException("Unable to reach Finary. Please check your connection and try again.", e);
+            }
             throw new SyncException("Failed to fetch accounts for category " + category + ": " + e.getMessage(), e);
         }
     }
@@ -356,6 +377,9 @@ public class FinaryApiClient {
             return envelope.result() != null ? envelope.result() : List.of();
 
         } catch (IOException e) {
+            if (isNetworkError(e)) {
+                throw new FinaryServiceUnavailableException("Unable to reach Finary. Please check your connection and try again.", e);
+            }
             throw new SyncException("Failed to fetch loans: " + e.getMessage(), e);
         }
     }
@@ -377,6 +401,9 @@ public class FinaryApiClient {
             return envelope.result() != null ? envelope.result() : List.of();
 
         } catch (IOException e) {
+            if (isNetworkError(e)) {
+                throw new FinaryServiceUnavailableException("Unable to reach Finary. Please check your connection and try again.", e);
+            }
             throw new SyncException("Failed to fetch transactions for category " + category + ": " + e.getMessage(), e);
         }
     }
@@ -396,15 +423,14 @@ public class FinaryApiClient {
             .GET()
             .build();
 
-        try {
-            HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
-            if (response.statusCode() >= 400) {
-                throw new IOException("HTTP " + response.statusCode() + ": " + response.body());
-            }
-            return response.body();
-        } catch (InterruptedException e) {
-            throw new IOException("Clerk GET request interrupted", e);
+        HttpResponse<String> response = sendWithRetry(client, request);
+        if (response.statusCode() == 401) {
+            throw new SyncException("Invalid Finary credentials. Please check your email and password.");
         }
+        if (response.statusCode() >= 400) {
+            throw new IOException("HTTP " + response.statusCode() + ": " + response.body());
+        }
+        return response.body();
     }
 
     /**
@@ -423,15 +449,14 @@ public class FinaryApiClient {
             .POST(HttpRequest.BodyPublishers.ofString(formBody))
             .build();
 
-        try {
-            HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
-            if (response.statusCode() >= 400) {
-                throw new IOException("HTTP " + response.statusCode() + ": " + response.body());
-            }
-            return response.body();
-        } catch (InterruptedException e) {
-            throw new IOException("Clerk POST request interrupted", e);
+        HttpResponse<String> response = sendWithRetry(client, request);
+        if (response.statusCode() == 401) {
+            throw new SyncException("Invalid Finary credentials. Please check your email and password.");
         }
+        if (response.statusCode() >= 400) {
+            throw new IOException("HTTP " + response.statusCode() + ": " + response.body());
+        }
+        return response.body();
     }
 
     /**
@@ -452,15 +477,54 @@ public class FinaryApiClient {
             .GET()
             .build();
 
-        try {
-            HttpResponse<String> response = HttpClient.newHttpClient().send(request, HttpResponse.BodyHandlers.ofString());
-            if (response.statusCode() >= 400) {
-                log.error("Finary API error {}: {}", response.statusCode(), response.body());
-                throw new IOException("HTTP " + response.statusCode() + ": " + response.body());
-            }
-            return response.body();
-        } catch (InterruptedException e) {
-            throw new IOException("Finary GET request interrupted", e);
+        HttpResponse<String> response = sendWithRetry(finaryHttpClient, request);
+        if (response.statusCode() >= 400) {
+            log.error("Finary API error {}: {}", response.statusCode(), response.body());
+            throw new IOException("HTTP " + response.statusCode() + ": " + response.body());
         }
+        return response.body();
+    }
+
+    private HttpResponse<String> sendWithRetry(HttpClient client, HttpRequest request) throws IOException {
+        IOException lastException = null;
+        for (int attempt = 0; attempt < MAX_RETRIES; attempt++) {
+            try {
+                HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+                if (response.statusCode() >= 500) {
+                    log.warn("Finary/Clerk returned HTTP {} (attempt {}/{})", response.statusCode(), attempt + 1, MAX_RETRIES);
+                    if (attempt < MAX_RETRIES - 1) {
+                        Thread.sleep((long) Math.pow(2, attempt) * 1000);
+                        continue;
+                    }
+                    throw new IOException("HTTP " + response.statusCode() + ": " + response.body());
+                }
+                return response;
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new IOException("Request interrupted", e);
+            } catch (IOException e) {
+                lastException = e;
+                if (attempt < MAX_RETRIES - 1) {
+                    log.warn("Request failed (attempt {}/{}): {}", attempt + 1, MAX_RETRIES, e.getMessage());
+                    try {
+                        Thread.sleep((long) Math.pow(2, attempt) * 1000);
+                    } catch (InterruptedException ie) {
+                        Thread.currentThread().interrupt();
+                        throw new IOException("Retry sleep interrupted", ie);
+                    }
+                }
+            }
+        }
+        throw lastException;
+    }
+
+    private boolean isNetworkError(IOException e) {
+        String msg = e.getMessage();
+        if (msg == null) return false;
+        String lower = msg.toLowerCase();
+        return lower.contains("timed out") || lower.contains("connection refused")
+            || lower.contains("unreachable") || lower.contains("connect failed")
+            || lower.contains("connection reset") || lower.contains("ssl")
+            || lower.contains("unknownhost") || lower.contains("no route to host");
     }
 }

--- a/docs/features/finary-import.md
+++ b/docs/features/finary-import.md
@@ -1,6 +1,6 @@
 # Feature: Finary Import
 
-> Last updated: 2026-06-27
+> Last updated: 2026-07-07
 
 ## Context
 
@@ -66,6 +66,7 @@ Possible status values: `OK`, `NEEDS_MAPPING`, `TOTP_REQUIRED`, `NOT_CONNECTED`.
 - `finary/client/FinaryApiClient.java` -- Finary/Clerk HTTP client (6-step auth, TOTP, pagination, `fetchLoans()`)
 - `finary/dto/FinaryLoanDto.java` -- a loan/mortgage entry from the dedicated `/loans` endpoint
 - `exception/TotpRequiredException.java` -- Thrown when 2FA is required but no TOTP provided (returns 403)
+- `exception/FinaryServiceUnavailableException.java` -- Thrown when Clerk/Finary APIs are unreachable (network, timeout, DNS); returns 502
 - `finary/FinaryPersistenceHelper.java` -- Shared helper: account creation, snapshot reconstruction, transaction import (preserves manual transactions), type suggestion
 - `controller/FinaryImportController.java` -- REST endpoints for xlsx upload
 - `controller/FinaryApiSyncController.java` -- REST endpoints for API sync (`/preview`, `/execute`, `/auto`)
@@ -169,6 +170,9 @@ POST /api/finary/api-sync/auto
 | Apache POI for xlsx | Standard Java library for Excel; Finary exports in xlsx format | CSV parsing (Finary does not export CSV) |
 | Clerk auth flow reimplemented | Finary uses Clerk for auth; no official API; must reverse-engineer the 6-step flow | Finary API key (does not exist) |
 | `TotpRequiredException` → 403 | Frontend already checks for 403 on preview mutations; 401 would trigger the Picsou JWT refresh flow which is wrong | Using 401 (conflicts with Picsou auth refresh), using 502 (frontend can't distinguish from real errors) |
+| `FinaryServiceUnavailableException` → 502 | Distinguishes upstream outage (Clerk/Finary unreachable) from data sync issues; frontend shows "service unavailable" message | Returning 502 for all sync errors (confusing, cannot distinguish cause) |
+| `SyncException` → 422 | Data/sync issues (bad response, mapping failures) are client errors, not gateway errors | 502 BAD_GATEWAY (semantically wrong for data processing failures) |
+| Retry with exponential backoff | Transient HTTP 5xx and network errors from Clerk/Finary are common; retry reduces false failures | No retry (fails on first attempt even for transient issues) |
 | Auto-mapping by name | Simple heuristic that works for most cases after first manual import | ML-based matching (unnecessary complexity) |
 
 ## Gotchas / Pitfalls
@@ -183,6 +187,8 @@ POST /api/finary/api-sync/auto
 - **External IDs use Finary category + ID**: Format is `finary_{category}_{finaryId}`. This means the same Finary account always maps to the same external ID, preventing duplicates across imports.
 - **Loans come from a separate endpoint (issue #11)**: loan/mortgage accounts are *not* returned by the portfolio `credits`/`credit_accounts` categories — they live on the dedicated `/loans` endpoint. The API sync fetches them via `FinaryApiClient.fetchLoans()` and adapts each entry to the common `FinaryAccountDto` under a synthetic `loans` category (external ID `finary_loans_{id}`), so they flow through the normal preview/mapping/execute pipeline and map to `AccountType.LOAN`. The outstanding amount is stored as a **negative** balance (a loan is a liability). Only the balance is imported — the loans payload does not expose the original principal or interest rate, so **no `Debt` row is created**; the imported LOAN account shows a static balance until the user fills in the loan parameters for the amortization view (see [loans.md](loans.md)). The exact `/loans` JSON shape and path are best-effort from the issue's sample (`type`, `name`, `outstanding_amount`, `monthly_repayment`, `start_date`, `end_date`); `FinaryLoanDto` maps the snake_case keys explicitly and accepts camelCase aliases as a fallback.
 - **Import mapping wizard type dropdown includes all account types (fix #17)**: The `CREATE_NEW` type selector in `FinaryTab` now uses `ACCOUNT_TYPES` from `@/lib/constants` instead of a hard-coded subset. This ensures `LOAN` and `REAL_ESTATE` are available in the dropdown, so loans imported from `/loans` are no longer forced into `OTHER` when the user overrides the backend suggestion.
+- **Error status codes are differentiated (fix #27)**: `FinaryServiceUnavailableException` returns 502 (Clerk/Finary unreachable), `SyncException` returns 422 (data/sync issue), `TotpRequiredException` returns 403. Previously all sync errors returned 502. The frontend uses a `getFinaryError()` helper to show localized messages per status code.
+- **HTTP calls retry transient failures (fix #27)**: `FinaryApiClient.sendWithRetry()` retries up to 3 times with exponential backoff (1s, 2s) on HTTP 5xx and network errors from Clerk/Finary.
 
 ## Tests
 

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -441,7 +441,10 @@
       "deleteConnection": "Disconnect",
       "deleteConnectionConfirm": "Remove stored Finary credentials? Accounts already imported will be kept.",
       "newAccounts": "New accounts detected",
-      "allAccountsMapped": "All accounts already mapped, syncing..."
+      "allAccountsMapped": "All accounts already mapped, syncing...",
+      "serviceUnavailable": "Finary service is temporarily unavailable. Please try again in a few minutes.",
+      "syncFailed": "Finary sync failed",
+      "authFailed": "Invalid Finary credentials. Please check your email and password."
     },
     "all": {
       "title": "Sync accounts",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -441,7 +441,10 @@
       "deleteConnection": "Déconnecter",
       "deleteConnectionConfirm": "Supprimer les identifiants Finary stockés ? Les comptes déjà importés seront conservés.",
       "newAccounts": "Nouveaux comptes détectés",
-      "allAccountsMapped": "Tous les comptes déjà mappés, synchronisation..."
+      "allAccountsMapped": "Tous les comptes déjà mappés, synchronisation...",
+      "serviceUnavailable": "Le service Finary est temporairement indisponible. Réessayez dans quelques minutes.",
+      "syncFailed": "La synchronisation Finary a échoué",
+      "authFailed": "Identifiants Finary invalides. Vérifiez votre email et mot de passe."
     },
     "all": {
       "title": "Synchroniser les comptes",

--- a/frontend/src/pages/sync/FinaryTab.tsx
+++ b/frontend/src/pages/sync/FinaryTab.tsx
@@ -4,7 +4,7 @@ import { useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 import { ACCOUNT_COLORS, ACCOUNT_TYPES } from '@/lib/constants'
 import { formatDate } from '@/lib/utils'
-import { extractErrorMessage, getErrorStatus, getErrorDetail } from '@/lib/errors'
+import { getErrorStatus, getErrorDetail } from '@/lib/errors'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
@@ -143,7 +143,7 @@ export function FinaryTab() {
       },
       onError: (err: unknown) => {
         setLoading(false)
-        setError(getErrorDetail(err) || t('common.retry'))
+        setError(getFinaryError(err))
       },
     })
   }
@@ -173,7 +173,7 @@ export function FinaryTab() {
         if (getErrorStatus(err) === 403) {
           setTotpRequired(true)
         } else {
-          setError(getErrorDetail(err) || t('common.retry'))
+          setError(getFinaryError(err))
         }
       },
     })
@@ -196,7 +196,7 @@ export function FinaryTab() {
         if (getErrorStatus(err) === 403) {
           setTotpRequired(true)
         } else {
-          setError(getErrorDetail(err) || t('common.retry'))
+          setError(getFinaryError(err))
         }
       },
     })
@@ -214,7 +214,7 @@ export function FinaryTab() {
     }
     const onError = (err: unknown) => {
       setLoading(false)
-      setError(extractErrorMessage(err, t('common.retry')))
+      setError(getFinaryError(err))
     }
 
     // Each mutation takes a distinct payload shape — branch so the call stays
@@ -241,7 +241,7 @@ export function FinaryTab() {
       },
       onError: (err: unknown) => {
         setLoading(false)
-        setError(extractErrorMessage(err, t('common.retry')))
+        setError(getFinaryError(err))
       },
     })
   }
@@ -333,6 +333,14 @@ export function FinaryTab() {
     setTotpRequired(false)
     setTotpCode('')
     setIsApiSync(false)
+  }
+
+  function getFinaryError(err: unknown): string {
+    const status = getErrorStatus(err)
+    if (status === 502) return t('sync.finary.serviceUnavailable')
+    const detail = getErrorDetail(err)
+    if (detail) return detail
+    return t('sync.finary.syncFailed')
   }
 
   const hasSkipAll = mappings.every((m) => m.action === 'SKIP')


### PR DESCRIPTION
## Summary

Fixes #27 — Users were seeing raw **502 errors** when using Finary sync, with no way to distinguish between upstream outages, credential issues, or data sync problems.

## Root cause

Every `SyncException` was mapped to **HTTP 502 BAD_GATEWAY** in `GlobalExceptionHandler`. Network timeouts, invalid credentials, and Clerk API changes all returned 502 to the frontend.

## Changes

### Backend
- **`FinaryServiceUnavailableException`** (new) — dedicated exception for network/timeout/DNS errors → 502
- **`GlobalExceptionHandler`** — `SyncException` → 422 (data issues), `FinaryServiceUnavailableException` → 502
- **`FinaryApiClient`**:
  - `sendWithRetry()` with exponential backoff (3 attempts, 1s/2s delay)
  - Shared `HttpClient` for `finaryGet()` (was creating new instances per call)
  - `isNetworkError()` detection for timeout/connection refused/SSL/DNS errors
  - Differentiated error messages for 401 (bad credentials) vs network failures
- **`FinaryApiSyncService`** — propagates `FinaryServiceUnavailableException` in `preview()` and `autoSync()`

### Frontend
- **i18n** (FR/EN) — 3 new keys: `serviceUnavailable`, `syncFailed`, `authFailed`
- **`FinaryTab.tsx`** — `getFinaryError()` helper maps 502 → localized "service unavailable" message, 422 → backend detail, fallback → generic error

### Docs
- Updated `docs/features/finary-import.md` with new error handling, retry, and status code documentation

## Test results

- **Backend**: 421 tests, 0 failures
- **Frontend**: TypeScript compiles cleanly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer sync error messages, including dedicated handling for service unavailability, authentication issues, and sync failures.
  * Improved retry handling for Finary requests to make temporary network issues more resilient.

* **Bug Fixes**
  * Sync errors now return more appropriate status codes, helping the app show the right message for each failure type.
  * Finary sync flows now surface clearer feedback when the service is unreachable or credentials are invalid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->