### PR TITLE
fix(settings): display build version in about panel

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,7 +3,7 @@ name: Build & publish Docker images
 on:
   push:
     branches: ['**']
-    tags: ['[0-9]*']
+    tags: ['[0-9]*', 'v[0-9]*']
   workflow_dispatch:
 
 env:
@@ -24,10 +24,12 @@ jobs:
             image: ${{ github.repository }}
             context: .
             dockerfile: docker/Dockerfile
+            versioned: true
           - name: tr-auth
             image: ${{ github.repository }}/tr-auth
             context: services/tr-auth
             dockerfile: services/tr-auth/Dockerfile
+            versioned: false
 
     steps:
       - name: Checkout
@@ -70,7 +72,7 @@ jobs:
         shell: bash
         run: |
           if [[ "$GITHUB_REF_TYPE" == "tag" ]]; then
-            echo "version=$GITHUB_REF_NAME" >> "$GITHUB_OUTPUT"
+            echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
           elif [[ "$GITHUB_REF_NAME" == "main" ]]; then
             echo "version=nightly-${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
           else
@@ -87,7 +89,6 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          build-args: |
-            APP_VERSION=${{ steps.app-version.outputs.version }}
+          build-args: ${{ matrix.versioned && format('APP_VERSION={0}', steps.app-version.outputs.version) || '' }}
           cache-from: type=gha,scope=${{ matrix.name }}
           cache-to: type=gha,mode=max,scope=${{ matrix.name }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -65,6 +65,19 @@ jobs:
             type=semver,pattern={{major}}
             type=sha,format=short
 
+      - name: Compute app version
+        id: app-version
+        shell: bash
+        run: |
+          if [[ "$GITHUB_REF_TYPE" == "tag" ]]; then
+            echo "version=$GITHUB_REF_NAME" >> "$GITHUB_OUTPUT"
+          elif [[ "$GITHUB_REF_NAME" == "main" ]]; then
+            echo "version=nightly-${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+          else
+            safe_ref="${GITHUB_REF_NAME//\//-}"
+            echo "version=${safe_ref}-${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
@@ -74,5 +87,7 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            APP_VERSION=${{ steps.app-version.outputs.version }}
           cache-from: type=gha,scope=${{ matrix.name }}
           cache-to: type=gha,mode=max,scope=${{ matrix.name }}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -94,6 +94,12 @@ management:
   endpoint:
     health:
       show-details: never
+  info:
+    # Expose `info.*` properties (below) via /actuator/info. The env info
+    # contributor is disabled by default since Spring Boot 2.6, so without this
+    # the app.version block would never surface.
+    env:
+      enabled: true
 
 info:
   app:

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -53,7 +53,7 @@ spring:
         stdio: false
         type: SYNC
         name: picsou
-        version: 1.0.8
+        version: ${APP_VERSION:dev}
         instructions: >-
           Picsou personal-finance MCP server. Every tool operates only on the financial data of
           the member who owns the access-key used to authenticate: it can never read or modify
@@ -94,6 +94,11 @@ management:
   endpoint:
     health:
       show-details: never
+
+info:
+  app:
+    name: picsou
+    version: ${APP_VERSION:dev}
 
 app:
   admin-recovery:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,7 +9,9 @@ FROM oven/bun:alpine AS frontend-build
 WORKDIR /build/frontend
 
 ARG VITE_DEMO_MODE=false
+ARG APP_VERSION=dev
 ENV VITE_DEMO_MODE=$VITE_DEMO_MODE
+ENV VITE_APP_VERSION=$APP_VERSION
 
 COPY frontend/package.json frontend/bun.lock ./
 RUN bun install --frozen-lockfile
@@ -30,6 +32,9 @@ RUN mvn package -DskipTests -q
 
 # ---------- Stage 3: Runtime ----------
 FROM eclipse-temurin:21-jre-jammy
+
+ARG APP_VERSION=dev
+ENV APP_VERSION=$APP_VERSION
 
 # Install Nginx + supervisor + openssl (entrypoint auto-generates secrets on first boot)
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/docs/features/docker-deployment.md
+++ b/docs/features/docker-deployment.md
@@ -82,14 +82,15 @@ docker tag ghcr.io/zoeille/picsou-finance/tr-auth:1.0.0 docker-tr-auth:latest
 Tag scheme:
 - `main` push → `nightly`
 - other branch push → branch name (e.g. `1.0.0`, `feature-foo`)
-- `v*` git tag → `latest` + semver (`1.0.0`, `1.0`, `1`)
+- version tag (`1.0.0` or `v1.0.0`) → `latest` + semver (`1.0.0`, `1.0`, `1`)
 
 ### Build version shown in the app
 
 The published Docker workflow computes `APP_VERSION` from the Git ref and passes
-it to the main image build. Version-tag builds display the tag value in Settings
-→ About (for example `1.0.13`), `main` builds display `nightly-<short-sha>`, and
-branch builds display `<branch-name>-<short-sha>`.
+it to the main image build. Version-tag builds display the normalized tag value
+in Settings → About (for example both `1.0.13` and `v1.0.13` tags display
+`1.0.13`), `main` builds display `nightly-<short-sha>`, and branch builds display
+`<branch-name>-<short-sha>`.
 
 Local source builds fall back to `frontend/package.json` for the frontend About
 screen. Backend runtime metadata (`/actuator/info` and the embedded MCP server

--- a/docs/features/docker-deployment.md
+++ b/docs/features/docker-deployment.md
@@ -84,6 +84,22 @@ Tag scheme:
 - other branch push → branch name (e.g. `1.0.0`, `feature-foo`)
 - `v*` git tag → `latest` + semver (`1.0.0`, `1.0`, `1`)
 
+### Build version shown in the app
+
+The published Docker workflow computes `APP_VERSION` from the Git ref and passes
+it to the main image build. Version-tag builds display the tag value in Settings
+→ About (for example `1.0.13`), `main` builds display `nightly-<short-sha>`, and
+branch builds display `<branch-name>-<short-sha>`.
+
+Local source builds fall back to `frontend/package.json` for the frontend About
+screen. Backend runtime metadata (`/actuator/info` and the embedded MCP server
+version) uses `APP_VERSION` when it is set and otherwise falls back to `dev`.
+For a local release-style build, pass both values explicitly:
+
+```bash
+APP_VERSION=1.0.13 docker build -f docker/Dockerfile --build-arg APP_VERSION=1.0.13 .
+```
+
 ## Technical choices
 
 | Choice | Why | Rejected alternative |

--- a/docs/features/docker-deployment.md
+++ b/docs/features/docker-deployment.md
@@ -95,10 +95,11 @@ in Settings → About (for example both `1.0.13` and `v1.0.13` tags display
 Local source builds fall back to `frontend/package.json` for the frontend About
 screen. Backend runtime metadata (`/actuator/info` and the embedded MCP server
 version) uses `APP_VERSION` when it is set and otherwise falls back to `dev`.
-For a local release-style build, pass both values explicitly:
+A single `APP_VERSION` build arg feeds both the frontend and backend. For a
+local release-style build, pass it explicitly:
 
 ```bash
-APP_VERSION=1.0.13 docker build -f docker/Dockerfile --build-arg APP_VERSION=1.0.13 .
+docker build -f docker/Dockerfile --build-arg APP_VERSION=1.0.13 .
 ```
 
 ## Technical choices

--- a/frontend/src/lib/app-version.test.ts
+++ b/frontend/src/lib/app-version.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from 'vitest'
+import { APP_VERSION } from './app-version'
+
+describe('APP_VERSION', () => {
+  it('comes from the build-time Vite define', () => {
+    expect(APP_VERSION).toBe('test-version')
+  })
+})

--- a/frontend/src/lib/app-version.ts
+++ b/frontend/src/lib/app-version.ts
@@ -1,0 +1,1 @@
+export const APP_VERSION = __APP_VERSION__

--- a/frontend/src/pages/settings/SettingsPage.tsx
+++ b/frontend/src/pages/settings/SettingsPage.tsx
@@ -33,6 +33,7 @@ import {
 } from 'lucide-react'
 import type { LucideIcon } from 'lucide-react'
 import { api } from '@/lib/api-client'
+import { APP_VERSION } from '@/lib/app-version'
 import { SecuritySection } from './security/SecuritySection'
 import { AccessKeysSection } from './sections/AccessKeysSection'
 
@@ -352,7 +353,7 @@ export function SettingsPage() {
             <p className="text-muted-foreground">
               {t('settings.version')}
             </p>
-            <p className="font-medium text-foreground">1.0.8</p>
+            <p className="font-medium text-foreground">{APP_VERSION}</p>
           </div>
           <div className="space-y-1 sm:justify-self-end sm:text-right">
             <p className="text-muted-foreground">GitHub</p>

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,0 +1,3 @@
+/// <reference types="vite/client" />
+
+declare const __APP_VERSION__: string

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -14,7 +14,18 @@ const localHttps =
       }
     : undefined
 
+interface PackageJson {
+  version: string
+}
+
+const packageJsonPath = path.resolve(__dirname, 'package.json')
+const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8')) as PackageJson
+const appVersion = process.env.VITE_APP_VERSION ?? packageJson.version
+
 export default defineConfig({
+  define: {
+    __APP_VERSION__: JSON.stringify(appVersion),
+  },
   plugins: [react(), tailwindcss()],
   resolve: {
     alias: {

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -2,6 +2,9 @@ import { defineConfig } from 'vitest/config'
 import path from 'path'
 
 export default defineConfig({
+  define: {
+    __APP_VERSION__: JSON.stringify('test-version'),
+  },
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),


### PR DESCRIPTION
## Summary

- Replace the hardcoded Settings → About version with a Vite build-time `APP_VERSION` constant.
- Pass `APP_VERSION` from GitHub Actions into Docker builds so semver tag builds display the deployed tag, e.g. `1.0.13`.
- Expose the same runtime version to backend metadata (`/actuator/info`) and the embedded MCP server.
- Document the release-version source of truth for Docker deployments.

## Root cause

The About panel and backend MCP metadata each carried their own stale literal `1.0.8`, separate from package manifests and Docker tags. A user running a newer published tag could therefore see an old application version even after pulling the correct image.

## Validation

- `bunx vitest run src/lib/app-version.test.ts`
- `bun run typecheck`
- `bun run lint`
- `VITE_APP_VERSION=1.0.13 bun run build`
- `APP_VERSION=1.0.13 JAVA_HOME=$(/usr/libexec/java_home -v 21) mvn package -DskipTests`
- `JAVA_HOME=$(/usr/libexec/java_home -v 21) mvn test` (451 tests)
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * App, backend metadata, and the embedded MCP server now surface a Docker-derived build version in Settings → About and `/actuator/info`.
* **Bug Fixes**
  * Removed hardcoded version values; the displayed/runtime version now consistently follows Docker build and Git-ref tagging rules (including `nightly-<short-sha>` and sanitized branch builds).
* **Documentation**
  * Updated Docker deployment docs with revised `latest`/semver tag mapping and “Build version shown in the app” guidance.
* **Tests**
  * Added a test that validates the build-time `APP_VERSION` value used by the app.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->