### PR TITLE
fix(dashboard): separate portfolio performance from debt impact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  backend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: maven
+      - name: Run backend tests
+        run: mvn -B test
+        working-directory: backend
+
+  frontend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+      - name: Install
+        run: bun install --frozen-lockfile
+        working-directory: frontend
+      - name: Lint
+        run: bun run lint
+        working-directory: frontend
+      - name: Typecheck
+        run: bun run typecheck
+        working-directory: frontend
+      - name: Unit tests
+        run: bun run test
+        working-directory: frontend

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,11 +5,16 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   backend:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-java@v4
         with:
           distribution: temurin
@@ -23,6 +28,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: oven-sh/setup-bun@v2
       - name: Install
         run: bun install --frozen-lockfile

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **PnL no longer counts outstanding debt as an investment loss (#18).** Loans
+  contribute 0 to `pnl` in every aggregation path (history points, live PnL,
+  MCP `get_profit_and_loss`); `rangePnl` compares only holdings priced on both
+  sides of the range; allocation percentages divide by their own side of the
+  balance sheet (assets by total assets, liabilities by total liabilities).
+  Net-worth totals are unchanged — loans remain liabilities. The dashboard
+  chart is now titled by wealth mode instead of "Gain / Loss", its tooltip
+  shows the backend's debt-neutral gain/loss, and a new Liabilities card lists
+  loans separately.
+
 ## [1.0.8] — 2026-06-27
 
 Security release: remediations from a 2026-06-27 security audit, the login

--- a/backend/src/main/java/com/picsou/finary/FinaryApiSyncService.java
+++ b/backend/src/main/java/com/picsou/finary/FinaryApiSyncService.java
@@ -480,15 +480,16 @@ public class FinaryApiSyncService {
      * Adapt a Finary loan entry to the common {@link FinaryAccountDto} so loans flow through
      * the existing preview/execute pipeline (mapping, auto-mapping, account creation).
      *
-     * <p>A loan is a liability, so the outstanding amount is stored as a NEGATIVE balance,
-     * mirroring how LOAN accounts are persisted elsewhere ({@code liveBalanceEur} returns a
-     * negative remaining capital). Only the outstanding balance is carried over; the original
+     * <p>A loan is a liability; the outstanding amount is stored as a POSITIVE balance and
+     * negated at aggregation time (dashboard, history, family view), matching
+     * {@code LoanAmortizationService.computeRemainingBalance} which returns a positive
+     * remaining capital. Only the outstanding balance is carried over; the original
      * principal, interest rate and amortization details are not exposed by the loans payload,
      * so no {@code Debt} is created here — the user can add those later for the amortization view.
      */
-    private FinaryAccountDto toLoanAccountDto(FinaryLoanDto loan) {
-        Double outstanding = loan.outstandingAmount();
-        Double balance = outstanding != null ? -outstanding : null;
+    FinaryAccountDto toLoanAccountDto(FinaryLoanDto loan) {
+        // Stored positive; aggregation negates (see LoanAmortizationService.computeRemainingBalance)
+        Double balance = loan.outstandingAmount();
         return new FinaryAccountDto(
             loan.id(),
             loan.name(),

--- a/backend/src/main/java/com/picsou/service/AccountService.java
+++ b/backend/src/main/java/com/picsou/service/AccountService.java
@@ -267,6 +267,16 @@ public class AccountService {
         return liveValue;
     }
 
+    /**
+     * Live balance in EUR with liability sign applied: LOAN accounts return a
+     * NEGATIVE value (outstanding debt), all other types return liveBalanceEur as-is.
+     * Use this for any net-worth-style summation.
+     */
+    public BigDecimal signedLiveBalanceEur(Account account) {
+        BigDecimal value = liveBalanceEur(account);
+        return account.getType() == AccountType.LOAN ? value.negate() : value;
+    }
+
     AccountResponse toResponse(Account account) {
         BigDecimal balanceEur = liveBalanceEur(account);
         AccountResponse response = AccountResponse.from(account, balanceEur);

--- a/backend/src/main/java/com/picsou/service/DashboardService.java
+++ b/backend/src/main/java/com/picsou/service/DashboardService.java
@@ -32,6 +32,7 @@ public class DashboardService {
     private final PriceService priceService;
     private final AccountHoldingRepository holdingRepository;
     private final HistoryService historyService;
+    private final AccountService accountService;
 
     public DashboardService(
         AccountRepository accountRepository,
@@ -39,7 +40,8 @@ public class DashboardService {
         GoalRepository goalRepository,
         PriceService priceService,
         AccountHoldingRepository holdingRepository,
-        HistoryService historyService
+        HistoryService historyService,
+        AccountService accountService
     ) {
         this.accountRepository = accountRepository;
         this.goalService = goalService;
@@ -47,6 +49,7 @@ public class DashboardService {
         this.priceService = priceService;
         this.holdingRepository = holdingRepository;
         this.historyService = historyService;
+        this.accountService = accountService;
     }
 
     public DashboardResponse getDashboard(Long memberId, String range) {
@@ -69,7 +72,13 @@ public class DashboardService {
             BigDecimal accountValue;
             BigDecimal accountInvested;
 
-            if (holdings.isEmpty()) {
+            if (account.getType() == AccountType.LOAN) {
+                // Same valuation source as HistoryService's live point: amortized
+                // remaining capital when a Debt row exists, stored balance otherwise.
+                // Keeps the hero's liabilities consistent with the chart's today point.
+                accountValue = accountService.liveBalanceEur(account);
+                accountInvested = BigDecimal.ZERO;
+            } else if (holdings.isEmpty()) {
                 accountValue = priceService.toEur(account.getCurrentBalance(), account.getCurrency(), account.getTicker());
                 accountInvested = accountValue;
             } else {
@@ -135,7 +144,10 @@ public class DashboardService {
 
             List<AccountHolding> holdings = holdingsByAccount.getOrDefault(account.getId(), List.of());
             BigDecimal balanceEur;
-            if (holdings.isEmpty()) {
+            if (isLoan) {
+                // Keep liability rows on the same valuation as the totals above.
+                balanceEur = accountService.liveBalanceEur(account);
+            } else if (holdings.isEmpty()) {
                 balanceEur = priceService.toEur(account.getCurrentBalance(), account.getCurrency(), account.getTicker());
             } else {
                 balanceEur = BigDecimal.ZERO;

--- a/backend/src/main/java/com/picsou/service/DashboardService.java
+++ b/backend/src/main/java/com/picsou/service/DashboardService.java
@@ -112,8 +112,10 @@ public class DashboardService {
         };
         List<NetWorthPoint> updatedHistory = historyService.buildHistory(allAccountIds, months, memberId);
 
-        List<DistributionItem> distribution = buildDistribution(accounts, totalNetWorth, holdingsByAccount, false);
-        List<DistributionItem> liabilities = buildDistribution(accounts, totalNetWorth, holdingsByAccount, true);
+        // Percentages are shares of their own side of the balance sheet:
+        // assets divide by totalAssets, liabilities by totalLiabilities (issue #18).
+        List<DistributionItem> distribution = buildDistribution(accounts, totalAssets, holdingsByAccount, false);
+        List<DistributionItem> liabilities = buildDistribution(accounts, totalLiabilities, holdingsByAccount, true);
 
         List<GoalProgressResponse> goals = goalRepository.findAllByMemberIdOrderByCreatedAtAsc(memberId).stream()
             .map(goalService::toProgressResponse)
@@ -122,7 +124,7 @@ public class DashboardService {
         return new DashboardResponse(totalNetWorth, totalLiabilities, updatedHistory, distribution, liabilities, goals);
     }
 
-    private List<DistributionItem> buildDistribution(List<Account> accounts, BigDecimal totalNetWorth,
+    private List<DistributionItem> buildDistribution(List<Account> accounts, BigDecimal divisor,
                                                        Map<Long, List<AccountHolding>> holdingsByAccount,
                                                        boolean liabilitiesOnly) {
         List<DistributionItem> items = new ArrayList<>();
@@ -142,8 +144,8 @@ public class DashboardService {
                 }
             }
 
-            double percentage = totalNetWorth.compareTo(BigDecimal.ZERO) > 0
-                ? balanceEur.divide(totalNetWorth, 6, RoundingMode.HALF_UP)
+            double percentage = divisor.compareTo(BigDecimal.ZERO) > 0
+                ? balanceEur.divide(divisor, 6, RoundingMode.HALF_UP)
                     .multiply(BigDecimal.valueOf(100))
                     .doubleValue()
                 : 0.0;

--- a/backend/src/main/java/com/picsou/service/FamilyViewService.java
+++ b/backend/src/main/java/com/picsou/service/FamilyViewService.java
@@ -75,7 +75,8 @@ public class FamilyViewService {
                 }
 
                 for (Account acc : accounts) {
-                    BigDecimal balanceEur = accountService.liveBalanceEur(acc);
+                    // Signed: LOAN accounts count negatively so totalNetWorth below is correct.
+                    BigDecimal balanceEur = accountService.signedLiveBalanceEur(acc);
                     sharedAccounts.add(new SharedAccountInfo(
                         acc.getId(),
                         ownerName,
@@ -107,7 +108,7 @@ public class FamilyViewService {
 
                 for (Goal goal : goals) {
                     BigDecimal currentTotal = goal.getAccounts().stream()
-                        .map(a -> accountService.liveBalanceEur(a))
+                        .map(a -> accountService.signedLiveBalanceEur(a))
                         .reduce(BigDecimal.ZERO, BigDecimal::add);
 
                     // Build contributions per member (from manual contributions)

--- a/backend/src/main/java/com/picsou/service/GoalService.java
+++ b/backend/src/main/java/com/picsou/service/GoalService.java
@@ -128,9 +128,10 @@ public class GoalService {
             .map(accountService::toResponse)
             .toList();
 
-        // Use live balance (with PnL from current prices) for each account
+        // Use live balance (with PnL from current prices) for each account.
+        // Signed: linked LOAN accounts count negatively against the goal.
         BigDecimal currentTotal = goal.getAccounts().stream()
-            .map(accountService::liveBalanceEur)
+            .map(accountService::signedLiveBalanceEur)
             .reduce(BigDecimal.ZERO, BigDecimal::add);
 
         BigDecimal target = goal.getTargetAmount();

--- a/backend/src/main/java/com/picsou/service/GoalService.java
+++ b/backend/src/main/java/com/picsou/service/GoalService.java
@@ -7,6 +7,7 @@ import com.picsou.dto.GoalProgressResponse;
 import com.picsou.dto.GoalRequest;
 import com.picsou.exception.ResourceNotFoundException;
 import com.picsou.model.Account;
+import com.picsou.model.AccountType;
 import com.picsou.model.BalanceSnapshot;
 import com.picsou.model.FamilyMember;
 import com.picsou.model.Goal;
@@ -191,8 +192,14 @@ public class GoalService {
                     snapshots.get(0).getDate(),
                     snapshots.get(snapshots.size() - 1).getDate()
                 ));
+                BigDecimal delta = last.subtract(first);
+                // Loan snapshots store outstanding debt (positive): paying it down
+                // shrinks the balance but is positive progress toward the goal.
+                if (account.getType() == AccountType.LOAN) {
+                    delta = delta.negate();
+                }
                 totalContribution = totalContribution.add(
-                    last.subtract(first).divide(BigDecimal.valueOf(months), 2, RoundingMode.HALF_UP)
+                    delta.divide(BigDecimal.valueOf(months), 2, RoundingMode.HALF_UP)
                 );
                 accountsWithData++;
             }
@@ -420,7 +427,13 @@ public class GoalService {
                 .findFirstByAccountIdAndDateLessThanEqualOrderByDateDesc(account.getId(), thisMonthEnd);
 
             if (prev.isPresent() && curr.isPresent()) {
-                total = total.add(curr.get().getBalance().subtract(prev.get().getBalance()));
+                BigDecimal delta = curr.get().getBalance().subtract(prev.get().getBalance());
+                // Same sign convention as calculateAvgMonthlyContribution: loan paydown
+                // (balance decrease) counts as positive progress.
+                if (account.getType() == AccountType.LOAN) {
+                    delta = delta.negate();
+                }
+                total = total.add(delta);
                 hasData = true;
             }
         }

--- a/backend/src/main/java/com/picsou/service/HistoryService.java
+++ b/backend/src/main/java/com/picsou/service/HistoryService.java
@@ -374,11 +374,19 @@ public class HistoryService {
         BigDecimal valueAtFrom = BigDecimal.ZERO;
         BigDecimal liveMatchedValue = BigDecimal.ZERO;
         int matchedPrices = 0;
+        // Same ticker can appear across several accounts — look each price up once.
+        Map<String, Optional<PriceSnapshot>> snapByTicker = new HashMap<>();
+        Map<String, BigDecimal> livePriceByTicker = new HashMap<>();
         for (AccountHolding h : allHoldings) {
-            if (h.getTicker() == null) continue;
-            Optional<PriceSnapshot> snap = priceSnapshotRepository.findLatestByTickerBeforeOrOnDate(h.getTicker(), fromDate);
+            String ticker = h.getTicker();
+            if (ticker == null) continue;
+            Optional<PriceSnapshot> snap = snapByTicker.computeIfAbsent(ticker,
+                t -> priceSnapshotRepository.findLatestByTickerBeforeOrOnDate(t, fromDate));
             if (snap.isEmpty()) continue;
-            BigDecimal livePrice = priceService.getPriceEur(h.getTicker());
+            if (!livePriceByTicker.containsKey(ticker)) {
+                livePriceByTicker.put(ticker, priceService.getPriceEur(ticker));
+            }
+            BigDecimal livePrice = livePriceByTicker.get(ticker);
             if (livePrice == null) continue;
             valueAtFrom = valueAtFrom.add(h.getQuantity().multiply(snap.get().getPriceEur()));
             liveMatchedValue = liveMatchedValue.add(h.getQuantity().multiply(livePrice));

--- a/backend/src/main/java/com/picsou/service/HistoryService.java
+++ b/backend/src/main/java/com/picsou/service/HistoryService.java
@@ -109,6 +109,7 @@ public class HistoryService {
         for (LocalDate date : ffData.dates()) {
             BigDecimal aggTotal = BigDecimal.ZERO;
             BigDecimal aggInvested = BigDecimal.ZERO;
+            BigDecimal aggPnl = BigDecimal.ZERO;
             Map<Long, AccountPoint> accountPoints = split ? new HashMap<>() : null;
 
             for (Account account : accounts) {
@@ -132,40 +133,50 @@ public class HistoryService {
                     : (invEntry != null ? invEntry.getValue() : rawBalance);
                 aggInvested = aggInvested.add(accInvested);
 
+                // Debt-neutral pnl (issue #18): loans contribute 0 — outstanding debt
+                // is a liability, not an investment loss.
+                BigDecimal accPnl = isLoan ? BigDecimal.ZERO : accTotal.subtract(accInvested);
+                aggPnl = aggPnl.add(accPnl);
+
                 if (split) {
-                    accountPoints.put(accId, new AccountPoint(accTotal, accInvested, accTotal.subtract(accInvested)));
+                    accountPoints.put(accId, new AccountPoint(accTotal, accInvested, accPnl));
                 }
             }
 
-            BigDecimal pnl = aggTotal.subtract(aggInvested);
-            result.add(new NetWorthPoint(date, aggTotal, aggInvested, pnl, accountPoints));
+            result.add(new NetWorthPoint(date, aggTotal, aggInvested, aggPnl, accountPoints));
         }
 
         // Replace today's point with live-calculated values
         BigDecimal liveTotal = BigDecimal.ZERO;
         BigDecimal liveInvested = BigDecimal.ZERO;
+        BigDecimal livePnl = BigDecimal.ZERO;
         Map<Long, AccountPoint> liveAccountPoints = split ? new HashMap<>() : null;
 
         for (Account account : accounts) {
             BigDecimal accLive = accountService.liveBalanceEur(account);
             BigDecimal accInvested = accountService.calculateInvestedAmount(account);
+            boolean isLoan = account.getType() == AccountType.LOAN;
 
-            if (account.getType() == AccountType.LOAN) {
+            if (isLoan) {
                 liveTotal = liveTotal.subtract(accLive);
             } else {
                 liveTotal = liveTotal.add(accLive);
                 liveInvested = liveInvested.add(accInvested);
             }
 
+            // Debt-neutral pnl (issue #18): loans contribute 0.
+            BigDecimal accPnl = isLoan ? BigDecimal.ZERO : accLive.subtract(accInvested);
+            livePnl = livePnl.add(accPnl);
+
             if (split) {
-                BigDecimal total = account.getType() == AccountType.LOAN ? accLive.negate() : accLive;
-                BigDecimal invested = account.getType() == AccountType.LOAN ? BigDecimal.ZERO : accInvested;
-                liveAccountPoints.put(account.getId(), new AccountPoint(total, invested, total.subtract(invested)));
+                BigDecimal total = isLoan ? accLive.negate() : accLive;
+                BigDecimal invested = isLoan ? BigDecimal.ZERO : accInvested;
+                liveAccountPoints.put(account.getId(), new AccountPoint(total, invested, accPnl));
             }
         }
 
         LocalDate today = LocalDate.now();
-        NetWorthPoint livePoint = new NetWorthPoint(today, liveTotal, liveInvested, liveTotal.subtract(liveInvested), liveAccountPoints);
+        NetWorthPoint livePoint = new NetWorthPoint(today, liveTotal, liveInvested, livePnl, liveAccountPoints);
 
         boolean replaced = false;
         for (int i = result.size() - 1; i >= 0; i--) {
@@ -324,9 +335,11 @@ public class HistoryService {
 
         assertOwnership(accounts, memberId);
 
-        // Live values
+        // Live values. `liveTotal` stays NET WORTH (loans negated); pnl is computed
+        // debt-neutrally from non-loan value only (issue #18).
         BigDecimal liveTotal = BigDecimal.ZERO;
         BigDecimal liveInvested = BigDecimal.ZERO;
+        BigDecimal liveNonLoanValue = BigDecimal.ZERO;
 
         // Collect all holdings for historical lookup
         List<AccountHolding> allHoldings = new ArrayList<>();
@@ -338,12 +351,14 @@ public class HistoryService {
             if (account.getType() == AccountType.LOAN) {
                 liveTotal = liveTotal.subtract(accountService.liveBalanceEur(account));
             } else {
-                liveTotal = liveTotal.add(accountService.liveBalanceEur(account));
+                BigDecimal accLive = accountService.liveBalanceEur(account);
+                liveTotal = liveTotal.add(accLive);
+                liveNonLoanValue = liveNonLoanValue.add(accLive);
                 liveInvested = liveInvested.add(accountService.calculateInvestedAmount(account));
             }
         }
 
-        BigDecimal pnl = liveTotal.subtract(liveInvested);
+        BigDecimal pnl = liveNonLoanValue.subtract(liveInvested);
         BigDecimal pnlPercent = liveInvested.compareTo(BigDecimal.ZERO) > 0
             ? pnl.multiply(BigDecimal.valueOf(100)).divide(liveInvested, 1, java.math.RoundingMode.HALF_UP)
             : null;
@@ -353,16 +368,21 @@ public class HistoryService {
             return new com.picsou.dto.PnlResponse(liveTotal, liveInvested, pnl, pnlPercent);
         }
 
-        // Compute portfolio value at fromDate using historical prices (with weekend/holiday fallback)
+        // Compute the range over holdings priced on BOTH sides (live and at fromDate,
+        // with weekend/holiday fallback). Cash, loans and unmatched holdings are
+        // excluded from both sides so rangePnl is pure portfolio performance.
         BigDecimal valueAtFrom = BigDecimal.ZERO;
+        BigDecimal liveMatchedValue = BigDecimal.ZERO;
         int matchedPrices = 0;
         for (AccountHolding h : allHoldings) {
             if (h.getTicker() == null) continue;
             Optional<PriceSnapshot> snap = priceSnapshotRepository.findLatestByTickerBeforeOrOnDate(h.getTicker(), fromDate);
-            if (snap.isPresent()) {
-                valueAtFrom = valueAtFrom.add(h.getQuantity().multiply(snap.get().getPriceEur()));
-                matchedPrices++;
-            }
+            if (snap.isEmpty()) continue;
+            BigDecimal livePrice = priceService.getPriceEur(h.getTicker());
+            if (livePrice == null) continue;
+            valueAtFrom = valueAtFrom.add(h.getQuantity().multiply(snap.get().getPriceEur()));
+            liveMatchedValue = liveMatchedValue.add(h.getQuantity().multiply(livePrice));
+            matchedPrices++;
         }
 
         if (matchedPrices == 0) {
@@ -370,14 +390,14 @@ public class HistoryService {
             return new com.picsou.dto.PnlResponse(liveTotal, liveInvested, pnl, pnlPercent);
         }
 
-        // Range PnL: live holdings value minus value at from date
-        BigDecimal rangePnl = liveTotal.subtract(valueAtFrom);
+        // Range PnL: matched holdings' live value minus their value at the from date
+        BigDecimal rangePnl = liveMatchedValue.subtract(valueAtFrom);
         BigDecimal rangePnlPercent = valueAtFrom.compareTo(BigDecimal.ZERO) > 0
             ? rangePnl.multiply(BigDecimal.valueOf(100)).divide(valueAtFrom, 1, java.math.RoundingMode.HALF_UP)
             : null;
 
-        log.info("buildPnl: fromDate={} valueAtFrom={} liveTotal={} rangePnl={} rangePnlPercent={}",
-            fromDate, valueAtFrom, liveTotal, rangePnl, rangePnlPercent);
+        log.info("buildPnl: fromDate={} valueAtFrom={} liveMatchedValue={} rangePnl={} rangePnlPercent={}",
+            fromDate, valueAtFrom, liveMatchedValue, rangePnl, rangePnlPercent);
 
         return new com.picsou.dto.PnlResponse(liveTotal, liveInvested, pnl, pnlPercent, valueAtFrom, rangePnl, rangePnlPercent);
     }

--- a/backend/src/main/java/com/picsou/service/ManualTransactionService.java
+++ b/backend/src/main/java/com/picsou/service/ManualTransactionService.java
@@ -53,7 +53,10 @@ public class ManualTransactionService {
 
         if (INVESTMENT_TYPES.contains(account.getType())) {
             holdingComputeService.recomputeHoldings(account);
-        } else {
+        // Synced accounts (bank/TR/wallet/exchange) own their balance & snapshot history
+        // via their provider sync; rebuilding from manual transactions would overwrite
+        // the balance and delete the provider-written snapshots.
+        } else if (account.isManual()) {
             recomputeCashBalance(account);
             finaryPersistenceHelper.reconstructSnapshotsFromDb(account);
         }
@@ -85,7 +88,7 @@ public class ManualTransactionService {
 
         if (INVESTMENT_TYPES.contains(account.getType())) {
             holdingComputeService.recomputeHoldings(account);
-        } else {
+        } else if (account.isManual()) {
             recomputeCashBalance(account);
             finaryPersistenceHelper.reconstructSnapshotsFromDb(account);
         }
@@ -109,7 +112,7 @@ public class ManualTransactionService {
 
         if (INVESTMENT_TYPES.contains(account.getType())) {
             holdingComputeService.recomputeHoldings(account);
-        } else {
+        } else if (account.isManual()) {
             recomputeCashBalance(account);
             finaryPersistenceHelper.reconstructSnapshotsFromDb(account);
         }

--- a/backend/src/main/java/com/picsou/service/ManualTransactionService.java
+++ b/backend/src/main/java/com/picsou/service/ManualTransactionService.java
@@ -51,15 +51,7 @@ public class ManualTransactionService {
 
         transactionRepository.save(tx);
 
-        if (INVESTMENT_TYPES.contains(account.getType())) {
-            holdingComputeService.recomputeHoldings(account);
-        // Synced accounts (bank/TR/wallet/exchange) own their balance & snapshot history
-        // via their provider sync; rebuilding from manual transactions would overwrite
-        // the balance and delete the provider-written snapshots.
-        } else if (account.isManual()) {
-            recomputeCashBalance(account);
-            finaryPersistenceHelper.reconstructSnapshotsFromDb(account);
-        }
+        recomputeDerivedState(account);
 
         return TransactionResponse.from(tx);
     }
@@ -86,12 +78,7 @@ public class ManualTransactionService {
         applyInstrumentFields(tx, req);
         transactionRepository.save(tx);
 
-        if (INVESTMENT_TYPES.contains(account.getType())) {
-            holdingComputeService.recomputeHoldings(account);
-        } else if (account.isManual()) {
-            recomputeCashBalance(account);
-            finaryPersistenceHelper.reconstructSnapshotsFromDb(account);
-        }
+        recomputeDerivedState(account);
 
         return TransactionResponse.from(tx);
     }
@@ -110,6 +97,18 @@ public class ManualTransactionService {
 
         transactionRepository.delete(tx);
 
+        recomputeDerivedState(account);
+    }
+
+    /**
+     * Recomputes derived state after a manual transaction is added, edited, or deleted.
+     * Investment accounts always recompute holdings. For other account types, the cash
+     * balance and snapshot history are only rebuilt for manual accounts — synced accounts
+     * (bank/TR/wallet/exchange) own their balance & snapshot history via provider sync,
+     * and rebuilding from manual transactions would overwrite the balance and delete the
+     * provider-written snapshots.
+     */
+    private void recomputeDerivedState(Account account) {
         if (INVESTMENT_TYPES.contains(account.getType())) {
             holdingComputeService.recomputeHoldings(account);
         } else if (account.isManual()) {

--- a/backend/src/main/resources/db/migration/V40__fix_negative_loan_balances.sql
+++ b/backend/src/main/resources/db/migration/V40__fix_negative_loan_balances.sql
@@ -1,0 +1,12 @@
+-- V40__fix_negative_loan_balances.sql
+-- Finary API sync stored loan balances negative (fixed in code at the same
+-- commit). Repo convention: LOAN balances are stored positive and negated at
+-- aggregation. Flip corrupted rows and their snapshots.
+UPDATE account
+SET current_balance = -current_balance
+WHERE type = 'LOAN' AND current_balance < 0;
+
+UPDATE balance_snapshot bs
+SET balance = -bs.balance
+FROM account a
+WHERE bs.account_id = a.id AND a.type = 'LOAN' AND bs.balance < 0;

--- a/backend/src/main/resources/db/migration/V52__fix_negative_loan_balances.sql
+++ b/backend/src/main/resources/db/migration/V52__fix_negative_loan_balances.sql
@@ -1,4 +1,4 @@
--- V40__fix_negative_loan_balances.sql
+-- V52__fix_negative_loan_balances.sql
 -- Finary API sync stored loan balances negative (fixed in code at the same
 -- commit). Repo convention: LOAN balances are stored positive and negated at
 -- aggregation. Flip corrupted rows and their snapshots.

--- a/backend/src/test/java/com/picsou/finary/FinaryApiSyncServiceTest.java
+++ b/backend/src/test/java/com/picsou/finary/FinaryApiSyncServiceTest.java
@@ -1,4 +1,4 @@
-package com.picsou.service;
+package com.picsou.finary;
 
 import com.picsou.config.CryptoEncryption;
 import com.picsou.dto.FinaryAccountMapping;
@@ -9,8 +9,6 @@ import com.picsou.dto.FinaryMappingAction;
 import com.picsou.dto.FinaryPreviewResponse;
 import com.picsou.dto.NewAccountDetails;
 import com.picsou.exception.ResourceNotFoundException;
-import com.picsou.finary.FinaryApiSyncService;
-import com.picsou.finary.FinaryPersistenceHelper;
 import com.picsou.finary.client.FinaryApiClient;
 import com.picsou.finary.dto.FinaryAccountCurrency;
 import com.picsou.finary.dto.FinaryAccountDto;
@@ -149,8 +147,8 @@ class FinaryApiSyncServiceTest {
         assertThat(loanPreview.finaryId()).isEqualTo("loan-1");
         assertThat(loanPreview.finaryName()).isEqualTo("PRET CONSO Auto");
         assertThat(loanPreview.suggestedType()).isEqualTo(AccountType.LOAN);
-        // A loan is a liability: outstanding amount becomes a negative balance.
-        assertThat(loanPreview.currentBalance()).isEqualTo(-12345.67);
+        // Repo convention: LOAN balances are stored POSITIVE; aggregation negates.
+        assertThat(loanPreview.currentBalance()).isEqualTo(12345.67);
 
         assertThat(response.accounts())
             .anyMatch(a -> "checkings".equals(a.finaryCategory()));
@@ -186,6 +184,29 @@ class FinaryApiSyncServiceTest {
         Account saved = captor.getValue();
         assertThat(saved.getType()).isEqualTo(AccountType.LOAN);
         assertThat(saved.getExternalAccountId()).isEqualTo("finary_loans_loan-1");
-        assertThat(saved.getCurrentBalance()).isEqualByComparingTo("-12345.67");
+        assertThat(saved.getCurrentBalance()).isEqualByComparingTo("12345.67");
+    }
+
+    @Test
+    void toLoanAccountDto_storesOutstandingAmountPositive() {
+        FinaryLoanDto loan = new FinaryLoanDto(
+            "loan-1", "loan", "PRET IMMO", 12000.0, 600.0,
+            "2023-01-01", "2043-01-01", new FinaryAccountCurrency("EUR", "€"), null);
+
+        FinaryAccountDto dto = service.toLoanAccountDto(loan);
+
+        // Repo convention: LOAN balances stored positive; negated only at aggregation.
+        assertThat(dto.balance()).isEqualTo(12000.0);
+    }
+
+    @Test
+    void toLoanAccountDto_keepsNullBalance_whenOutstandingAmountMissing() {
+        FinaryLoanDto loan = new FinaryLoanDto(
+            "loan-2", "loan", "PRET SANS MONTANT", null, null,
+            null, null, new FinaryAccountCurrency("EUR", "€"), null);
+
+        FinaryAccountDto dto = service.toLoanAccountDto(loan);
+
+        assertThat(dto.balance()).isNull();
     }
 }

--- a/backend/src/test/java/com/picsou/service/AccountServiceTest.java
+++ b/backend/src/test/java/com/picsou/service/AccountServiceTest.java
@@ -6,6 +6,7 @@ import com.picsou.exception.ResourceNotFoundException;
 import com.picsou.model.Account;
 import com.picsou.model.AccountHolding;
 import com.picsou.model.AccountType;
+import com.picsou.model.Debt;
 import com.picsou.repository.AccountHoldingRepository;
 import com.picsou.repository.AccountRepository;
 import com.picsou.repository.BalanceSnapshotRepository;
@@ -19,12 +20,15 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.within;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -117,5 +121,78 @@ class AccountServiceTest {
             .isInstanceOf(ResourceNotFoundException.class);
         // The cross-member reference must never be persisted.
         verify(debtRepository, never()).save(org.mockito.ArgumentMatchers.any());
+    }
+
+    // ─── liveBalanceEur characterization ──────────────────────────────────────
+
+    private Account loanAccount() {
+        return Account.builder()
+            .id(1L)
+            .name("Mortgage")
+            .type(AccountType.LOAN)
+            .currency("EUR")
+            .currentBalance(new BigDecimal("12000"))
+            .build();
+    }
+
+    @Test
+    void liveBalanceEur_loanWithDebt_returnsPositiveRemainingBalance() {
+        Account loan = loanAccount();
+        Debt debt = Debt.builder().build();
+        when(debtRepository.findByAccountId(1L)).thenReturn(Optional.of(debt));
+        when(loanAmortizationService.computeRemainingBalance(eq(debt), any(LocalDate.class)))
+            .thenReturn(new BigDecimal("8500"));
+
+        BigDecimal result = accountService.liveBalanceEur(loan);
+
+        // computeRemainingBalance returns a POSITIVE outstanding amount and
+        // liveBalanceEur passes it through unnegated — callers negate loans themselves.
+        assertThat(result).isEqualByComparingTo("8500");
+    }
+
+    @Test
+    void liveBalanceEur_loanWithoutDebt_fallsBackToStoredBalance() {
+        Account loan = loanAccount();
+        when(debtRepository.findByAccountId(1L)).thenReturn(Optional.empty());
+        when(priceService.toEur(new BigDecimal("12000"), "EUR", null)).thenReturn(new BigDecimal("12000"));
+
+        BigDecimal result = accountService.liveBalanceEur(loan);
+
+        // No Debt row → plain toEur pass-through of the stored balance, sign untouched.
+        assertThat(result).isEqualByComparingTo("12000");
+    }
+
+    @Test
+    void liveBalanceEur_skipsHoldingsWithoutLivePrice() {
+        Account account = ownedAccount();
+        AccountHolding priced = AccountHolding.builder()
+            .ticker("AAPL").quantity(new BigDecimal("5")).build();
+        AccountHolding unpriced = AccountHolding.builder()
+            .ticker("PHYMF").quantity(new BigDecimal("10")).build();
+        when(holdingRepository.findByAccount_Id(1L)).thenReturn(List.of(priced, unpriced));
+        when(priceService.getPriceEur("AAPL")).thenReturn(new BigDecimal("200"));
+        when(priceService.getPriceEur("PHYMF")).thenReturn(null);
+
+        BigDecimal result = accountService.liveBalanceEur(account);
+
+        // CHARACTERIZATION: unpriced holdings are silently skipped (audit TEST-04).
+        assertThat(result).isEqualByComparingTo("1000"); // 5 × 200; PHYMF contributes nothing
+    }
+
+    @Test
+    void liveBalanceEur_cashAccount_convertsStoredBalance() {
+        Account cash = Account.builder()
+            .id(2L)
+            .name("USD Cash")
+            .type(AccountType.CHECKING)
+            .currency("USD")
+            .currentBalance(new BigDecimal("2500"))
+            .build();
+        when(holdingRepository.findByAccount_Id(2L)).thenReturn(List.of());
+        when(priceService.toEur(new BigDecimal("2500"), "USD", null)).thenReturn(new BigDecimal("2300"));
+
+        BigDecimal result = accountService.liveBalanceEur(cash);
+
+        assertThat(result).isEqualByComparingTo("2300");
     }
 }

--- a/backend/src/test/java/com/picsou/service/AccountServiceTest.java
+++ b/backend/src/test/java/com/picsou/service/AccountServiceTest.java
@@ -195,4 +195,37 @@ class AccountServiceTest {
 
         assertThat(result).isEqualByComparingTo("2300");
     }
+
+    // ─── signedLiveBalanceEur ─────────────────────────────────────────────────
+
+    @Test
+    void signedLiveBalanceEur_loan_returnsNegativeOutstanding() {
+        Account loan = loanAccount();
+        Debt debt = Debt.builder().build();
+        when(debtRepository.findByAccountId(1L)).thenReturn(Optional.of(debt));
+        when(loanAmortizationService.computeRemainingBalance(eq(debt), any(LocalDate.class)))
+            .thenReturn(new BigDecimal("8500"));
+
+        BigDecimal result = accountService.signedLiveBalanceEur(loan);
+
+        // LOAN accounts are stored positive; the signed helper applies the liability sign.
+        assertThat(result).isEqualByComparingTo("-8500");
+    }
+
+    @Test
+    void signedLiveBalanceEur_checking_returnsBalanceUnchanged() {
+        Account cash = Account.builder()
+            .id(2L)
+            .name("Checking")
+            .type(AccountType.CHECKING)
+            .currency("EUR")
+            .currentBalance(new BigDecimal("2500"))
+            .build();
+        when(holdingRepository.findByAccount_Id(2L)).thenReturn(List.of());
+        when(priceService.toEur(new BigDecimal("2500"), "EUR", null)).thenReturn(new BigDecimal("2500"));
+
+        BigDecimal result = accountService.signedLiveBalanceEur(cash);
+
+        assertThat(result).isEqualByComparingTo("2500");
+    }
 }

--- a/backend/src/test/java/com/picsou/service/DashboardServiceTest.java
+++ b/backend/src/test/java/com/picsou/service/DashboardServiceTest.java
@@ -17,6 +17,7 @@ import java.math.BigDecimal;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -75,6 +76,91 @@ class DashboardServiceTest {
         assertThat(response.totalNetWorth()).isEqualByComparingTo("2000");
         assertThat(response.distribution()).hasSize(1);
         assertThat(response.distribution().getFirst().balanceEur()).isEqualByComparingTo("2000");
+    }
+
+    // ─── Liabilities path characterization ────────────────────────────────────
+
+    @Test
+    void getDashboard_loan_flowsToLiabilitiesNotDistribution() {
+        stubLoanAndCashFixture();
+
+        DashboardResponse response = dashboardService.getDashboard(42L, "1Y");
+
+        // Loan balance lands in totalLiabilities, never totalAssets.
+        assertThat(response.totalLiabilities()).isEqualByComparingTo("10000");
+        // netWorth = assets 2000 − liabilities 10000.
+        assertThat(response.totalNetWorth()).isEqualByComparingTo("-8000");
+        // The loan appears only in the liabilities list, the cash account only in distribution.
+        assertThat(response.liabilities())
+            .extracting(DashboardResponse.DistributionItem::accountId)
+            .containsExactly(10L);
+        assertThat(response.distribution())
+            .extracting(DashboardResponse.DistributionItem::accountId)
+            .containsExactly(1L);
+    }
+
+    @Test
+    void getDashboard_distributionPercentages_divideByNetWorth() {
+        stubLoanAndCashFixture();
+
+        DashboardResponse response = dashboardService.getDashboard(42L, "1Y");
+
+        // CHARACTERIZATION: percentages divide by net worth (audit BE-15); plan 005 changes
+        // the divisor — update here. Net worth is -8000 here, and the compareTo > 0 guard
+        // yields 0.0 for every item when net worth ≤ 0 (with positive net worth and debt,
+        // percentages exceed 100 %).
+        assertThat(response.distribution().getFirst().percentage()).isEqualTo(0.0);
+        assertThat(response.liabilities().getFirst().percentage()).isEqualTo(0.0);
+    }
+
+    @Test
+    void getDashboard_rangeSwitch_mapsMonths() {
+        Account cashAcc = cashAccount();
+        when(accountRepository.findAllByMemberIdOrderByCreatedAtAsc(42L)).thenReturn(List.of(cashAcc));
+        when(holdingRepository.findByAccount_Id(1L)).thenReturn(List.of());
+        when(priceService.toEur(new BigDecimal("2000"), "EUR", null)).thenReturn(new BigDecimal("2000"));
+        when(historyService.buildHistory(List.of(1L), 3, 42L)).thenReturn(List.of());
+        when(goalRepository.findAllByMemberIdOrderByCreatedAtAsc(42L)).thenReturn(List.of());
+
+        dashboardService.getDashboard(42L, "3M");
+
+        // Range "3M" maps to a 3-month history window.
+        verify(historyService).buildHistory(List.of(1L), 3, 42L);
+    }
+
+    /** LOAN 10000 EUR (id 10) + CHECKING 2000 EUR (id 1), no holdings, toEur pass-through. */
+    private void stubLoanAndCashFixture() {
+        Account loanAcc = loanAccount();
+        Account cashAcc = cashAccount();
+        when(accountRepository.findAllByMemberIdOrderByCreatedAtAsc(42L)).thenReturn(List.of(loanAcc, cashAcc));
+        when(holdingRepository.findByAccount_Id(10L)).thenReturn(List.of());
+        when(holdingRepository.findByAccount_Id(1L)).thenReturn(List.of());
+        when(priceService.toEur(new BigDecimal("10000"), "EUR", null)).thenReturn(new BigDecimal("10000"));
+        when(priceService.toEur(new BigDecimal("2000"), "EUR", null)).thenReturn(new BigDecimal("2000"));
+        when(historyService.buildHistory(List.of(10L, 1L), 12, 42L)).thenReturn(List.of());
+        when(goalRepository.findAllByMemberIdOrderByCreatedAtAsc(42L)).thenReturn(List.of());
+    }
+
+    private Account loanAccount() {
+        return Account.builder()
+            .id(10L)
+            .name("Mortgage")
+            .type(AccountType.LOAN)
+            .currency("EUR")
+            .currentBalance(new BigDecimal("10000"))
+            .color("#ef4444")
+            .build();
+    }
+
+    private Account cashAccount() {
+        return Account.builder()
+            .id(1L)
+            .name("Checking")
+            .type(AccountType.CHECKING)
+            .currency("EUR")
+            .currentBalance(new BigDecimal("2000"))
+            .color("#3b82f6")
+            .build();
     }
 
     private Account holdingAccount() {

--- a/backend/src/test/java/com/picsou/service/DashboardServiceTest.java
+++ b/backend/src/test/java/com/picsou/service/DashboardServiceTest.java
@@ -100,17 +100,49 @@ class DashboardServiceTest {
     }
 
     @Test
-    void getDashboard_distributionPercentages_divideByNetWorth() {
+    void getDashboard_distributionPercentages_divideByOwnSideTotals() {
         stubLoanAndCashFixture();
 
         DashboardResponse response = dashboardService.getDashboard(42L, "1Y");
 
-        // CHARACTERIZATION: percentages divide by net worth (audit BE-15); plan 005 changes
-        // the divisor — update here. Net worth is -8000 here, and the compareTo > 0 guard
-        // yields 0.0 for every item when net worth ≤ 0 (with positive net worth and debt,
-        // percentages exceed 100 %).
-        assertThat(response.distribution().getFirst().percentage()).isEqualTo(0.0);
-        assertThat(response.liabilities().getFirst().percentage()).isEqualTo(0.0);
+        // CHARACTERIZATION (updated by plan 005): assets divide by totalAssets and
+        // liabilities by totalLiabilities, so percentages stay meaningful even when
+        // net worth is negative (-8000 here) and can never exceed 100 %.
+        assertThat(response.distribution().getFirst().percentage()).isEqualTo(100.0); // 2000 / 2000
+        assertThat(response.liabilities().getFirst().percentage()).isEqualTo(100.0);  // 10000 / 10000
+    }
+
+    @Test
+    void getDashboard_assetPercentages_shareOfTotalAssets_withDebtPresent() {
+        Account cashAcc = cashAccount();               // id 1, CHECKING 2000
+        Account savingsAcc = Account.builder()
+            .id(2L)
+            .name("Livret")
+            .type(AccountType.SAVINGS)
+            .currency("EUR")
+            .currentBalance(new BigDecimal("6000"))
+            .color("#22c55e")
+            .build();
+        Account loanAcc = loanAccount();               // id 10, LOAN 10000
+        when(accountRepository.findAllByMemberIdOrderByCreatedAtAsc(42L))
+            .thenReturn(List.of(cashAcc, savingsAcc, loanAcc));
+        when(holdingRepository.findByAccount_Id(1L)).thenReturn(List.of());
+        when(holdingRepository.findByAccount_Id(2L)).thenReturn(List.of());
+        when(holdingRepository.findByAccount_Id(10L)).thenReturn(List.of());
+        when(priceService.toEur(new BigDecimal("2000"), "EUR", null)).thenReturn(new BigDecimal("2000"));
+        when(priceService.toEur(new BigDecimal("6000"), "EUR", null)).thenReturn(new BigDecimal("6000"));
+        when(priceService.toEur(new BigDecimal("10000"), "EUR", null)).thenReturn(new BigDecimal("10000"));
+        when(historyService.buildHistory(List.of(1L, 2L, 10L), 12, 42L)).thenReturn(List.of());
+        when(goalRepository.findAllByMemberIdOrderByCreatedAtAsc(42L)).thenReturn(List.of());
+
+        DashboardResponse response = dashboardService.getDashboard(42L, "1Y");
+
+        // Assets split 2000 / 6000 of totalAssets 8000 → 25 % / 75 %, regardless of the
+        // 10000 debt; the loan is 100 % of totalLiabilities.
+        assertThat(response.distribution())
+            .extracting(DashboardResponse.DistributionItem::percentage)
+            .containsExactly(25.0, 75.0);
+        assertThat(response.liabilities().getFirst().percentage()).isEqualTo(100.0);
     }
 
     @Test

--- a/backend/src/test/java/com/picsou/service/DashboardServiceTest.java
+++ b/backend/src/test/java/com/picsou/service/DashboardServiceTest.java
@@ -29,6 +29,7 @@ class DashboardServiceTest {
     @Mock PriceService priceService;
     @Mock AccountHoldingRepository holdingRepository;
     @Mock HistoryService historyService;
+    @Mock AccountService accountService;
 
     @InjectMocks DashboardService dashboardService;
 
@@ -131,7 +132,7 @@ class DashboardServiceTest {
         when(holdingRepository.findByAccount_Id(10L)).thenReturn(List.of());
         when(priceService.toEur(new BigDecimal("2000"), "EUR", null)).thenReturn(new BigDecimal("2000"));
         when(priceService.toEur(new BigDecimal("6000"), "EUR", null)).thenReturn(new BigDecimal("6000"));
-        when(priceService.toEur(new BigDecimal("10000"), "EUR", null)).thenReturn(new BigDecimal("10000"));
+        when(accountService.liveBalanceEur(loanAcc)).thenReturn(new BigDecimal("10000"));
         when(historyService.buildHistory(List.of(1L, 2L, 10L), 12, 42L)).thenReturn(List.of());
         when(goalRepository.findAllByMemberIdOrderByCreatedAtAsc(42L)).thenReturn(List.of());
 
@@ -143,6 +144,28 @@ class DashboardServiceTest {
             .extracting(DashboardResponse.DistributionItem::percentage)
             .containsExactly(25.0, 75.0);
         assertThat(response.liabilities().getFirst().percentage()).isEqualTo(100.0);
+    }
+
+    @Test
+    void getDashboard_loanValuation_usesAmortizedLiveBalance_notStoredBalance() {
+        Account loanAcc = loanAccount();               // stored balance 10000
+        Account cashAcc = cashAccount();
+        when(accountRepository.findAllByMemberIdOrderByCreatedAtAsc(42L)).thenReturn(List.of(loanAcc, cashAcc));
+        when(holdingRepository.findByAccount_Id(10L)).thenReturn(List.of());
+        when(holdingRepository.findByAccount_Id(1L)).thenReturn(List.of());
+        // Amortization has progressed: remaining capital 9500 < stored 10000.
+        when(accountService.liveBalanceEur(loanAcc)).thenReturn(new BigDecimal("9500"));
+        when(priceService.toEur(new BigDecimal("2000"), "EUR", null)).thenReturn(new BigDecimal("2000"));
+        when(historyService.buildHistory(List.of(10L, 1L), 12, 42L)).thenReturn(List.of());
+        when(goalRepository.findAllByMemberIdOrderByCreatedAtAsc(42L)).thenReturn(List.of());
+
+        DashboardResponse response = dashboardService.getDashboard(42L, "1Y");
+
+        // Hero totals and the liability row both use the amortized value, matching
+        // what HistoryService's live point reports for the same loan.
+        assertThat(response.totalLiabilities()).isEqualByComparingTo("9500");
+        assertThat(response.totalNetWorth()).isEqualByComparingTo("-7500");
+        assertThat(response.liabilities().getFirst().balanceEur()).isEqualByComparingTo("9500");
     }
 
     @Test
@@ -167,7 +190,9 @@ class DashboardServiceTest {
         when(accountRepository.findAllByMemberIdOrderByCreatedAtAsc(42L)).thenReturn(List.of(loanAcc, cashAcc));
         when(holdingRepository.findByAccount_Id(10L)).thenReturn(List.of());
         when(holdingRepository.findByAccount_Id(1L)).thenReturn(List.of());
-        when(priceService.toEur(new BigDecimal("10000"), "EUR", null)).thenReturn(new BigDecimal("10000"));
+        // Loans are valued through AccountService.liveBalanceEur (amortized when a Debt
+        // row exists), not through the raw stored-balance conversion.
+        when(accountService.liveBalanceEur(loanAcc)).thenReturn(new BigDecimal("10000"));
         when(priceService.toEur(new BigDecimal("2000"), "EUR", null)).thenReturn(new BigDecimal("2000"));
         when(historyService.buildHistory(List.of(10L, 1L), 12, 42L)).thenReturn(List.of());
         when(goalRepository.findAllByMemberIdOrderByCreatedAtAsc(42L)).thenReturn(List.of());

--- a/backend/src/test/java/com/picsou/service/FamilyViewServiceTest.java
+++ b/backend/src/test/java/com/picsou/service/FamilyViewServiceTest.java
@@ -69,7 +69,7 @@ class FamilyViewServiceTest {
         when(sharedResourceRepository.findAllByOwnerMemberIdAndResourceType(2L, "ACCOUNT"))
             .thenReturn(List.of(resource));
         when(accountRepository.findByIdInAndMemberId(List.of(10L), 2L)).thenReturn(List.of(account));
-        when(accountService.liveBalanceEur(account)).thenReturn(new BigDecimal("123"));
+        when(accountService.signedLiveBalanceEur(account)).thenReturn(new BigDecimal("123"));
 
         FamilyDashboardResponse response = familyViewService.getFamilyDashboard(1L);
 
@@ -112,5 +112,92 @@ class FamilyViewServiceTest {
         assertThat(response.sharedGoals().getFirst().id()).isEqualTo(20L);
         verify(goalRepository).findByIdInAndMemberId(List.of(20L), 2L);
         verify(goalRepository, never()).findAllById(any());
+    }
+
+    // ─── Loan sign convention: shared loans reduce family net worth ──────────
+
+    @Test
+    void getFamilyDashboard_sharedLoan_countsNegativelyInNetWorth() {
+        FamilyMember viewer = FamilyMember.builder().id(1L).displayName("Viewer").build();
+        FamilyMember owner = FamilyMember.builder().id(2L).displayName("Owner").build();
+        Account checking = Account.builder()
+            .id(10L)
+            .name("Checking")
+            .type(AccountType.CHECKING)
+            .currency("EUR")
+            .currentBalance(new BigDecimal("2000"))
+            .build();
+        Account loan = Account.builder()
+            .id(11L)
+            .name("Mortgage")
+            .type(AccountType.LOAN)
+            .currency("EUR")
+            .currentBalance(new BigDecimal("10000"))
+            .build();
+
+        when(memberRepository.findAllByOrderByCreatedAtAsc()).thenReturn(List.of(viewer, owner));
+        when(sharingSettingsRepository.findByMemberIdAndResourceType(2L, "ACCOUNT"))
+            .thenReturn(Optional.of(new SharingSettings(null, owner, "ACCOUNT", SharingLevel.ALL)));
+        when(sharingSettingsRepository.findByMemberIdAndResourceType(2L, "GOAL"))
+            .thenReturn(Optional.empty());
+        when(accountRepository.findAllByMemberIdOrderByCreatedAtAsc(2L))
+            .thenReturn(List.of(checking, loan));
+        when(accountService.signedLiveBalanceEur(checking)).thenReturn(new BigDecimal("2000"));
+        when(accountService.signedLiveBalanceEur(loan)).thenReturn(new BigDecimal("-10000"));
+
+        FamilyDashboardResponse response = familyViewService.getFamilyDashboard(1L);
+
+        assertThat(response.sharedAccounts()).hasSize(2);
+        FamilyDashboardResponse.SharedAccountInfo loanInfo = response.sharedAccounts().stream()
+            .filter(a -> a.id().equals(11L))
+            .findFirst()
+            .orElseThrow();
+        // The shared loan row shows the debt as negative...
+        assertThat(loanInfo.balanceEur()).isEqualByComparingTo("-10000");
+        // ...so the family net worth is assets minus debts: 2000 − 10000.
+        assertThat(response.totalSharedNetWorth()).isEqualByComparingTo("-8000");
+    }
+
+    @Test
+    void getFamilyDashboard_sharedGoalWithLoan_progressCountsLoanNegatively() {
+        FamilyMember viewer = FamilyMember.builder().id(1L).displayName("Viewer").build();
+        FamilyMember owner = FamilyMember.builder().id(2L).displayName("Owner").build();
+        Account checking = Account.builder()
+            .id(10L)
+            .name("Checking")
+            .type(AccountType.CHECKING)
+            .currency("EUR")
+            .currentBalance(new BigDecimal("2000"))
+            .build();
+        Account loan = Account.builder()
+            .id(11L)
+            .name("Mortgage")
+            .type(AccountType.LOAN)
+            .currency("EUR")
+            .currentBalance(new BigDecimal("10000"))
+            .build();
+        Goal goal = Goal.builder()
+            .id(20L)
+            .name("House")
+            .targetAmount(new BigDecimal("50000"))
+            .deadline(LocalDate.now().plusMonths(6))
+            .accounts(List.of(checking, loan))
+            .member(owner)
+            .build();
+
+        when(memberRepository.findAllByOrderByCreatedAtAsc()).thenReturn(List.of(viewer, owner));
+        when(sharingSettingsRepository.findByMemberIdAndResourceType(2L, "ACCOUNT"))
+            .thenReturn(Optional.empty());
+        when(sharingSettingsRepository.findByMemberIdAndResourceType(2L, "GOAL"))
+            .thenReturn(Optional.of(new SharingSettings(null, owner, "GOAL", SharingLevel.ALL)));
+        when(goalRepository.findAllByMemberIdOrderByCreatedAtAsc(2L)).thenReturn(List.of(goal));
+        when(accountService.signedLiveBalanceEur(checking)).thenReturn(new BigDecimal("2000"));
+        when(accountService.signedLiveBalanceEur(loan)).thenReturn(new BigDecimal("-10000"));
+
+        FamilyDashboardResponse response = familyViewService.getFamilyDashboard(1L);
+
+        assertThat(response.sharedGoals()).hasSize(1);
+        // Goal progress nets the linked loan against the linked asset: 2000 − 10000.
+        assertThat(response.sharedGoals().getFirst().currentTotal()).isEqualByComparingTo("-8000");
     }
 }

--- a/backend/src/test/java/com/picsou/service/GoalServiceTest.java
+++ b/backend/src/test/java/com/picsou/service/GoalServiceTest.java
@@ -75,7 +75,7 @@ class GoalServiceTest {
                 null, true, "#6366f1", null, null, null, null, null
             )
         );
-        when(accountService.liveBalanceEur(account)).thenReturn(new BigDecimal("5000"));
+        when(accountService.signedLiveBalanceEur(account)).thenReturn(new BigDecimal("5000"));
         when(snapshotRepository.findRecentByAccountId(
             org.mockito.ArgumentMatchers.eq(1L),
             org.mockito.ArgumentMatchers.any()
@@ -96,6 +96,66 @@ class GoalServiceTest {
         assertThat(progress.monthlyNeeded()).isEqualByComparingTo(
             new BigDecimal("15000").divide(BigDecimal.valueOf(monthsLeft), 2, RoundingMode.HALF_UP));
         assertThat(progress.percentComplete()).isEqualByComparingTo("25.0000");
+    }
+
+    @Test
+    void progressCalculation_linkedLoan_countsNegatively() {
+        Account asset = Account.builder()
+            .id(1L)
+            .name("LEP")
+            .type(AccountType.LEP)
+            .currency("EUR")
+            .currentBalance(new BigDecimal("5000"))
+            .color("#6366f1")
+            .build();
+        Account loan = Account.builder()
+            .id(2L)
+            .name("Prêt")
+            .type(AccountType.LOAN)
+            .currency("EUR")
+            .currentBalance(new BigDecimal("2000"))
+            .color("#ef4444")
+            .build();
+
+        Goal goal = Goal.builder()
+            .id(1L)
+            .name("Apport net")
+            .targetAmount(new BigDecimal("20000"))
+            .deadline(LocalDate.now().plusMonths(6))
+            .accounts(List.of(asset, loan))
+            .build();
+
+        when(accountService.toResponse(asset)).thenReturn(
+            new com.picsou.dto.AccountResponse(
+                1L, "LEP", AccountType.LEP, null, "EUR",
+                new BigDecimal("5000"), new BigDecimal("5000"),
+                null, true, "#6366f1", null, null, null, null, null
+            )
+        );
+        when(accountService.toResponse(loan)).thenReturn(
+            new com.picsou.dto.AccountResponse(
+                2L, "Prêt", AccountType.LOAN, null, "EUR",
+                new BigDecimal("2000"), new BigDecimal("2000"),
+                null, true, "#ef4444", null, null, null, null, null
+            )
+        );
+        when(accountService.signedLiveBalanceEur(asset)).thenReturn(new BigDecimal("5000"));
+        // LOAN: the signed helper returns the outstanding debt as a NEGATIVE value.
+        when(accountService.signedLiveBalanceEur(loan)).thenReturn(new BigDecimal("-2000"));
+        when(snapshotRepository.findRecentByAccountId(
+            org.mockito.ArgumentMatchers.any(),
+            org.mockito.ArgumentMatchers.any()
+        )).thenReturn(List.of());
+
+        GoalProgressResponse progress = goalService.toProgressResponse(goal);
+
+        // 5000 − 2000: the linked loan reduces goal progress.
+        assertThat(progress.currentTotal()).isEqualByComparingTo("3000");
+        long monthsLeft = progress.monthsLeft();
+        assertThat(monthsLeft).isIn(5L, 6L);
+        // monthlyNeeded derives from the netted total: (20000 − 3000) / monthsLeft.
+        assertThat(progress.monthlyNeeded()).isEqualByComparingTo(
+            new BigDecimal("17000").divide(BigDecimal.valueOf(monthsLeft), 2, RoundingMode.HALF_UP));
     }
 
     // ─── IDOR regression (GHSA security audit 2026-06-27) ──────────────────────
@@ -242,7 +302,7 @@ class GoalServiceTest {
                 null, true, "#000", null, null, null, null, null
             )
         );
-        when(accountService.liveBalanceEur(account)).thenReturn(BigDecimal.ZERO);
+        when(accountService.signedLiveBalanceEur(account)).thenReturn(BigDecimal.ZERO);
         when(snapshotRepository.findRecentByAccountId(
             org.mockito.ArgumentMatchers.eq(1L),
             org.mockito.ArgumentMatchers.any()
@@ -301,7 +361,7 @@ class GoalServiceTest {
                 null, true, "#000", null, null, null, null, null
             )
         );
-        when(accountService.liveBalanceEur(account)).thenReturn(BigDecimal.ZERO);
+        when(accountService.signedLiveBalanceEur(account)).thenReturn(BigDecimal.ZERO);
         when(snapshotRepository.findRecentByAccountId(
             org.mockito.ArgumentMatchers.eq(1L),
             org.mockito.ArgumentMatchers.any()
@@ -347,7 +407,7 @@ class GoalServiceTest {
                 null, true, "#000", null, null, null, null, null
             )
         );
-        when(accountService.liveBalanceEur(account)).thenReturn(BigDecimal.ZERO);
+        when(accountService.signedLiveBalanceEur(account)).thenReturn(BigDecimal.ZERO);
         when(snapshotRepository.findRecentByAccountId(
             org.mockito.ArgumentMatchers.eq(1L),
             org.mockito.ArgumentMatchers.any()

--- a/backend/src/test/java/com/picsou/service/GoalServiceTest.java
+++ b/backend/src/test/java/com/picsou/service/GoalServiceTest.java
@@ -337,6 +337,48 @@ class GoalServiceTest {
     }
 
     @Test
+    void avgMonthlyContribution_loanPaydown_countsAsPositiveProgress() {
+        // Outstanding debt shrinks 12000 → 9000 over 3 months: the raw snapshot delta
+        // is −1000/month, but paying down a linked loan is positive progress.
+        Account loan = Account.builder()
+            .id(1L).name("Mortgage").type(AccountType.LOAN)
+            .currency("EUR").currentBalance(new BigDecimal("9000"))
+            .color("#ef4444").build();
+
+        Goal goal = Goal.builder()
+            .id(1L).name("Rembourser").targetAmount(new BigDecimal("12000"))
+            .deadline(LocalDate.now().plusMonths(12))
+            .accounts(List.of(loan))
+            .build();
+
+        when(accountService.toResponse(loan)).thenReturn(
+            new com.picsou.dto.AccountResponse(
+                1L, "Mortgage", AccountType.LOAN, null, "EUR",
+                new BigDecimal("9000"), new BigDecimal("9000"),
+                null, true, "#ef4444", null, null, null, null, null
+            )
+        );
+        when(accountService.signedLiveBalanceEur(loan)).thenReturn(new BigDecimal("-9000"));
+        LocalDate threeMonthsAgo = LocalDate.now().minusMonths(3);
+        when(snapshotRepository.findRecentByAccountId(
+            org.mockito.ArgumentMatchers.eq(1L),
+            org.mockito.ArgumentMatchers.any()
+        )).thenReturn(List.of(
+            com.picsou.model.BalanceSnapshot.builder()
+                .balance(new BigDecimal("12000")).date(threeMonthsAgo).build(),
+            com.picsou.model.BalanceSnapshot.builder()
+                .balance(new BigDecimal("9000")).date(LocalDate.now()).build()
+        ));
+        lenient().when(overrideRepository.findByGoalId(1L)).thenReturn(List.of());
+        lenient().when(manualContributionRepository.findByGoalId(1L)).thenReturn(List.of());
+
+        GoalProgressResponse progress = goalService.toProgressResponse(goal);
+
+        // (12000 − 9000) / 3 months, sign flipped for the LOAN account.
+        assertThat(progress.avgMonthlyContribution()).isEqualByComparingTo("1000");
+    }
+
+    @Test
     void isOnTrack_true_whenManualContributionCoversShortfall() {
         // Same setup as the "behind" test but user declares 4000€ manual contribution
         // for each of the 3 past months → effective matches objective → on track.

--- a/backend/src/test/java/com/picsou/service/HistoryServiceTest.java
+++ b/backend/src/test/java/com/picsou/service/HistoryServiceTest.java
@@ -149,6 +149,11 @@ class HistoryServiceTest {
         // Per-account split: loan invested is ZERO regardless of its snapshot column.
         assertThat(point.accounts().get(1L).invested()).isEqualByComparingTo("0");
         assertThat(point.accounts().get(2L).invested()).isEqualByComparingTo("2000");
+        // Debt-neutral pnl (plan 005): the loan contributes 0 to pnl — outstanding
+        // debt is no longer read as an investment loss.
+        assertThat(point.pnl()).isEqualByComparingTo("0");
+        assertThat(point.accounts().get(1L).pnl()).isEqualByComparingTo("0");
+        assertThat(point.accounts().get(2L).pnl()).isEqualByComparingTo("0");
     }
 
     @Test
@@ -263,12 +268,12 @@ class HistoryServiceTest {
 
         PnlResponse result = historyService.buildPnl(List.of(1L, 2L), MEMBER_ID);
 
-        // CHARACTERIZATION: pnl currently absorbs the full loan balance (issue #18 root cause).
-        // Plan 005 will change pnl to be debt-neutral — update this assertion there.
-        assertThat(result.total()).isEqualByComparingTo("-4900");   // 5100 − 10000
+        // CHARACTERIZATION (updated by plan 005): pnl is debt-neutral — loans contribute 0,
+        // so pnl reflects only non-loan performance while total stays net worth.
+        assertThat(result.total()).isEqualByComparingTo("-4900");   // 5100 − 10000 (net worth, loan negated)
         assertThat(result.invested()).isEqualByComparingTo("4800"); // loan excluded from invested
-        assertThat(result.pnl()).isEqualByComparingTo("-9700");     // −4900 − 4800
-        assertThat(result.pnlPercent()).isEqualByComparingTo("-202.1"); // −9700 × 100 / 4800, HALF_UP scale 1
+        assertThat(result.pnl()).isEqualByComparingTo("300");       // 5100 − 4800, loan contributes 0
+        assertThat(result.pnlPercent()).isEqualByComparingTo("6.3"); // 300 × 100 / 4800, HALF_UP scale 1
     }
 
     @Test
@@ -283,7 +288,7 @@ class HistoryServiceTest {
 
         // A loan-only selection sums invested to 0 → the compareTo > 0 guard skips the division.
         assertThat(result.invested()).isEqualByComparingTo("0");
-        assertThat(result.pnl()).isEqualByComparingTo("-10000");
+        assertThat(result.pnl()).isEqualByComparingTo("0"); // Debt-neutral pnl (plan 005): a loan-only selection has zero investment pnl.
         assertThat(result.pnlPercent()).isNull();
     }
 
@@ -332,13 +337,48 @@ class HistoryServiceTest {
         when(priceSnapshotRepository.findLatestByTickerBeforeOrOnDate("AAPL", fromDate))
             .thenReturn(Optional.of(PriceSnapshot.builder()
                 .ticker("AAPL").date(fromDate).priceEur(new BigDecimal("90")).build()));
+        when(priceService.getPriceEur("AAPL")).thenReturn(new BigDecimal("510"));
 
         PnlResponse result = historyService.buildPnl(List.of(1L, 2L), MEMBER_ID, fromDate);
 
-        // CHARACTERIZATION: baseline is holdings-only while liveTotal includes cash/loans (audit BE-04).
-        // valueAtFrom = 10 × 90 = 900 (holding only); liveTotal = 5100 + 2000 = 7100 (cash included).
+        // CHARACTERIZATION (updated by plan 005): both sides of the range use the SAME
+        // matched-holdings universe — cash/loans no longer inflate the live side (audit BE-04).
+        // valueAtFrom = 10 × 90 = 900; liveMatchedValue = 10 × 510 = 5100 (cash 2000 excluded).
         assertThat(result.valueAtFrom()).isEqualByComparingTo("900");
-        assertThat(result.rangePnl()).isEqualByComparingTo("6200"); // 7100 − 900
+        assertThat(result.rangePnl()).isEqualByComparingTo("4200"); // 5100 − 900
+    }
+
+    @Test
+    void buildPnl_rangePnl_ignoresHoldingsWithoutSnapshotOnBothSides() {
+        LocalDate fromDate = LocalDate.now().minusDays(30);
+        Account brokerageAcc = brokerage(1L, "CT");
+        AccountHolding matched = AccountHolding.builder()
+            .account(brokerageAcc).ticker("AAPL")
+            .quantity(new BigDecimal("10")).averageBuyIn(new BigDecimal("100")).build();
+        AccountHolding unmatched = AccountHolding.builder()
+            .account(brokerageAcc).ticker("MSFT")
+            .quantity(new BigDecimal("4")).averageBuyIn(new BigDecimal("200")).build();
+
+        when(accountRepository.findAllById(List.of(1L))).thenReturn(List.of(brokerageAcc));
+        when(holdingRepository.findByAccount_Id(1L)).thenReturn(List.of(matched, unmatched));
+        when(accountService.liveBalanceEur(brokerageAcc)).thenReturn(new BigDecimal("6300"));
+        when(accountService.calculateInvestedAmount(brokerageAcc)).thenReturn(new BigDecimal("1800"));
+        when(priceSnapshotRepository.findLatestByTickerBeforeOrOnDate("AAPL", fromDate))
+            .thenReturn(Optional.of(PriceSnapshot.builder()
+                .ticker("AAPL").date(fromDate).priceEur(new BigDecimal("90")).build()));
+        // MSFT has NO snapshot at fromDate → excluded from BOTH sides of the range.
+        when(priceSnapshotRepository.findLatestByTickerBeforeOrOnDate("MSFT", fromDate))
+            .thenReturn(Optional.empty());
+        when(priceService.getPriceEur("AAPL")).thenReturn(new BigDecimal("510"));
+
+        PnlResponse result = historyService.buildPnl(List.of(1L), MEMBER_ID, fromDate);
+
+        // Only AAPL is priced on both sides: valueAtFrom = 10 × 90 = 900,
+        // liveMatchedValue = 10 × 510 = 5100 → rangePnl = 4200. MSFT's live value
+        // never enters the comparison, so an unmatched holding cannot skew the range.
+        assertThat(result.valueAtFrom()).isEqualByComparingTo("900");
+        assertThat(result.rangePnl()).isEqualByComparingTo("4200");
+        assertThat(result.rangePnlPercent()).isEqualByComparingTo("466.7"); // 4200 × 100 / 900
     }
 
     @Test

--- a/backend/src/test/java/com/picsou/service/HistoryServiceTest.java
+++ b/backend/src/test/java/com/picsou/service/HistoryServiceTest.java
@@ -1,10 +1,14 @@
 package com.picsou.service;
 
+import com.picsou.dto.DashboardResponse.NetWorthIntradayPoint;
 import com.picsou.dto.DashboardResponse.NetWorthPoint;
+import com.picsou.dto.PnlResponse;
 import com.picsou.exception.ResourceNotFoundException;
 import com.picsou.model.Account;
+import com.picsou.model.AccountHolding;
 import com.picsou.model.AccountType;
 import com.picsou.model.FamilyMember;
+import com.picsou.model.PriceSnapshot;
 import com.picsou.repository.AccountHoldingRepository;
 import com.picsou.repository.AccountRepository;
 import com.picsou.repository.BalanceSnapshotRepository;
@@ -18,6 +22,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -228,5 +233,158 @@ class HistoryServiceTest {
         // not a signal to return every requested account unscoped.
         assertThatThrownBy(() -> historyService.buildHistory(List.of(1L), 1, false, null))
             .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    // ─── buildPnl characterization ────────────────────────────────────────────
+
+    private static Account loan(long id, String balance) {
+        return Account.builder()
+            .id(id).name("Loan").type(AccountType.LOAN).currency("EUR")
+            .currentBalance(new BigDecimal(balance)).color("#ef4444").member(MEMBER).build();
+    }
+
+    private static Account checking(long id, String balance) {
+        return Account.builder()
+            .id(id).name("Checking").type(AccountType.CHECKING).currency("EUR")
+            .currentBalance(new BigDecimal(balance)).color("#3b82f6").member(MEMBER).build();
+    }
+
+    @Test
+    void buildPnl_loanSubtractsFromTotal_excludedFromInvested() {
+        Account loanAcc = loan(1L, "10000");
+        Account brokerageAcc = brokerage(2L, "CT");
+
+        when(accountRepository.findAllById(List.of(1L, 2L))).thenReturn(List.of(loanAcc, brokerageAcc));
+        when(holdingRepository.findByAccount_Id(1L)).thenReturn(List.of());
+        when(holdingRepository.findByAccount_Id(2L)).thenReturn(List.of());
+        when(accountService.liveBalanceEur(loanAcc)).thenReturn(new BigDecimal("10000"));
+        when(accountService.liveBalanceEur(brokerageAcc)).thenReturn(new BigDecimal("5100"));
+        when(accountService.calculateInvestedAmount(brokerageAcc)).thenReturn(new BigDecimal("4800"));
+
+        PnlResponse result = historyService.buildPnl(List.of(1L, 2L), MEMBER_ID);
+
+        // CHARACTERIZATION: pnl currently absorbs the full loan balance (issue #18 root cause).
+        // Plan 005 will change pnl to be debt-neutral — update this assertion there.
+        assertThat(result.total()).isEqualByComparingTo("-4900");   // 5100 − 10000
+        assertThat(result.invested()).isEqualByComparingTo("4800"); // loan excluded from invested
+        assertThat(result.pnl()).isEqualByComparingTo("-9700");     // −4900 − 4800
+        assertThat(result.pnlPercent()).isEqualByComparingTo("-202.1"); // −9700 × 100 / 4800, HALF_UP scale 1
+    }
+
+    @Test
+    void buildPnl_zeroInvested_returnsNullPercent() {
+        Account loanAcc = loan(1L, "10000");
+
+        when(accountRepository.findAllById(List.of(1L))).thenReturn(List.of(loanAcc));
+        when(holdingRepository.findByAccount_Id(1L)).thenReturn(List.of());
+        when(accountService.liveBalanceEur(loanAcc)).thenReturn(new BigDecimal("10000"));
+
+        PnlResponse result = historyService.buildPnl(List.of(1L), MEMBER_ID);
+
+        // A loan-only selection sums invested to 0 → the compareTo > 0 guard skips the division.
+        assertThat(result.invested()).isEqualByComparingTo("0");
+        assertThat(result.pnl()).isEqualByComparingTo("-10000");
+        assertThat(result.pnlPercent()).isNull();
+    }
+
+    @Test
+    void buildPnl_noHistoricalPrices_fallsBackToLivePnl() {
+        LocalDate fromDate = LocalDate.now().minusDays(30);
+        Account brokerageAcc = brokerage(1L, "CT");
+        AccountHolding holding = AccountHolding.builder()
+            .account(brokerageAcc).ticker("AAPL")
+            .quantity(new BigDecimal("10")).averageBuyIn(new BigDecimal("100")).build();
+
+        when(accountRepository.findAllById(List.of(1L))).thenReturn(List.of(brokerageAcc));
+        when(holdingRepository.findByAccount_Id(1L)).thenReturn(List.of(holding));
+        when(accountService.liveBalanceEur(brokerageAcc)).thenReturn(new BigDecimal("5100"));
+        when(accountService.calculateInvestedAmount(brokerageAcc)).thenReturn(new BigDecimal("4800"));
+        when(priceSnapshotRepository.findLatestByTickerBeforeOrOnDate("AAPL", fromDate))
+            .thenReturn(Optional.empty());
+
+        PnlResponse result = historyService.buildPnl(List.of(1L), MEMBER_ID, fromDate);
+
+        // Zero matched prices → the live-only response shape: range fields stay null.
+        assertThat(result.total()).isEqualByComparingTo("5100");
+        assertThat(result.invested()).isEqualByComparingTo("4800");
+        assertThat(result.pnl()).isEqualByComparingTo("300");
+        assertThat(result.valueAtFrom()).isNull();
+        assertThat(result.rangePnl()).isNull();
+        assertThat(result.rangePnlPercent()).isNull();
+    }
+
+    @Test
+    void buildPnl_rangePnl_computedAgainstHoldingsOnlyBaseline() {
+        LocalDate fromDate = LocalDate.now().minusDays(30);
+        Account brokerageAcc = brokerage(1L, "CT");
+        Account cashAcc = checking(2L, "2000");
+        AccountHolding holding = AccountHolding.builder()
+            .account(brokerageAcc).ticker("AAPL")
+            .quantity(new BigDecimal("10")).averageBuyIn(new BigDecimal("100")).build();
+
+        when(accountRepository.findAllById(List.of(1L, 2L))).thenReturn(List.of(brokerageAcc, cashAcc));
+        when(holdingRepository.findByAccount_Id(1L)).thenReturn(List.of(holding));
+        when(holdingRepository.findByAccount_Id(2L)).thenReturn(List.of());
+        when(accountService.liveBalanceEur(brokerageAcc)).thenReturn(new BigDecimal("5100"));
+        when(accountService.liveBalanceEur(cashAcc)).thenReturn(new BigDecimal("2000"));
+        when(accountService.calculateInvestedAmount(brokerageAcc)).thenReturn(new BigDecimal("4800"));
+        when(accountService.calculateInvestedAmount(cashAcc)).thenReturn(new BigDecimal("2000"));
+        when(priceSnapshotRepository.findLatestByTickerBeforeOrOnDate("AAPL", fromDate))
+            .thenReturn(Optional.of(PriceSnapshot.builder()
+                .ticker("AAPL").date(fromDate).priceEur(new BigDecimal("90")).build()));
+
+        PnlResponse result = historyService.buildPnl(List.of(1L, 2L), MEMBER_ID, fromDate);
+
+        // CHARACTERIZATION: baseline is holdings-only while liveTotal includes cash/loans (audit BE-04).
+        // valueAtFrom = 10 × 90 = 900 (holding only); liveTotal = 5100 + 2000 = 7100 (cash included).
+        assertThat(result.valueAtFrom()).isEqualByComparingTo("900");
+        assertThat(result.rangePnl()).isEqualByComparingTo("6200"); // 7100 − 900
+    }
+
+    @Test
+    void buildPnl_emptyAccountIds_returnsZeros() {
+        when(accountRepository.findAllById(List.of())).thenReturn(List.of());
+
+        PnlResponse result = historyService.buildPnl(List.of(), MEMBER_ID);
+
+        assertThat(result.total()).isEqualByComparingTo("0");
+        assertThat(result.invested()).isEqualByComparingTo("0");
+        assertThat(result.pnl()).isEqualByComparingTo("0");
+        assertThat(result.pnlPercent()).isNull();
+    }
+
+    @Test
+    void buildPnl_foreignAccount_throws() {
+        Account othersAccount = brokerage(1L, "CT"); // belongs to MEMBER (id 99)
+        when(accountRepository.findAllById(List.of(1L))).thenReturn(List.of(othersAccount));
+
+        // A different member must not be able to read account 1's PnL.
+        assertThatThrownBy(() -> historyService.buildPnl(List.of(1L), 7L))
+            .isInstanceOf(ResourceNotFoundException.class);
+    }
+
+    // ─── buildIntradayHistory characterization ────────────────────────────────
+
+    @Test
+    void buildIntradayHistory_loanNegated_cashConstant() {
+        Account loanAcc = loan(1L, "10000");
+        Account cashAcc = checking(2L, "2000");
+
+        when(accountRepository.findAllById(List.of(1L, 2L))).thenReturn(List.of(loanAcc, cashAcc));
+        when(holdingRepository.findByAccount_Id(1L)).thenReturn(List.of());
+        when(holdingRepository.findByAccount_Id(2L)).thenReturn(List.of());
+        when(snapshotRepository.findByAccountIdAndDate(eq(1L), any(LocalDate.class))).thenReturn(Optional.empty());
+        when(snapshotRepository.findByAccountIdAndDate(eq(2L), any(LocalDate.class))).thenReturn(Optional.empty());
+        when(accountService.liveBalanceEur(loanAcc)).thenReturn(new BigDecimal("10000"));
+        when(accountService.liveBalanceEur(cashAcc)).thenReturn(new BigDecimal("2000"));
+
+        List<NetWorthIntradayPoint> result = historyService.buildIntradayHistory(List.of(1L, 2L), MEMBER_ID);
+
+        assertThat(result).isNotEmpty();
+        for (NetWorthIntradayPoint point : result) {
+            // Every hourly point: total = cash 2000 − loan 10000; loan excluded from invested.
+            assertThat(point.total()).isEqualByComparingTo("-8000");
+            assertThat(point.invested()).isEqualByComparingTo("2000");
+        }
     }
 }

--- a/backend/src/test/java/com/picsou/service/ManualTransactionServiceTest.java
+++ b/backend/src/test/java/com/picsou/service/ManualTransactionServiceTest.java
@@ -44,6 +44,18 @@ class ManualTransactionServiceTest {
             .type(AccountType.CHECKING)
             .currency("EUR")
             .currentBalance(BigDecimal.ZERO)
+            .isManual(true)
+            .build();
+    }
+
+    private Account syncedCheckingAccount() {
+        return Account.builder()
+            .id(3L)
+            .name("Bank-synced Checking")
+            .type(AccountType.CHECKING)
+            .currency("EUR")
+            .currentBalance(new BigDecimal("2500"))
+            .isManual(false)
             .build();
     }
 
@@ -58,7 +70,7 @@ class ManualTransactionServiceTest {
     }
 
     @Test
-    void addTransaction_cashAccount_recomputesBalance() {
+    void addTransaction_manualCashAccount_recomputesBalanceAndSnapshots() {
         Account account = checkingAccount();
         TransactionRequest req = new TransactionRequest(
             LocalDate.of(2024, 1, 15),
@@ -80,6 +92,58 @@ class ManualTransactionServiceTest {
         verify(accountRepository).save(account);
         verify(holdingComputeService, never()).recomputeHoldings(any());
         verify(finaryPersistenceHelper).reconstructSnapshotsFromDb(account);
+    }
+
+    @Test
+    void addTransaction_syncedCashAccount_savesTransactionButLeavesBalanceAndSnapshots() {
+        Account account = syncedCheckingAccount();
+        TransactionRequest req = new TransactionRequest(
+            LocalDate.of(2024, 5, 20),
+            "Cash expense noted by hand",
+            new BigDecimal("-10"),
+            TransactionType.WITHDRAWAL,
+            null, null, null, null, "EUR"
+        );
+
+        when(accountRepository.findByIdAndMemberId(3L, 10L)).thenReturn(Optional.of(account));
+        when(transactionRepository.save(any(Transaction.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        TransactionResponse result = manualTransactionService.addTransaction(3L, 10L, req);
+
+        // The annotation is recorded...
+        assertThat(result).isNotNull();
+        assertThat(result.amount()).isEqualByComparingTo("-10");
+        verify(transactionRepository).save(any(Transaction.class));
+        // ...but the provider-owned balance and snapshot history are untouched.
+        assertThat(account.getCurrentBalance()).isEqualByComparingTo("2500");
+        verify(transactionRepository, never()).sumAmountByAccountId(any());
+        verify(accountRepository, never()).save(any());
+        verify(finaryPersistenceHelper, never()).reconstructSnapshotsFromDb(any());
+    }
+
+    @Test
+    void deleteTransaction_syncedAccount_doesNotReconstruct() {
+        Account account = syncedCheckingAccount();
+        Transaction tx = Transaction.builder()
+            .id(7L)
+            .account(account)
+            .date(LocalDate.of(2024, 5, 21))
+            .description("Manual annotation on synced account")
+            .amount(new BigDecimal("-10"))
+            .isManual(true)
+            .nativeCurrency("EUR")
+            .build();
+
+        when(accountRepository.findByIdAndMemberId(3L, 10L)).thenReturn(Optional.of(account));
+        when(transactionRepository.findByIdAndAccountId(7L, 3L)).thenReturn(Optional.of(tx));
+
+        manualTransactionService.deleteTransaction(3L, 7L, 10L);
+
+        verify(transactionRepository).delete(tx);
+        assertThat(account.getCurrentBalance()).isEqualByComparingTo("2500");
+        verify(transactionRepository, never()).sumAmountByAccountId(any());
+        verify(accountRepository, never()).save(any());
+        verify(finaryPersistenceHelper, never()).reconstructSnapshotsFromDb(any());
     }
 
     @Test
@@ -107,6 +171,39 @@ class ManualTransactionServiceTest {
         verify(holdingComputeService).recomputeHoldings(account);
         verify(finaryPersistenceHelper, never()).reconstructSnapshotsFromDb(any());
         verify(transactionRepository, never()).sumAmountByAccountId(any());
+    }
+
+    @Test
+    void addTransaction_syncedInvestmentAccount_stillRecomputesHoldings() {
+        Account account = Account.builder()
+            .id(4L)
+            .name("Synced CTO")
+            .type(AccountType.COMPTE_TITRES)
+            .currency("EUR")
+            .currentBalance(BigDecimal.ZERO)
+            .isManual(false)
+            .build();
+        TransactionRequest req = new TransactionRequest(
+            LocalDate.of(2024, 4, 2),
+            "Buy AAPL",
+            new BigDecimal("-500"),
+            TransactionType.BUY,
+            "AAPL",
+            null,
+            new BigDecimal("5"),
+            new BigDecimal("100"),
+            "EUR"
+        );
+
+        when(accountRepository.findByIdAndMemberId(4L, 10L)).thenReturn(Optional.of(account));
+        when(transactionRepository.save(any(Transaction.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        manualTransactionService.addTransaction(4L, 10L, req);
+
+        // The isManual guard only gates the cash recompute path — holdings
+        // derivation runs for investment accounts regardless of provenance.
+        verify(holdingComputeService).recomputeHoldings(account);
+        verify(finaryPersistenceHelper, never()).reconstructSnapshotsFromDb(any());
     }
 
     @Test

--- a/backend/src/test/java/com/picsou/service/ManualTransactionServiceTest.java
+++ b/backend/src/test/java/com/picsou/service/ManualTransactionServiceTest.java
@@ -122,6 +122,40 @@ class ManualTransactionServiceTest {
     }
 
     @Test
+    void updateTransaction_syncedAccount_doesNotRewriteBalanceOrSnapshots() {
+        Account account = syncedCheckingAccount();
+        Transaction tx = Transaction.builder()
+            .id(7L)
+            .account(account)
+            .date(LocalDate.of(2024, 5, 21))
+            .description("Manual annotation on synced account")
+            .amount(new BigDecimal("-10"))
+            .isManual(true)
+            .nativeCurrency("EUR")
+            .build();
+        TransactionRequest req = new TransactionRequest(
+            LocalDate.of(2024, 5, 22),
+            "Corrected annotation",
+            new BigDecimal("-15"),
+            TransactionType.WITHDRAWAL,
+            null, null, null, null, "EUR"
+        );
+
+        when(accountRepository.findByIdAndMemberId(3L, 10L)).thenReturn(Optional.of(account));
+        when(transactionRepository.findByIdAndAccountId(7L, 3L)).thenReturn(Optional.of(tx));
+        when(transactionRepository.save(any(Transaction.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        TransactionResponse result = manualTransactionService.updateTransaction(3L, 7L, 10L, req);
+
+        assertThat(result.amount()).isEqualByComparingTo("-15");
+        // Provider-owned balance and snapshot history stay untouched, same as add/delete.
+        assertThat(account.getCurrentBalance()).isEqualByComparingTo("2500");
+        verify(transactionRepository, never()).sumAmountByAccountId(any());
+        verify(accountRepository, never()).save(any());
+        verify(finaryPersistenceHelper, never()).reconstructSnapshotsFromDb(any());
+    }
+
+    @Test
     void deleteTransaction_syncedAccount_doesNotReconstruct() {
         Account account = syncedCheckingAccount();
         Transaction tx = Transaction.builder()

--- a/backend/src/test/java/com/picsou/service/ManualTransactionServiceTest.java
+++ b/backend/src/test/java/com/picsou/service/ManualTransactionServiceTest.java
@@ -59,6 +59,19 @@ class ManualTransactionServiceTest {
             .build();
     }
 
+    /** Manual annotation (id 7) living on a synced account — shared by the update/delete guard tests. */
+    private Transaction syncedManualTransaction(Account account) {
+        return Transaction.builder()
+            .id(7L)
+            .account(account)
+            .date(LocalDate.of(2024, 5, 21))
+            .description("Manual annotation on synced account")
+            .amount(new BigDecimal("-10"))
+            .isManual(true)
+            .nativeCurrency("EUR")
+            .build();
+    }
+
     private Account peaAccount() {
         return Account.builder()
             .id(2L)
@@ -124,15 +137,7 @@ class ManualTransactionServiceTest {
     @Test
     void updateTransaction_syncedAccount_doesNotRewriteBalanceOrSnapshots() {
         Account account = syncedCheckingAccount();
-        Transaction tx = Transaction.builder()
-            .id(7L)
-            .account(account)
-            .date(LocalDate.of(2024, 5, 21))
-            .description("Manual annotation on synced account")
-            .amount(new BigDecimal("-10"))
-            .isManual(true)
-            .nativeCurrency("EUR")
-            .build();
+        Transaction tx = syncedManualTransaction(account);
         TransactionRequest req = new TransactionRequest(
             LocalDate.of(2024, 5, 22),
             "Corrected annotation",
@@ -158,15 +163,7 @@ class ManualTransactionServiceTest {
     @Test
     void deleteTransaction_syncedAccount_doesNotReconstruct() {
         Account account = syncedCheckingAccount();
-        Transaction tx = Transaction.builder()
-            .id(7L)
-            .account(account)
-            .date(LocalDate.of(2024, 5, 21))
-            .description("Manual annotation on synced account")
-            .amount(new BigDecimal("-10"))
-            .isManual(true)
-            .nativeCurrency("EUR")
-            .build();
+        Transaction tx = syncedManualTransaction(account);
 
         when(accountRepository.findByIdAndMemberId(3L, 10L)).thenReturn(Optional.of(account));
         when(transactionRepository.findByIdAndAccountId(7L, 3L)).thenReturn(Optional.of(tx));

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -48,6 +48,7 @@
 | Demo mode | 2026-04-08 | [demo-mode.md](./features/demo-mode.md) |
 | Theme (dark / light / system) + theme-adaptive rendering | 2026-06-02 | [theme-persistence.md](./features/theme-persistence.md) |
 | Dashboard — Time range isolation | 2026-04-13 | [dashboard-time-range-isolation.md](./features/dashboard-time-range-isolation.md) |
+| Dashboard — Liabilities separated from performance | 2026-07-08 | [dashboard-liabilities-separation.md](./features/dashboard-liabilities-separation.md) |
 | Bank sync | 2026-06-03 | [bank-sync.md](./features/bank-sync.md) |
 | Trade Republic | 2026-07-07 | [trade-republic.md](./features/trade-republic.md) |
 | Trade Republic — Holdings deduplication | 2026-05-18 | [trade-republic-holding-deduplication.md](./features/trade-republic-holding-deduplication.md) |

--- a/docs/features/dashboard-liabilities-separation.md
+++ b/docs/features/dashboard-liabilities-separation.md
@@ -59,7 +59,7 @@ data-model change — but the dashboard now separates four readings: **assets**,
 
 ### Flow
 
-```
+```text
 balance_snapshot ──► buildHistory ──► NetWorthPoint(total=net worth,
         │                                pnl=Σ non-loan (value−invested))
         │                                      │

--- a/docs/features/dashboard-liabilities-separation.md
+++ b/docs/features/dashboard-liabilities-separation.md
@@ -1,0 +1,112 @@
+# Feature: Dashboard — Liabilities separated from portfolio performance
+
+> Last updated: 2026-07-08
+
+## Context
+
+With LOAN accounts present, the dashboard used to read debt drag as poor
+portfolio performance: `pnl = total − invested` where loans contribute
+`−balance` to `total` and `0` to `invested`, so the full outstanding debt
+appeared as an investment loss (GitHub issue #18). Loans stay liabilities — no
+data-model change — but the dashboard now separates four readings: **assets**,
+**liabilities**, **net worth**, and **portfolio performance**.
+
+## How it works
+
+**The four readings and their semantics:**
+
+- `total` (history points, PnL response) remains **net worth**: loans are
+  negated, so the curve is honest about debt.
+- `pnl` (every aggregation path: historical points, the live point, `buildPnl`,
+  and the MCP `get_profit_and_loss` tool which delegates to `buildPnl`) is
+  **debt-neutral**: the sum over non-LOAN accounts of `(value − invested)`.
+  Loans contribute exactly 0 — never `−balance`. A loan-only selection has
+  `pnl = 0`.
+- `rangePnl` is **pure portfolio performance**: computed only over holdings
+  whose price is known on BOTH sides of the range (live via
+  `PriceService.getPriceEur` and at `fromDate` via `price_snapshot`). Cash,
+  loans, and unmatched holdings are excluded from both sides, so
+  `rangePnl = liveMatchedValue − valueAtFrom`.
+- Allocation percentages divide by their own side of the balance sheet:
+  asset items by `totalAssets`, liability items by `totalLiabilities`
+  (≤ 0 divisor → 0.0). Percentages can no longer exceed 100 % when debt exists.
+
+**UI:**
+
+- The dashboard chart card is titled by wealth mode
+  (`dashboard.evolution.net|gross|financial` — "Net worth evolution" etc.), not
+  "Gain / Loss": the curve plots wealth, not performance.
+- The chart tooltip's gain/loss row reads the backend `pnl` field of each
+  `NetWorthPoint` instead of recomputing `total − invested` client-side. Intraday
+  points carry no `pnl` → the row is omitted on the 24H range.
+- `LiabilitiesCard` renders `data.liabilities` (name, outstanding amount in
+  red, share of `totalLiabilities` computed client-side), below the charts row,
+  only when `totalLiabilities > 0`.
+
+### Key files
+
+- `backend/src/main/java/com/picsou/service/HistoryService.java` —
+  `buildHistory` (per-date `aggPnl` accumulator + live point `livePnl`),
+  `buildPnl` (`liveNonLoanValue`, matched-holdings `rangePnl`)
+- `backend/src/main/java/com/picsou/service/DashboardService.java` —
+  `buildDistribution(accounts, divisor, …)` with per-side divisors
+- `frontend/src/pages/dashboard/DashboardPage.tsx` — mode-dependent chart
+  title, renders `LiabilitiesCard`
+- `frontend/src/components/shared/NetWorthChart.tsx` — tooltip reads row `pnl`
+- `frontend/src/components/shared/LiabilitiesCard.tsx` — liabilities list
+- `frontend/src/demo/data/dashboard.ts` — demo mock ships one loan so demo
+  mode exercises the card
+
+### Flow
+
+```
+balance_snapshot ──► buildHistory ──► NetWorthPoint(total=net worth,
+        │                                pnl=Σ non-loan (value−invested))
+        │                                      │
+live balances ────► buildPnl ──► PnlResponse(total, pnl debt-neutral,
+        │                          rangePnl over matched holdings only)
+        │                                      │
+DashboardService ─► distribution %  = balance / totalAssets
+                    liabilities %   = balance / totalLiabilities
+                                               │
+DashboardPage ─► chart (title per wealth mode, tooltip = point.pnl)
+              ─► LiabilitiesCard (when totalLiabilities > 0)
+```
+
+## Technical choices
+
+| Choice | Why | Rejected alternative |
+|--------|-----|----------------------|
+| Loans contribute 0 to pnl everywhere | Debt is a liability, not an investment loss | Changing `AccountType` / data model (explicitly rejected by issue author) |
+| `rangePnl` over holdings priced on both sides | Comparing a net-worth live side against a holdings-only baseline mixed cash/debt into "performance" (audit BE-04) | Keeping `liveTotal − valueAtFrom` |
+| Per-side percentage divisors | Net-worth divisor produced >100 % shares (or all-zero when net worth ≤ 0) | Keeping net-worth divisor |
+| Tooltip reads backend `pnl` | One source of truth; hero PnL and tooltip agree by construction | Client-side `total − invested` recomputation |
+
+## Gotchas / Pitfalls
+
+- Any surviving `subtract` of a loan value inside a pnl computation is a bug —
+  "loans contribute 0 to pnl" is the invariant across ALL aggregation paths.
+- `total`/`invested` in `PnlResponse` keep their old meaning (net worth /
+  invested); only `pnl` and `rangePnl` changed semantics.
+- Intraday points (`buildIntradayHistory`) carry no pnl field — deliberately
+  untouched (its timezone bugs are a separate concern, audit BE-11).
+- If a future feature wants per-liability "progress" (debt paydown as a
+  positive metric), build it as its OWN series — do not re-mix it into pnl.
+- The demo `GET /history` handler is still missing (known bug FE-06), so the
+  demo dashboard chart relies on the dashboard mock, not history.
+
+## Tests
+
+- `HistoryServiceTest` — debt-neutral pnl in `buildHistory` (aggregate +
+  per-account split), `buildPnl` (loan + brokerage, loan-only → pnl 0),
+  matched-holdings `rangePnl` (incl. a holding without a snapshot at
+  `fromDate` excluded from both sides)
+- `DashboardServiceTest` — percentages divide by own-side totals; asset split
+  25 / 75 with debt present
+
+## Links
+
+- Issue: https://github.com/Zoeille/picsou-finance/issues/18
+- Related: [loans.md](./loans.md) (loan balance sign convention),
+  [accounts-overview.md](./accounts-overview.md) (PnL chart consumes the same
+  history points)

--- a/docs/features/loans.md
+++ b/docs/features/loans.md
@@ -17,7 +17,7 @@ and negated only at aggregation time:
 - Negation sites: `DashboardService` and `HistoryService` (inline LOAN branches, kept until
   plan 005), `FamilyViewService` and `GoalService` (via `signedLiveBalanceEur`).
 - The Finary API sync (`FinaryApiSyncService.toLoanAccountDto`) stores the outstanding amount
-  positive. It briefly stored it negative — migration `V40__fix_negative_loan_balances.sql`
+  positive. It briefly stored it negative — migration `V52__fix_negative_loan_balances.sql`
   repaired the corrupted rows and snapshots (existing users saw their net worth *drop to the
   correct value*: the data was wrong before, not after).
 

--- a/docs/features/loans.md
+++ b/docs/features/loans.md
@@ -1,6 +1,25 @@
 # Feature: Loan accounts (LOAN type)
 
-> Last updated: 2026-04-26
+> Last updated: 2026-07-08
+
+## Sign convention
+
+**LOAN balances are stored POSITIVE** (`account.current_balance`, `balance_snapshot.balance`)
+and negated only at aggregation time:
+
+- `AccountService.liveBalanceEur(account)` returns the remaining capital as a **positive**
+  value for LOAN accounts (`LoanAmortizationService.computeRemainingBalance` returns positive;
+  the fallback to the stored balance is positive too).
+- `AccountService.signedLiveBalanceEur(account)` is the single helper for net-worth-style
+  summations: it negates LOAN balances and passes every other type through. Any new code that
+  sums balances across account types MUST use it — reviewers should reject new unsigned
+  `liveBalanceEur` sums.
+- Negation sites: `DashboardService` and `HistoryService` (inline LOAN branches, kept until
+  plan 005), `FamilyViewService` and `GoalService` (via `signedLiveBalanceEur`).
+- The Finary API sync (`FinaryApiSyncService.toLoanAccountDto`) stores the outstanding amount
+  positive. It briefly stored it negative — migration `V40__fix_negative_loan_balances.sql`
+  repaired the corrupted rows and snapshots (existing users saw their net worth *drop to the
+  correct value*: the data was wrong before, not after).
 
 ## Context
 
@@ -35,7 +54,8 @@ remaining capital from the formula. As a result, the historical balance chart sh
 - `backend/src/main/java/com/picsou/service/LoanAmortizationService.java` — formula + records
   (`LoanInstallment`, `LoanSummary`, `LoanScheduleResponse`)
 - `backend/src/main/java/com/picsou/service/AccountService.java`
-  - `liveBalanceEur` — branched for LOAN to return the negative remaining capital
+  - `liveBalanceEur` — branched for LOAN to return the (positive) remaining capital
+  - `signedLiveBalanceEur` — applies the liability sign (LOAN → negative) for net-worth sums
   - `getLoanSummary(id, memberId)` — loads the Debt, validates type, delegates to amortization service
 - `backend/src/main/java/com/picsou/controller/AccountController.java` — `GET /accounts/{id}/loan-summary`
 - `backend/src/main/resources/db/migration/V27__loan_extra_fields.sql` — adds `insurance_monthly`, `file_fees`
@@ -74,7 +94,7 @@ SchedulerService.dailySnapshots
 AccountService.liveBalanceEur(account=LOAN)
    │
    ▼
-LoanAmortizationService.computeRemainingBalance(debt, today)  → negative BigDecimal
+LoanAmortizationService.computeRemainingBalance(debt, today)  → positive BigDecimal
    │
    ▼
 BalanceSnapshot persisted  →  historical balance chart steps down monthly
@@ -94,8 +114,9 @@ BalanceSnapshot persisted  →  historical balance chart steps down monthly
 - **The last installment absorbs the rounding residue.** With BigDecimal precision and scale 2,
   240 monthly capitals do not sum exactly to the borrowed amount; the service forces the
   last installment to bring `remainingBalance` to zero.
-- **`liveBalanceEur` returns NEGATIVE for LOAN.** A loan is a liability — `currentBalance` is
-  stored negative, which the dashboard "Total liabilities" card relies on.
+- **`liveBalanceEur` returns POSITIVE for LOAN; only aggregation negates.** See the
+  "Sign convention" section above — the dashboard "Total liabilities" card adds the positive
+  value to liabilities and subtracts liabilities from assets.
 - **`paidInstallments` is computed from "today", not from a count of payments.** No transaction
   is required against the LOAN account — the formula assumes payments occur on schedule. If a
   user pays late or makes prepayments, the model does not capture that (out of scope).
@@ -105,7 +126,7 @@ BalanceSnapshot persisted  →  historical balance chart steps down monthly
   accounts in `AccountDetailPage` — the loan section is the canonical view.
 - **Finary-imported loans have no `Debt` row.** The Finary API sync imports loan/mortgage
   accounts from the dedicated `/loans` endpoint (see [finary-import.md](finary-import.md), issue #11)
-  as `LOAN` accounts with the outstanding amount stored as a negative `currentBalance`. The
+  as `LOAN` accounts with the outstanding amount stored as a positive `currentBalance`. The
   loans payload does not expose the original principal or interest rate, so no `Debt` is
   created — `liveBalanceEur` gracefully falls back to the stored balance when no `Debt` exists,
   and the rich amortization view only appears once the user fills in the loan parameters via

--- a/docs/features/manual-transactions.md
+++ b/docs/features/manual-transactions.md
@@ -1,6 +1,6 @@
 # Feature: Manual Transactions
 
-> Last updated: 2026-06-03
+> Last updated: 2026-07-08
 
 ## Context
 
@@ -55,7 +55,11 @@ A user-supplied "Nom" always wins over the resolved name. The same logic runs fo
 
 ### Balance derivation (cash accounts)
 
-When a manual transaction is added or deleted on a cash account, `ManualTransactionService` recomputes `account.currentBalance` as the sum of all transaction amounts via a single aggregate query (`sumAmountByAccountId`). It then calls `FinaryPersistenceHelper.reconstructSnapshotsFromDb()` to rebuild the balance history from scratch.
+When a manual transaction is added, edited, or deleted on a **manual** cash account (`account.isManual = true`), `ManualTransactionService` recomputes `account.currentBalance` as the sum of all transaction amounts via a single aggregate query (`sumAmountByAccountId`). It then calls `FinaryPersistenceHelper.reconstructSnapshotsFromDb()` to rebuild the balance history from scratch.
+
+### Synced accounts
+
+Manual transactions on a **synced** cash account (`account.isManual = false` — bank-synced via Enable Banking, Trade Republic, wallet, or exchange accounts) are recorded but never drive the account's balance or snapshot history. Only `isManual` accounts get transaction-derived balances; for synced accounts the balance and snapshots are owned by the provider sync, and rebuilding them from the (usually sparse) manual transaction list would overwrite the balance and delete the provider-written snapshot history. Finary-created accounts have `isManual = true`, so they keep the transaction-derived path. Investment accounts are unaffected: `recomputeHoldings` runs after every manual BUY/SELL regardless of account provenance. The MCP `add_transaction` tool goes through the same service, so it inherits the rule.
 
 ### Holdings derivation (investment accounts)
 
@@ -133,5 +137,5 @@ After submit, `useAddTransaction` / `useDeleteTransaction` hooks invalidate the 
 ## Tests
 
 - `HoldingComputeServiceTest` — 11 unit tests: BUY-only, multi-BUY VWAP, BUY+SELL, fully-sold position, null ticker/quantity skipping, multiple tickers, existing holding update, plus position name = newest transaction's name and name-preserved-when-transactions-have-none.
-- `ManualTransactionServiceTest` — 8 unit tests: cash add, investment add (holdings recomputed), non-owned account rejection, manual delete, synced-transaction delete rejection, not-found rejection, plus ISIN input → resolved ticker/name/description and plain-ticker uppercased with the user "Nom" winning.
+- `ManualTransactionServiceTest` — 11 unit tests: manual cash add (balance + snapshots recomputed), synced cash add (transaction saved, balance/snapshots untouched), investment add (holdings recomputed, for both manual and synced accounts), non-owned account rejection, manual delete, synced-account delete (no reconstruct), synced-transaction delete rejection, not-found rejection, plus ISIN input → resolved ticker/name/description and plain-ticker uppercased with the user "Nom" winning.
 - `OpenFigiIsinConverterTest` — 4 unit tests for the `isIsin()` detector: valid ISINs, case/whitespace normalization, rejects tickers/non-ISIN strings, rejects null/blank.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,6 +9,7 @@
     "lint": "eslint .",
     "format": "prettier --write \"**/*.{ts,tsx}\"",
     "typecheck": "tsc --noEmit",
+    "test": "vitest run",
     "preview": "vite preview",
     "test:e2e": "playwright test"
   },

--- a/frontend/src/components/shared/AddAccountModal.test.tsx
+++ b/frontend/src/components/shared/AddAccountModal.test.tsx
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const { createAccount, updateDebtMetadata } = vi.hoisted(() => ({
   createAccount: vi.fn(),
@@ -67,10 +67,21 @@ function fillPhoneAndPin() {
 
 describe('AddAccountModal Trade Republic wizard', () => {
   beforeEach(() => {
+    // The OTP/PIN field (input-otp) schedules an internal setTimeout that it
+    // does not cancel on unmount. With real timers it can fire after jsdom is
+    // torn down, throwing "window is not defined" as an unhandled error that
+    // fails the whole vitest run (all assertions still pass). Fake timers keep
+    // that callback under our control so afterEach can drop it before teardown.
+    vi.useFakeTimers({ shouldAdvanceTime: true })
     createAccount.mockReset()
     updateDebtMetadata.mockReset()
     initiateTrAuth.mockReset()
     completeTrAuth.mockReset()
+  })
+
+  afterEach(() => {
+    vi.clearAllTimers()
+    vi.useRealTimers()
   })
 
   it('keeps the credentials form visible when initiation fails', async () => {

--- a/frontend/src/components/shared/HoldingDetailModal.tsx
+++ b/frontend/src/components/shared/HoldingDetailModal.tsx
@@ -69,11 +69,16 @@ export function HoldingDetailModal({ line, onClose }: HoldingDetailModalProps) {
 
   const intraday = useMemo(() => {
     if (!is24H || !rawHistory) return []
-    return rawHistory.map(p => ({
-      timestamp: p.date,
-      total: mode === 'holding' && line ? p.priceEur * line.quantity : p.priceEur,
-      ...(investedRef !== undefined ? { invested: investedRef } : {}),
-    }))
+    return rawHistory.map(p => {
+      const total = mode === 'holding' && line ? p.priceEur * line.quantity : p.priceEur
+      return {
+        timestamp: p.date,
+        total,
+        // Same as the history mapping above: value − cost basis is the holding's
+        // debt-free pnl; the tooltip reads `pnl` and never recomputes it.
+        ...(investedRef !== undefined ? { invested: investedRef, pnl: total - investedRef } : {}),
+      }
+    })
   }, [rawHistory, mode, line, is24H, investedRef])
 
   const priceChange = useMemo(() => {

--- a/frontend/src/components/shared/HoldingDetailModal.tsx
+++ b/frontend/src/components/shared/HoldingDetailModal.tsx
@@ -54,11 +54,17 @@ export function HoldingDetailModal({ line, onClose }: HoldingDetailModalProps) {
 
   const history = useMemo(() => {
     if (!rawHistory) return []
-    return rawHistory.map(p => ({
-      date: p.date,
-      total: mode === 'holding' && line ? p.priceEur * line.quantity : p.priceEur,
-      ...(investedRef !== undefined ? { invested: investedRef } : {}),
-    }))
+    return rawHistory.map(p => {
+      const total = mode === 'holding' && line ? p.priceEur * line.quantity : p.priceEur
+      return {
+        date: p.date,
+        total,
+        // For a pure holding, value − cost basis IS its debt-free investment
+        // pnl — emit it so the chart tooltip keeps its gain/loss row (the
+        // tooltip reads `pnl` and never recomputes total − invested).
+        ...(investedRef !== undefined ? { invested: investedRef, pnl: total - investedRef } : {}),
+      }
+    })
   }, [rawHistory, mode, line, investedRef])
 
   const intraday = useMemo(() => {

--- a/frontend/src/components/shared/LiabilitiesCard.tsx
+++ b/frontend/src/components/shared/LiabilitiesCard.tsx
@@ -1,0 +1,75 @@
+import { useTranslation } from 'react-i18next'
+import { CurrencyDisplay } from '@/components/shared/CurrencyDisplay'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+import {
+  Item,
+  ItemContent,
+  ItemGroup,
+  ItemMedia,
+  ItemTitle,
+} from '@/components/ui/item'
+import type { DashboardData } from '@/types/api'
+
+interface LiabilitiesCardProps {
+  liabilities: DashboardData['liabilities']
+  totalLiabilities: number
+}
+
+/**
+ * Renders the dashboard's liabilities (loans) as their own reading, separate
+ * from assets and portfolio performance (issue #18). Each row shows the
+ * outstanding amount in red and its share of total liabilities.
+ */
+export function LiabilitiesCard({ liabilities, totalLiabilities }: LiabilitiesCardProps) {
+  const { t } = useTranslation()
+
+  if (liabilities.length === 0 || totalLiabilities <= 0) return null
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{t('dashboard.liabilitiesTitle')}</CardTitle>
+        <CardDescription>{t('dashboard.liabilitiesDescription')}</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <ItemGroup className="gap-2">
+          {liabilities.map(item => {
+            const share = (item.balanceEur / totalLiabilities) * 100
+            return (
+              <Item key={item.accountId} variant="muted">
+                <ItemMedia>
+                  <div
+                    className="size-3 shrink-0 rounded-full"
+                    style={{ backgroundColor: item.color }}
+                  />
+                </ItemMedia>
+                <ItemContent>
+                  <ItemTitle>{item.name}</ItemTitle>
+                </ItemContent>
+                <div className="flex shrink-0 items-center gap-4">
+                  <span className="text-xs tabular-nums text-muted-foreground">
+                    {share.toFixed(1)}%
+                  </span>
+                  <CurrencyDisplay
+                    value={item.balanceEur}
+                    className="font-medium tabular-nums text-red-500"
+                  />
+                </div>
+              </Item>
+            )
+          })}
+        </ItemGroup>
+        <div className="mt-3 flex items-center justify-between border-t border-border pt-3 text-sm">
+          <span className="text-muted-foreground">{t('dashboard.totalLiabilities')}</span>
+          <CurrencyDisplay value={totalLiabilities} className="font-semibold tabular-nums text-red-500" />
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/frontend/src/components/shared/NetWorthChart.tsx
+++ b/frontend/src/components/shared/NetWorthChart.tsx
@@ -230,6 +230,9 @@ export function NetWorthChart({ data, intraday = [], range, onRangeChange, showI
           dateMs: new Date(p.timestamp).getTime(),
           total: p.total as number | null,
           invested: p.invested,
+          // Dashboard intraday points carry no pnl (row omitted); synthetic
+          // intraday series (holding modal) may provide one.
+          pnl: p.pnl,
         }))
       : filterByRange(data, range).map(p => ({
           ...p,

--- a/frontend/src/components/shared/NetWorthChart.tsx
+++ b/frontend/src/components/shared/NetWorthChart.tsx
@@ -38,7 +38,7 @@ interface NetWorthChartProps {
   todayLabel?: string
 }
 
-function NetWorthTooltip({ active, payload, labels, is24H }: {
+function NetWorthTooltip({ active, payload, labels, is24H, showGainLoss }: {
   active?: boolean
   payload?: Array<{
     value: number
@@ -47,6 +47,9 @@ function NetWorthTooltip({ active, payload, labels, is24H }: {
   }>
   labels: { total: string; invested: string; target: string; projection: string; gainLoss: string; locale: string; currency: string }
   is24H: boolean
+  // Callers that hide investment info (showInvested={false}, e.g. goal charts)
+  // must not surface a gain/loss row either.
+  showGainLoss: boolean
 }) {
   if (!active || !payload?.length) return null
 
@@ -126,7 +129,7 @@ function NetWorthTooltip({ active, payload, labels, is24H }: {
           </span>
         </div>
       )}
-      {gainLoss !== null && (
+      {showGainLoss && gainLoss !== null && (
         <>
           <div className="my-1.5 border-t border-border" />
           <div className="flex items-center justify-between gap-3 py-0.5">
@@ -387,7 +390,7 @@ export function NetWorthChart({ data, intraday = [], range, onRangeChange, showI
           width={45}
           tickCount={5}
         />
-        <ChartTooltip content={<NetWorthTooltip labels={labels} is24H={is24H} />} />
+        <ChartTooltip content={<NetWorthTooltip labels={labels} is24H={is24H} showGainLoss={showInvested} />} />
         <Area
           dataKey="total"
           type="monotone"

--- a/frontend/src/components/shared/NetWorthChart.tsx
+++ b/frontend/src/components/shared/NetWorthChart.tsx
@@ -16,7 +16,7 @@ interface TrajectoryOverlay {
 }
 
 interface NetWorthChartProps {
-  data: { date: string; total: number; invested?: number }[]
+  data: { date: string; total: number; invested?: number; pnl?: number }[]
   intraday?: IntradayPoint[]
   range: TimeRange
   onRangeChange: (range: TimeRange) => void
@@ -43,7 +43,7 @@ function NetWorthTooltip({ active, payload, labels, is24H }: {
   payload?: Array<{
     value: number
     dataKey: string
-    payload: { date?: string; timestamp?: string; total: number | null; invested?: number; target?: number; projection?: number }
+    payload: { date?: string; timestamp?: string; total: number | null; invested?: number; pnl?: number; target?: number; projection?: number }
   }>
   labels: { total: string; invested: string; target: string; projection: string; gainLoss: string; locale: string; currency: string }
   is24H: boolean
@@ -60,7 +60,11 @@ function NetWorthTooltip({ active, payload, labels, is24H }: {
   const investedItem = payload.find(p => p.dataKey === 'invested' && p.value != null)
   const hasInvested = investedItem != null
   const invested = hasInvested ? (investedItem.value as number) : 0
-  const gainLoss = total != null && hasInvested ? total - invested : null
+  // Gain/loss comes from the backend's debt-neutral pnl field — never recomputed
+  // locally, so debt can't be read as an investment loss (issue #18). Intraday
+  // points carry no pnl → the row is omitted.
+  const rowPnl = anchorItem.payload?.pnl
+  const gainLoss = typeof rowPnl === 'number' ? rowPnl : null
   const targetItem = payload.find(p => p.dataKey === 'target' && p.value != null)
   const target = targetItem ? (targetItem.value as number) : null
   const projectionItem = payload.find(p => p.dataKey === 'projection' && p.value != null)
@@ -122,7 +126,7 @@ function NetWorthTooltip({ active, payload, labels, is24H }: {
           </span>
         </div>
       )}
-      {hasInvested && gainLoss !== null && (
+      {gainLoss !== null && (
         <>
           <div className="my-1.5 border-t border-border" />
           <div className="flex items-center justify-between gap-3 py-0.5">

--- a/frontend/src/demo/data/dashboard.ts
+++ b/frontend/src/demo/data/dashboard.ts
@@ -25,7 +25,7 @@ function generateNetWorthHistory(): { date: string; total: number; invested: num
 
 export const mockDashboard: DashboardData = {
   totalNetWorth: 41862.35,
-  totalLiabilities: 0,
+  totalLiabilities: 8500,
   netWorthHistory: generateNetWorthHistory(),
   distribution: mockAccounts.map(a => ({
     accountId: a.id,
@@ -36,6 +36,17 @@ export const mockDashboard: DashboardData = {
     accountType: a.type,
     hasHoldings: ['PEA', 'COMPTE_TITRES', 'CRYPTO'].includes(a.type),
   })),
-  liabilities: [],
+  // One loan so demo mode exercises the liabilities card (issue #18).
+  liabilities: [
+    {
+      accountId: 100,
+      name: 'Car loan',
+      color: '#ef4444',
+      balanceEur: 8500,
+      percentage: 100,
+      accountType: 'LOAN',
+      hasHoldings: false,
+    },
+  ],
   goalSummaries: mockGoals,
 }

--- a/frontend/src/features/dashboard/api.test.ts
+++ b/frontend/src/features/dashboard/api.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/lib/api-client', () => ({
+  api: { get: vi.fn().mockResolvedValue({ data: [] }) },
+}))
+
+import { api } from '@/lib/api-client'
+import { dashboardApi } from './api'
+
+describe('dashboardApi param serialization', () => {
+  it('sends accountIds as a comma-joined string to /history/pnl', async () => {
+    await dashboardApi.getPnl([9, 12], '2026-01-01')
+    expect(api.get).toHaveBeenCalledWith('/history/pnl', {
+      params: { accountIds: '9,12', from: '2026-01-01' },
+    })
+  })
+
+  it('sends accountIds as a comma-joined string to intraday', async () => {
+    await dashboardApi.getIntraday([9])
+    expect(api.get).toHaveBeenCalledWith('/history/net-worth/intraday', {
+      params: { accountIds: '9' },
+    })
+  })
+})

--- a/frontend/src/features/dashboard/api.ts
+++ b/frontend/src/features/dashboard/api.ts
@@ -22,8 +22,12 @@ export const dashboardApi = {
     api.get<DashboardData>('/dashboard', { params: range ? { range } : {} }).then(r => r.data),
 
   getIntraday: (accountIds: number[]) =>
-    api.get<IntradayPoint[]>('/history/net-worth/intraday', { params: { accountIds } }).then(r => r.data),
+    api.get<IntradayPoint[]>('/history/net-worth/intraday', {
+      params: { accountIds: accountIds.join(',') },
+    }).then(r => r.data),
 
   getPnl: (accountIds: number[], from?: string) =>
-    api.get<PnlData>('/history/pnl', { params: { accountIds, ...(from ? { from } : {}) } }).then(r => r.data),
+    api.get<PnlData>('/history/pnl', {
+      params: { accountIds: accountIds.join(','), ...(from ? { from } : {}) },
+    }).then(r => r.data),
 }

--- a/frontend/src/features/dashboard/api.ts
+++ b/frontend/src/features/dashboard/api.ts
@@ -5,6 +5,8 @@ export interface IntradayPoint {
   timestamp: string
   total: number
   invested?: number
+  /** Absent on backend intraday points; synthetic series (holding modal) may set it. */
+  pnl?: number
 }
 
 export interface PnlData {

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -128,7 +128,14 @@
     "recentAccounts": "Recent accounts",
     "viewAll": "View all",
     "totalLiabilities": "Total liabilities",
-    "totalAssets": "Total assets"
+    "totalAssets": "Total assets",
+    "evolution": {
+      "net": "Net worth evolution",
+      "gross": "Gross assets evolution",
+      "financial": "Financial assets evolution"
+    },
+    "liabilitiesTitle": "Liabilities",
+    "liabilitiesDescription": "Outstanding debt by account"
   },
   "accounts": {
     "title": "Accounts",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -128,7 +128,14 @@
     "recentAccounts": "Comptes récents",
     "viewAll": "Voir tout",
     "totalLiabilities": "Total des dettes",
-    "totalAssets": "Total des actifs"
+    "totalAssets": "Total des actifs",
+    "evolution": {
+      "net": "Évolution du patrimoine net",
+      "gross": "Évolution du patrimoine brut",
+      "financial": "Évolution du patrimoine financier"
+    },
+    "liabilitiesTitle": "Passifs",
+    "liabilitiesDescription": "Dette restante par compte"
   },
   "accounts": {
     "title": "Comptes",

--- a/frontend/src/pages/dashboard/DashboardPage.tsx
+++ b/frontend/src/pages/dashboard/DashboardPage.tsx
@@ -9,6 +9,7 @@ import { NetWorthChart } from '@/components/shared/NetWorthChart'
 import { DistributionPie } from '@/components/shared/DistributionPie'
 import { LoadingSkeleton } from '@/components/shared/LoadingSkeleton'
 import { HoldingsCard } from '@/components/shared/HoldingsCard'
+import { LiabilitiesCard } from '@/components/shared/LiabilitiesCard'
 import { SyncAllModal } from '@/components/sync/SyncAllModal'
 import { type TimeRange } from '@/components/shared/TimeRangeSelector'
 import {
@@ -225,7 +226,9 @@ export function DashboardPage() {
       <div className="grid gap-4 md:grid-cols-2">
         <Card className="h-[420px]">
           <CardHeader>
-            <CardTitle>{t('dashboard.gainLoss')}</CardTitle>
+            {/* Titled by wealth mode — the curve plots (net/gross/financial) wealth,
+                not gain/loss (issue #18). */}
+            <CardTitle>{t(`dashboard.evolution.${wealthMode}`)}</CardTitle>
           </CardHeader>
           <CardContent className="min-h-0 flex-1">
             <NetWorthChart data={history ?? []} intraday={intraday ?? []} range={range} onRangeChange={setRange} />
@@ -234,6 +237,11 @@ export function DashboardPage() {
 
         <DistributionPie data={data.distribution} />
       </div>
+
+      {/* Liabilities — rendered separately from assets (issue #18) */}
+      {(data.totalLiabilities ?? 0) > 0 && (
+        <LiabilitiesCard liabilities={data.liabilities} totalLiabilities={data.totalLiabilities} />
+      )}
 
       {/* Goals section */}
       <Card>


### PR DESCRIPTION
## Summary

Separates the dashboard's four readings — **assets, liabilities, net worth, portfolio performance** — so debt is never displayed as poor investment performance. Along the way, a deep audit of the money-aggregation paths surfaced (and this PR fixes) several correctness bugs that made the displayed numbers wrong regardless of presentation.

Closes #18. Loans remain `LOAN` liabilities — no data-model change, as required by the issue.

## What changed

**Correctness fixes**
- `accountIds` was serialized by axios as `accountIds[]`, which Spring cannot bind, so `GET /history/pnl` and `GET /history/net-worth/intraday` silently failed with 400. The headline PnL always showed 0 and the 24H chart was empty. Now comma-joined like the existing `/history` call.
- Finary API sync stored loan balances **negative**, and every aggregation negates loans again, so net worth was inflated by roughly 2x the outstanding amount. Loans are now stored positive per the repo convention; migration `V40` repairs already-imported rows (accounts + snapshots).
- Family dashboard and goal progress summed loan balances **unsigned**, so sharing a mortgage increased family net worth. Both now use a new `AccountService.signedLiveBalanceEur` helper.
- Adding/editing/deleting a manual transaction on a provider-synced account overwrote its balance and **deleted its entire snapshot history**. The recompute/rebuild path is now gated on `account.isManual()`.

**Issue #18 — debt-neutral performance**
- `pnl` is now debt-neutral in every path (`buildHistory` historical + live points, `buildPnl`, split per-account points, MCP tools): loans contribute 0 to pnl instead of minus the outstanding amount. `total` remains true net worth.
- `rangePnl` compares only holdings priced on **both** sides (live and at the from-date): pure portfolio performance, no cash/loan/unmatched-holding contamination.
- Allocation percentages divide by their own side of the balance sheet (assets/totalAssets, liabilities/totalLiabilities) instead of net worth — no more >100% slices when debt exists.
- The chart card is titled by wealth mode ("Net worth evolution" / "Evolution du patrimoine net"...) instead of the misleading "Gain / Loss"; the tooltip's gain/loss row reads the backend `pnl` field instead of recomputing `total - invested` locally.
- New `LiabilitiesCard` renders the `liabilities[]` list the API already shipped (outstanding per loan, share of total, in red), shown whenever debt exists.

**Infrastructure**
- New `ci.yml`: backend `mvn test` + frontend lint/typecheck/vitest on every PR and push to main (previously no CI ran any test).
- 14 characterization tests locked the money paths before the rework; more tests cover each fix (462 backend / 85 frontend tests, all green).

## User-visible changes

- The headline PnL shows real values for the first time against a live backend.
- Users with loans (e.g. imported from Finary) will see their net worth **drop to its correct value** after `V40` — the previous number was inflated by the sign bug.
- Distribution percentages and the gain/loss readings change for anyone with debt — deliberately, per the semantics above.

## Docs

- `docs/features/dashboard-liabilities-separation.md` (new), `docs/features/loans.md` (sign convention), `docs/features/manual-transactions.md` (synced-account rule), `CHANGELOG.md` entry.

## Test plan

- `cd backend && mvn test` — 462 tests, 0 failures
- `cd frontend && bun run lint && bun run typecheck && bun run test` — clean, 85 tests
- Manually verified against a copy of a real database (checking + PEA + Trade Republic accounts): PnL populated, 24H chart populated, V40 applied out-of-order cleanly, liabilities card renders with a test loan while PnL stays unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated **Liabilities** card to display loan liabilities separately.
  * Updated dashboard chart UI for **wealth-mode** (net/gross/financial) and now uses backend-provided PnL in tooltips.

* **Bug Fixes**
  * Loans are now **debt-neutral for profit/loss** (contribute 0) while still impacting net worth.
  * Range PnL compares only holdings with pricing on both sides of the range.
  * Asset vs. liability allocation percentages are calculated independently (side-specific totals).

* **Documentation**
  * Updated loan and dashboard semantics documentation, plus manual transactions notes.

* **Chores**
  * Added CI workflow and expanded frontend/backend test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->