### PR TITLE
feat: CSV transaction import + realized P&L for PEA/CTO (#38)

### DIFF
--- a/backend/src/main/java/com/picsou/controller/AccountController.java
+++ b/backend/src/main/java/com/picsou/controller/AccountController.java
@@ -8,6 +8,7 @@ import com.picsou.dto.HoldingRequest;
 import com.picsou.dto.HoldingResponse;
 import com.picsou.dto.RealEstateMetadataRequest;
 import com.picsou.dto.RealEstateMetadataResponse;
+import com.picsou.dto.RealizedPnlResponse;
 import com.picsou.dto.SnapshotRequest;
 import com.picsou.dto.TransactionRequest;
 import com.picsou.dto.TransactionResponse;
@@ -15,6 +16,7 @@ import com.picsou.model.BalanceSnapshot;
 import com.picsou.service.AccountService;
 import com.picsou.service.LoanAmortizationService;
 import com.picsou.service.ManualTransactionService;
+import com.picsou.service.RealizedPnlService;
 import com.picsou.service.UserContext;
 import jakarta.validation.Valid;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -32,11 +34,15 @@ public class AccountController {
     private final AccountService accountService;
     private final UserContext userContext;
     private final ManualTransactionService manualTransactionService;
+    private final RealizedPnlService realizedPnlService;
 
-    public AccountController(AccountService accountService, UserContext userContext, ManualTransactionService manualTransactionService) {
+    public AccountController(AccountService accountService, UserContext userContext,
+                            ManualTransactionService manualTransactionService,
+                            RealizedPnlService realizedPnlService) {
         this.accountService = accountService;
         this.userContext = userContext;
         this.manualTransactionService = manualTransactionService;
+        this.realizedPnlService = realizedPnlService;
     }
 
     @GetMapping
@@ -92,6 +98,11 @@ public class AccountController {
     @GetMapping("/{id}/transactions")
     public List<TransactionResponse> getTransactions(@PathVariable Long id) {
         return accountService.getTransactions(id, userContext.currentMemberId());
+    }
+
+    @GetMapping("/{id}/realized-pnl")
+    public RealizedPnlResponse getRealizedPnl(@PathVariable Long id) {
+        return realizedPnlService.compute(id, userContext.currentMemberId());
     }
 
     @PostMapping("/{id}/transactions")

--- a/backend/src/main/java/com/picsou/controller/TransactionImportController.java
+++ b/backend/src/main/java/com/picsou/controller/TransactionImportController.java
@@ -1,0 +1,84 @@
+package com.picsou.controller;
+
+import com.picsou.config.RateLimitConfig;
+import com.picsou.dto.TransactionImportPreviewResponse;
+import com.picsou.dto.TransactionImportRequest;
+import com.picsou.dto.TransactionImportResultResponse;
+import com.picsou.service.TransactionImportService;
+import com.picsou.service.UserContext;
+import io.github.bucket4j.Bucket;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ProblemDetail;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.Map;
+
+/**
+ * Two-phase CSV import of investment transactions into a single account. Both endpoints are
+ * member-scoped (the service resolves the account by member) and IP-throttled with the shared
+ * sync buckets to bound upload abuse.
+ */
+@RestController
+@RequestMapping("/api/accounts/{id}/transactions/import")
+public class TransactionImportController {
+
+    private final TransactionImportService importService;
+    private final UserContext userContext;
+    private final Map<String, Bucket> syncBuckets;
+
+    public TransactionImportController(
+        TransactionImportService importService,
+        UserContext userContext,
+        @Qualifier("syncBuckets") Map<String, Bucket> syncBuckets
+    ) {
+        this.importService = importService;
+        this.userContext = userContext;
+        this.syncBuckets = syncBuckets;
+    }
+
+    @PostMapping(value = "/preview", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<?> preview(
+        @PathVariable Long id,
+        @RequestParam("file") MultipartFile file,
+        HttpServletRequest request
+    ) {
+        if (!checkRateLimit(request)) {
+            return tooManyRequests();
+        }
+        TransactionImportPreviewResponse preview =
+            importService.preview(id, userContext.currentMemberId(), file);
+        return ResponseEntity.ok(preview);
+    }
+
+    @PostMapping
+    public ResponseEntity<?> execute(
+        @PathVariable Long id,
+        @Valid @RequestBody TransactionImportRequest req,
+        HttpServletRequest request
+    ) {
+        if (!checkRateLimit(request)) {
+            return tooManyRequests();
+        }
+        TransactionImportResultResponse result =
+            importService.executeImport(id, userContext.currentMemberId(), req);
+        return ResponseEntity.status(HttpStatus.CREATED).body(result);
+    }
+
+    private boolean checkRateLimit(HttpServletRequest request) {
+        String ip = request.getRemoteAddr();
+        Bucket bucket = syncBuckets.computeIfAbsent(ip, k -> RateLimitConfig.createSyncBucket());
+        return bucket.tryConsume(1);
+    }
+
+    private static ResponseEntity<ProblemDetail> tooManyRequests() {
+        ProblemDetail detail = ProblemDetail.forStatus(HttpStatus.TOO_MANY_REQUESTS);
+        detail.setDetail("Too many import requests. Please wait a moment.");
+        return ResponseEntity.status(HttpStatus.TOO_MANY_REQUESTS).body(detail);
+    }
+}

--- a/backend/src/main/java/com/picsou/dto/ColumnMappingDto.java
+++ b/backend/src/main/java/com/picsou/dto/ColumnMappingDto.java
@@ -1,0 +1,19 @@
+package com.picsou.dto;
+
+/**
+ * Maps each canonical transaction field to a zero-based CSV column index (or {@code null} if
+ * the column is absent). {@code side} is the BUY/SELL column; {@code tickerOrIsin} accepts either
+ * a Yahoo ticker or an ISIN (resolved at import time). {@code amount} is optional — when
+ * {@code unitPrice} is absent it is used to derive the unit price.
+ */
+public record ColumnMappingDto(
+    Integer date,
+    Integer side,
+    Integer tickerOrIsin,
+    Integer name,
+    Integer quantity,
+    Integer unitPrice,
+    Integer fees,
+    Integer currency,
+    Integer amount
+) {}

--- a/backend/src/main/java/com/picsou/dto/CsvDialectDto.java
+++ b/backend/src/main/java/com/picsou/dto/CsvDialectDto.java
@@ -1,0 +1,12 @@
+package com.picsou.dto;
+
+/**
+ * Wire form of a CSV dialect for the import wizard. {@code delimiter} is a single-character
+ * string ({@code ","}, {@code ";"}, or a tab), {@code decimal} is {@code "DOT"} or
+ * {@code "COMMA"}, and {@code dateFormat} is a {@code java.time} pattern (e.g. {@code dd/MM/yyyy}).
+ */
+public record CsvDialectDto(
+    String delimiter,
+    String decimal,
+    String dateFormat
+) {}

--- a/backend/src/main/java/com/picsou/dto/RealizedPnlResponse.java
+++ b/backend/src/main/java/com/picsou/dto/RealizedPnlResponse.java
@@ -1,0 +1,42 @@
+package com.picsou.dto;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * Realized profit/loss on an investment account, computed on the fly from the ordered BUY/SELL
+ * stream using the moving-average (PMP) cost basis — buy fees are part of the cost, sell fees
+ * reduce the proceeds. This is a strictly separate series from the unrealized {@code PnlResponse.pnl}.
+ * All amounts are in the account's own currency (no re-pricing / FX).
+ *
+ * @param realizedTotal sum of realized gains/losses across every sell
+ * @param byTicker      per-security aggregates ({@code warning} true if a sell exceeded the held qty)
+ * @param lots          one entry per sell, in chronological order
+ */
+public record RealizedPnlResponse(
+    String currency,
+    BigDecimal realizedTotal,
+    List<TickerRealized> byTicker,
+    List<ClosedLot> lots
+) {
+    public record TickerRealized(
+        String ticker,
+        String name,
+        BigDecimal realized,
+        BigDecimal quantitySold,
+        BigDecimal proceeds,
+        BigDecimal costBasis,
+        boolean warning
+    ) {}
+
+    public record ClosedLot(
+        String ticker,
+        String name,
+        LocalDate date,
+        BigDecimal quantity,
+        BigDecimal avgCost,
+        BigDecimal proceeds,
+        BigDecimal realized
+    ) {}
+}

--- a/backend/src/main/java/com/picsou/dto/TransactionImportPreviewResponse.java
+++ b/backend/src/main/java/com/picsou/dto/TransactionImportPreviewResponse.java
@@ -1,0 +1,19 @@
+package com.picsou.dto;
+
+import java.util.List;
+
+/**
+ * Preview returned by the first phase of a CSV transaction import. Carries a {@code fileToken}
+ * (bound to the target account, ~30-min TTL) the client echoes back to commit, the detected
+ * column headers, a handful of sample rows, the total data-row count, the detected dialect,
+ * and a best-guess column mapping — all overridable by the user before the import runs.
+ */
+public record TransactionImportPreviewResponse(
+    String fileToken,
+    List<String> detectedColumns,
+    List<List<String>> sampleRows,
+    int totalRows,
+    boolean hasHeaderRow,
+    CsvDialectDto dialect,
+    ColumnMappingDto suggestedMapping
+) {}

--- a/backend/src/main/java/com/picsou/dto/TransactionImportRequest.java
+++ b/backend/src/main/java/com/picsou/dto/TransactionImportRequest.java
@@ -1,0 +1,22 @@
+package com.picsou.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.Map;
+
+/**
+ * Commit request for the second phase of a CSV transaction import. Echoes the {@code fileToken}
+ * from the preview plus the (possibly user-adjusted) column mapping and dialect. {@code hasHeaderRow}
+ * tells the importer to skip the first data row; {@code feesIncludedInAmount} says the mapped amount
+ * column already nets fees (so the unit price is derived accordingly); {@code sideValueMap} maps raw
+ * cell text (e.g. "Achat") to {@code "BUY"}/{@code "SELL"} when the side column uses custom labels.
+ */
+public record TransactionImportRequest(
+    @NotBlank String fileToken,
+    @NotNull ColumnMappingDto mapping,
+    @NotNull CsvDialectDto dialect,
+    boolean hasHeaderRow,
+    boolean feesIncludedInAmount,
+    Map<String, String> sideValueMap
+) {}

--- a/backend/src/main/java/com/picsou/dto/TransactionImportResultResponse.java
+++ b/backend/src/main/java/com/picsou/dto/TransactionImportResultResponse.java
@@ -1,0 +1,15 @@
+package com.picsou.dto;
+
+import java.util.List;
+
+/**
+ * Result of a committed CSV transaction import: how many rows were imported, how many were
+ * skipped, and a per-row error list for the skipped ones (1-based row numbers, user-safe messages).
+ */
+public record TransactionImportResultResponse(
+    int imported,
+    int skipped,
+    List<RowError> errors
+) {
+    public record RowError(int rowNumber, String message) {}
+}

--- a/backend/src/main/java/com/picsou/dto/TransactionRequest.java
+++ b/backend/src/main/java/com/picsou/dto/TransactionRequest.java
@@ -16,5 +16,13 @@ public record TransactionRequest(
     String name,
     BigDecimal quantity,
     BigDecimal pricePerUnit,
-    String currency
-) {}
+    String currency,
+    BigDecimal fees
+) {
+    /** Backwards-compatible constructor for callers that do not specify per-trade fees. */
+    public TransactionRequest(
+        LocalDate date, String description, BigDecimal amount, TransactionType txType,
+        String ticker, String name, BigDecimal quantity, BigDecimal pricePerUnit, String currency) {
+        this(date, description, amount, txType, ticker, name, quantity, pricePerUnit, currency, null);
+    }
+}

--- a/backend/src/main/java/com/picsou/dto/TransactionResponse.java
+++ b/backend/src/main/java/com/picsou/dto/TransactionResponse.java
@@ -21,7 +21,8 @@ public record TransactionResponse(
     String ticker,
     String name,
     BigDecimal quantity,
-    BigDecimal pricePerUnit
+    BigDecimal pricePerUnit,
+    BigDecimal fees
 ) {
     public static TransactionResponse from(Transaction t) {
         return new TransactionResponse(
@@ -38,7 +39,8 @@ public record TransactionResponse(
             t.getTicker(),
             t.getName(),
             t.getQuantity(),
-            t.getPricePerUnit()
+            t.getPricePerUnit(),
+            t.getFees()
         );
     }
 }

--- a/backend/src/main/java/com/picsou/export/TransactionsExporter.java
+++ b/backend/src/main/java/com/picsou/export/TransactionsExporter.java
@@ -36,7 +36,7 @@ class TransactionsExporter implements EntityExporter {
         return List.of(
             "id", "account_id", "date", "description", "amount", "type", "category",
             "native_currency", "is_manual", "tx_type", "ticker", "quantity",
-            "price_per_unit", "created_at"
+            "price_per_unit", "fees", "created_at"
         );
     }
 
@@ -57,6 +57,7 @@ class TransactionsExporter implements EntityExporter {
                 nullSafe(t.getTicker()),
                 t.getQuantity() == null ? "" : t.getQuantity().toPlainString(),
                 t.getPricePerUnit() == null ? "" : t.getPricePerUnit().toPlainString(),
+                t.getFees() == null ? "" : t.getFees().toPlainString(),
                 t.getCreatedAt() == null ? "" : t.getCreatedAt().toString()
             ));
         }
@@ -80,6 +81,7 @@ class TransactionsExporter implements EntityExporter {
             json.writeStringField("ticker", t.getTicker());
             writeBigDecimal(json, "quantity", t.getQuantity());
             writeBigDecimal(json, "price_per_unit", t.getPricePerUnit());
+            writeBigDecimal(json, "fees", t.getFees());
             writeInstant(json, "created_at", t.getCreatedAt());
             json.writeEndObject();
         }

--- a/backend/src/main/java/com/picsou/imports/TransactionAmountCalculator.java
+++ b/backend/src/main/java/com/picsou/imports/TransactionAmountCalculator.java
@@ -1,0 +1,43 @@
+package com.picsou.imports;
+
+import com.picsou.model.TransactionType;
+
+import java.math.BigDecimal;
+
+/**
+ * Single source of truth for signing a BUY/SELL transaction's stored {@code amount}
+ * from its quantity/price/fees. Shared by every writer of investment transactions —
+ * today the CSV importer, and mirrored (not shared, since it's TypeScript) by the
+ * manual-entry frontend modal — so the sign convention never drifts between paths.
+ *
+ * <p>Convention: BUY is a cash outflow, SELL is a cash inflow.
+ * <ul>
+ *   <li>BUY:  {@code amount = -(quantity * pricePerUnit + fees)}</li>
+ *   <li>SELL: {@code amount = +(quantity * pricePerUnit - fees)}</li>
+ * </ul>
+ *
+ * <p>{@code null} quantity, price or fees are treated as zero, matching the
+ * null-as-zero convention used throughout {@code HoldingComputeService}. No
+ * rounding is applied beyond what {@link BigDecimal} multiplication/addition
+ * yields — the {@code amount} column is {@code NUMERIC(20,8)}, so callers may
+ * still want to scale the result before persisting, but this helper never
+ * truncates precision itself.
+ */
+public final class TransactionAmountCalculator {
+
+    private TransactionAmountCalculator() {
+    }
+
+    public static BigDecimal signedAmount(TransactionType side, BigDecimal quantity, BigDecimal pricePerUnit, BigDecimal fees) {
+        BigDecimal qty = quantity != null ? quantity : BigDecimal.ZERO;
+        BigDecimal price = pricePerUnit != null ? pricePerUnit : BigDecimal.ZERO;
+        BigDecimal safeFees = fees != null ? fees : BigDecimal.ZERO;
+        BigDecimal gross = qty.multiply(price);
+
+        if (side == TransactionType.SELL) {
+            return gross.subtract(safeFees);
+        }
+        // BUY (and any other side, defensively) is treated as an outflow.
+        return gross.add(safeFees).negate();
+    }
+}

--- a/backend/src/main/java/com/picsou/imports/TransactionRowMapper.java
+++ b/backend/src/main/java/com/picsou/imports/TransactionRowMapper.java
@@ -1,0 +1,163 @@
+package com.picsou.imports;
+
+import com.picsou.dto.ColumnMappingDto;
+import com.picsou.imports.csv.CsvDialect;
+import com.picsou.imports.csv.CsvValueParser;
+import com.picsou.model.Account;
+import com.picsou.model.Transaction;
+import com.picsou.model.TransactionType;
+import com.picsou.service.InstrumentFieldResolver;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDate;
+import java.time.format.DateTimeParseException;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Maps one raw CSV row into an unsaved BUY/SELL {@link Transaction} using a user-confirmed
+ * column mapping and {@link CsvDialect}. Reuses {@link InstrumentFieldResolver} (so an imported
+ * ISIN and a manually-typed one collapse to the same position) and {@link TransactionAmountCalculator}
+ * (so the stored signed amount — fees included — never drifts from the manual-entry path).
+ *
+ * <p>Invalid rows throw {@link IllegalArgumentException} with a user-safe message; the import
+ * service turns that into a per-row error rather than failing the whole file.
+ */
+@Component
+@RequiredArgsConstructor
+public class TransactionRowMapper {
+
+    private final InstrumentFieldResolver instrumentFieldResolver;
+
+    public Transaction map(List<String> row, ColumnMappingDto mapping, CsvDialect dialect,
+                           Map<String, String> sideValueMap, boolean feesIncludedInAmount,
+                           Account account) {
+
+        TransactionType side = resolveSide(cell(row, mapping.side()), cell(row, mapping.amount()),
+            dialect, sideValueMap);
+
+        LocalDate date = parseDate(cell(row, mapping.date()), dialect);
+        if (date == null) {
+            throw new IllegalArgumentException("Missing date");
+        }
+
+        BigDecimal quantity = parseDecimal(cell(row, mapping.quantity()), dialect, "quantity");
+        if (quantity == null || quantity.signum() <= 0) {
+            throw new IllegalArgumentException("Missing or non-positive quantity");
+        }
+
+        BigDecimal fees = parseDecimal(cell(row, mapping.fees()), dialect, "fees");
+        if (fees == null) {
+            fees = BigDecimal.ZERO;
+        } else if (fees.signum() < 0) {
+            throw new IllegalArgumentException("Fees cannot be negative");
+        }
+
+        BigDecimal price = resolvePrice(row, mapping, dialect, side, quantity, fees, feesIncludedInAmount);
+
+        String currency = cell(row, mapping.currency());
+        if (currency == null || currency.isBlank()) {
+            currency = account.getCurrency();
+        }
+
+        InstrumentFieldResolver.ResolvedInstrument instrument =
+            instrumentFieldResolver.resolve(cell(row, mapping.tickerOrIsin()), cell(row, mapping.name()), side);
+        if (instrument == null) {
+            throw new IllegalArgumentException("Missing ticker/ISIN");
+        }
+
+        BigDecimal amount = TransactionAmountCalculator.signedAmount(side, quantity, price, fees);
+
+        return Transaction.builder()
+            .account(account)
+            .date(date)
+            .description(instrument.description())
+            .amount(amount)
+            .txType(side)
+            .ticker(instrument.ticker())
+            .name(instrument.name())
+            .quantity(quantity)
+            .pricePerUnit(price)
+            .fees(fees)
+            .isManual(true)
+            .nativeCurrency(currency)
+            .build();
+    }
+
+    private TransactionType resolveSide(String sideCell, String amountCell, CsvDialect dialect,
+                                        Map<String, String> sideValueMap) {
+        if (sideCell != null && !sideCell.isBlank()) {
+            String raw = sideCell.trim();
+            if (sideValueMap != null) {
+                for (Map.Entry<String, String> e : sideValueMap.entrySet()) {
+                    if (e.getKey().equalsIgnoreCase(raw)) {
+                        return TransactionType.valueOf(e.getValue().trim().toUpperCase());
+                    }
+                }
+            }
+            String lower = raw.toLowerCase();
+            if (lower.startsWith("s") || lower.contains("vent") || lower.contains("sell") || lower.contains("sale")) {
+                return TransactionType.SELL;
+            }
+            if (lower.startsWith("b") || lower.contains("ach") || lower.contains("buy")) {
+                return TransactionType.BUY;
+            }
+        }
+        // Fall back to the sign of the amount column: outflow = BUY, inflow = SELL.
+        BigDecimal amount = parseDecimal(amountCell, dialect, "amount");
+        if (amount != null) {
+            return amount.signum() < 0 ? TransactionType.BUY : TransactionType.SELL;
+        }
+        throw new IllegalArgumentException("Cannot determine BUY/SELL");
+    }
+
+    private BigDecimal resolvePrice(List<String> row, ColumnMappingDto mapping, CsvDialect dialect,
+                                    TransactionType side, BigDecimal quantity, BigDecimal fees,
+                                    boolean feesIncludedInAmount) {
+        BigDecimal price = parseDecimal(cell(row, mapping.unitPrice()), dialect, "unit price");
+        if (price != null) {
+            if (price.signum() < 0) {
+                throw new IllegalArgumentException("Unit price cannot be negative");
+            }
+            return price;
+        }
+        // Derive the unit price from the total amount when no per-unit price column is mapped.
+        BigDecimal amount = parseDecimal(cell(row, mapping.amount()), dialect, "amount");
+        if (amount == null) {
+            throw new IllegalArgumentException("Missing unit price (or amount)");
+        }
+        BigDecimal gross = amount.abs();
+        if (feesIncludedInAmount) {
+            // The amount nets fees: recover the fee-free gross before dividing by quantity.
+            gross = side == TransactionType.SELL ? gross.add(fees) : gross.subtract(fees);
+        }
+        return gross.divide(quantity, 8, RoundingMode.HALF_UP);
+    }
+
+    private static String cell(List<String> row, Integer index) {
+        if (index == null || index < 0 || index >= row.size()) {
+            return null;
+        }
+        String v = row.get(index);
+        return v == null ? null : v.trim();
+    }
+
+    private static BigDecimal parseDecimal(String raw, CsvDialect dialect, String field) {
+        try {
+            return CsvValueParser.parseDecimal(raw, dialect.decimal());
+        } catch (NumberFormatException ex) {
+            throw new IllegalArgumentException("Invalid " + field + " '" + raw + "'");
+        }
+    }
+
+    private static LocalDate parseDate(String raw, CsvDialect dialect) {
+        try {
+            return CsvValueParser.parseDate(raw, dialect.dateFormat());
+        } catch (DateTimeParseException ex) {
+            throw new IllegalArgumentException("Invalid date '" + raw + "'");
+        }
+    }
+}

--- a/backend/src/main/java/com/picsou/imports/TransactionRowMapper.java
+++ b/backend/src/main/java/com/picsou/imports/TransactionRowMapper.java
@@ -99,10 +99,12 @@ public class TransactionRowMapper {
                 }
             }
             String lower = raw.toLowerCase();
-            if (lower.startsWith("s") || lower.contains("vent") || lower.contains("sell") || lower.contains("sale")) {
+            // Explicit tokens first; a bare "s"/"b" only matches exactly (so e.g. "Souscription"
+            // is not mistaken for a sell), then fall through to the amount-sign heuristic.
+            if (lower.equals("s") || lower.contains("vent") || lower.contains("sell") || lower.contains("sale")) {
                 return TransactionType.SELL;
             }
-            if (lower.startsWith("b") || lower.contains("ach") || lower.contains("buy")) {
+            if (lower.equals("b") || lower.contains("ach") || lower.contains("buy")) {
                 return TransactionType.BUY;
             }
         }

--- a/backend/src/main/java/com/picsou/imports/csv/CsvDialect.java
+++ b/backend/src/main/java/com/picsou/imports/csv/CsvDialect.java
@@ -1,0 +1,9 @@
+package com.picsou.imports.csv;
+
+/**
+ * The dialect needed to interpret a CSV: the field delimiter, how decimals are written,
+ * and the date pattern. Detected as a best guess by {@link CsvDialectDetector} and
+ * overridable by the user in the import wizard before the final import runs.
+ */
+public record CsvDialect(char delimiter, DecimalStyle decimal, String dateFormat) {
+}

--- a/backend/src/main/java/com/picsou/imports/csv/CsvDialectDetector.java
+++ b/backend/src/main/java/com/picsou/imports/csv/CsvDialectDetector.java
@@ -1,0 +1,112 @@
+package com.picsou.imports.csv;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.regex.Pattern;
+
+/**
+ * Best-effort detection of a CSV's {@link CsvDialect} (delimiter, decimal style, date format).
+ * The result is only a starting guess — the import wizard lets the user override every field
+ * before the final import runs, so detection favors the common cases (French {@code ;} + comma
+ * decimals, and the RFC-4180 {@code ,} + dot decimals the GDPR export produces).
+ */
+public final class CsvDialectDetector {
+
+    private static final char[] DELIMITER_CANDIDATES = {';', ',', '\t'};
+
+    // Priority-ordered date patterns probed against sample cells.
+    private static final List<String> DATE_PATTERNS = List.of(
+        "yyyy-MM-dd", "dd/MM/yyyy", "dd.MM.yyyy", "MM/dd/yyyy", "yyyy/MM/dd", "dd-MM-yyyy");
+
+    private static final Pattern COMMA_DECIMAL = Pattern.compile("^[+-]?\\d{1,3}(\\.\\d{3})*,\\d+$|^[+-]?\\d+,\\d+$");
+    private static final Pattern DOT_DECIMAL = Pattern.compile("^[+-]?\\d{1,3}(,\\d{3})*\\.\\d+$|^[+-]?\\d+\\.\\d+$");
+
+    private static final int SAMPLE_LIMIT = 50;
+
+    private CsvDialectDetector() {
+    }
+
+    /** Picks the delimiter that appears most on the first non-empty line; defaults to comma. */
+    public static char detectDelimiter(String content) {
+        if (content == null || content.isEmpty()) {
+            return ',';
+        }
+        String firstLine = content;
+        int nl = content.indexOf('\n');
+        if (nl >= 0) {
+            firstLine = content.substring(0, nl);
+        }
+        char best = ',';
+        int bestCount = 0;
+        for (char d : DELIMITER_CANDIDATES) {
+            int count = 0;
+            for (int i = 0; i < firstLine.length(); i++) {
+                if (firstLine.charAt(i) == d) {
+                    count++;
+                }
+            }
+            if (count > bestCount) {
+                bestCount = count;
+                best = d;
+            }
+        }
+        return best;
+    }
+
+    /** Classifies decimal style by counting comma- vs dot-decimal cells; defaults to dot. */
+    public static DecimalStyle detectDecimal(List<List<String>> rows) {
+        int comma = 0;
+        int dot = 0;
+        int seen = 0;
+        for (List<String> row : rows) {
+            if (seen >= SAMPLE_LIMIT) {
+                break;
+            }
+            seen++;
+            for (String cell : row) {
+                String c = cell == null ? "" : cell.trim();
+                if (COMMA_DECIMAL.matcher(c).matches()) {
+                    comma++;
+                } else if (DOT_DECIMAL.matcher(c).matches()) {
+                    dot++;
+                }
+            }
+        }
+        return comma > dot ? DecimalStyle.COMMA : DecimalStyle.DOT;
+    }
+
+    /** Returns the date pattern that parses the most sample cells; defaults to {@code yyyy-MM-dd}. */
+    public static String detectDateFormat(List<List<String>> rows) {
+        String best = DATE_PATTERNS.get(0);
+        int bestCount = 0;
+        for (String pattern : DATE_PATTERNS) {
+            DateTimeFormatter fmt = DateTimeFormatter.ofPattern(pattern);
+            int count = 0;
+            int seen = 0;
+            for (List<String> row : rows) {
+                if (seen >= SAMPLE_LIMIT) {
+                    break;
+                }
+                seen++;
+                for (String cell : row) {
+                    String c = cell == null ? "" : cell.trim();
+                    if (c.isEmpty()) {
+                        continue;
+                    }
+                    try {
+                        LocalDate.parse(c, fmt);
+                        count++;
+                    } catch (RuntimeException ignored) {
+                        // not a date in this pattern
+                    }
+                }
+            }
+            if (count > bestCount) {
+                bestCount = count;
+                best = pattern;
+            }
+        }
+        return best;
+    }
+}

--- a/backend/src/main/java/com/picsou/imports/csv/CsvReader.java
+++ b/backend/src/main/java/com/picsou/imports/csv/CsvReader.java
@@ -1,0 +1,87 @@
+package com.picsou.imports.csv;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Minimal, dependency-free RFC-4180 CSV reader with a configurable delimiter. Handles
+ * quoted fields (embedded delimiters, CR/LF inside quotes, and doubled {@code ""} escapes),
+ * a leading UTF-8 BOM, and both CRLF and LF line endings. Fully-blank lines are skipped,
+ * but a row of empty cells ({@code ,,}) is preserved. Symmetric with the hand-rolled
+ * {@code CsvWriter} used for GDPR export, so an exported file round-trips.
+ */
+public final class CsvReader {
+
+    private static final char BOM = '\uFEFF';
+
+    private CsvReader() {
+    }
+
+    public static List<List<String>> parse(String content, char delimiter) {
+        List<List<String>> rows = new ArrayList<>();
+        if (content == null || content.isEmpty()) {
+            return rows;
+        }
+        // Strip a leading UTF-8 BOM if present.
+        if (content.charAt(0) == BOM) {
+            content = content.substring(1);
+        }
+
+        List<String> row = new ArrayList<>();
+        StringBuilder field = new StringBuilder();
+        boolean inQuotes = false;
+        int i = 0;
+        int n = content.length();
+
+        while (i < n) {
+            char c = content.charAt(i);
+            if (inQuotes) {
+                if (c == '"') {
+                    if (i + 1 < n && content.charAt(i + 1) == '"') {
+                        field.append('"');
+                        i += 2;
+                    } else {
+                        inQuotes = false;
+                        i++;
+                    }
+                } else {
+                    field.append(c);
+                    i++;
+                }
+            } else if (c == '"') {
+                inQuotes = true;
+                i++;
+            } else if (c == delimiter) {
+                row.add(field.toString());
+                field.setLength(0);
+                i++;
+            } else if (c == '\r' || c == '\n') {
+                row.add(field.toString());
+                field.setLength(0);
+                addRow(rows, row);
+                row = new ArrayList<>();
+                if (c == '\r' && i + 1 < n && content.charAt(i + 1) == '\n') {
+                    i += 2;
+                } else {
+                    i++;
+                }
+            } else {
+                field.append(c);
+                i++;
+            }
+        }
+
+        // Finalize the trailing field/row (files not ending in a newline).
+        row.add(field.toString());
+        addRow(rows, row);
+        return rows;
+    }
+
+    private static void addRow(List<List<String>> rows, List<String> row) {
+        // Skip a fully-blank line (a single empty field); keep intentional empty cells.
+        if (row.size() == 1 && row.get(0).isEmpty()) {
+            return;
+        }
+        rows.add(row);
+    }
+}

--- a/backend/src/main/java/com/picsou/imports/csv/CsvValueParser.java
+++ b/backend/src/main/java/com/picsou/imports/csv/CsvValueParser.java
@@ -1,0 +1,67 @@
+package com.picsou.imports.csv;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+/**
+ * Parses raw CSV cell strings into {@link BigDecimal} amounts and {@link LocalDate} dates
+ * according to a {@link CsvDialect}. Money is always {@code BigDecimal} — never a double —
+ * so no precision is lost from a broker's decimal formatting.
+ */
+public final class CsvValueParser {
+
+    private CsvValueParser() {
+    }
+
+    /**
+     * Parses a decimal written in the given style. Thousands separators and whitespace
+     * (including non-breaking / thin spaces) are stripped; the decimal separator is
+     * normalized to a dot.
+     *
+     * @return the parsed value, or {@code null} if the cell is blank.
+     * @throws NumberFormatException if the cell is non-blank but not a number.
+     */
+    public static BigDecimal parseDecimal(String raw, DecimalStyle style) {
+        if (raw == null) {
+            return null;
+        }
+        String s = raw.trim();
+        if (s.isEmpty()) {
+            return null;
+        }
+        // Drop currency symbols and any whitespace (regular, non-breaking, thin).
+        s = s.replace(" ", "").replace("\u00A0", "").replace("\u202F", "");
+        s = s.replace("€", "").replace("$", "").replace("£", "");
+
+        if (style == DecimalStyle.COMMA) {
+            // French style: dots are thousands separators, comma is the decimal point.
+            s = s.replace(".", "").replace(',', '.');
+        } else {
+            // Dot style: commas are thousands separators.
+            s = s.replace(",", "");
+        }
+        // Tolerate a leading '+'.
+        if (s.startsWith("+")) {
+            s = s.substring(1);
+        }
+        return new BigDecimal(s);
+    }
+
+    /**
+     * Parses a date with the given pattern (e.g. {@code dd/MM/yyyy}, {@code yyyy-MM-dd}).
+     *
+     * @return the parsed date, or {@code null} if the cell is blank.
+     * @throws java.time.format.DateTimeParseException if the cell is non-blank but unparseable.
+     */
+    public static LocalDate parseDate(String raw, String pattern) {
+        if (raw == null) {
+            return null;
+        }
+        String s = raw.trim();
+        if (s.isEmpty()) {
+            return null;
+        }
+        return LocalDate.parse(s, DateTimeFormatter.ofPattern(pattern));
+    }
+}

--- a/backend/src/main/java/com/picsou/imports/csv/DecimalStyle.java
+++ b/backend/src/main/java/com/picsou/imports/csv/DecimalStyle.java
@@ -1,0 +1,13 @@
+package com.picsou.imports.csv;
+
+/**
+ * How decimal numbers are written in a CSV. Broker exports vary by locale:
+ * <ul>
+ *   <li>{@code DOT}   — {@code 1,234.56} (dot decimal, optional comma thousands)</li>
+ *   <li>{@code COMMA} — {@code 1 234,56} / {@code 1.234,56} (comma decimal, French style)</li>
+ * </ul>
+ */
+public enum DecimalStyle {
+    DOT,
+    COMMA
+}

--- a/backend/src/main/java/com/picsou/model/Transaction.java
+++ b/backend/src/main/java/com/picsou/model/Transaction.java
@@ -67,4 +67,8 @@ public class Transaction {
 
     @Column(name = "price_per_unit", precision = 20, scale = 8)
     private BigDecimal pricePerUnit;
+
+    /** Broker/transaction fees. Null (no fee recorded) is treated as zero downstream. */
+    @Column(name = "fees", precision = 20, scale = 8)
+    private BigDecimal fees;
 }

--- a/backend/src/main/java/com/picsou/service/HoldingComputeService.java
+++ b/backend/src/main/java/com/picsou/service/HoldingComputeService.java
@@ -57,7 +57,9 @@ public class HoldingComputeService {
                 netQuantity.merge(ticker, qty, BigDecimal::add);
                 // null price treated as 0; averageBuyIn will be 0, which is intentional
                 BigDecimal price = tx.getPricePerUnit() != null ? tx.getPricePerUnit() : BigDecimal.ZERO;
-                vwapNumerator.merge(ticker, qty.multiply(price), BigDecimal::add);
+                // Fees fold into the VWAP numerator (PMP cost basis), null fees treated as 0.
+                BigDecimal fees = tx.getFees() != null ? tx.getFees() : BigDecimal.ZERO;
+                vwapNumerator.merge(ticker, qty.multiply(price).add(fees), BigDecimal::add);
                 vwapDenominator.merge(ticker, qty, BigDecimal::add);
             } else { // SELL
                 netQuantity.merge(ticker, qty.negate(), BigDecimal::add);

--- a/backend/src/main/java/com/picsou/service/InstrumentFieldResolver.java
+++ b/backend/src/main/java/com/picsou/service/InstrumentFieldResolver.java
@@ -1,0 +1,63 @@
+package com.picsou.service;
+
+import com.picsou.adapter.OpenFigiIsinConverter;
+import com.picsou.model.TransactionType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+/**
+ * Resolves the instrument fields (ticker, display name, description) of a BUY/SELL
+ * transaction from a raw ticker-or-ISIN input. Single source of truth shared by the
+ * manual-entry service and the CSV importer, so an ISIN row and the equivalent ticker
+ * row always collapse to the same position.
+ *
+ * <p>When the input is an ISIN it is resolved (via OpenFIGI) to a Yahoo ticker + display
+ * name, so an ISIN entry and the equivalent ticker entry merge into one position and Yahoo
+ * pricing works. A user-supplied {@code name} always wins over the resolved one. The
+ * description is owned here so a raw ISIN never surfaces in the row.
+ */
+@Component
+@RequiredArgsConstructor
+public class InstrumentFieldResolver {
+
+    private final OpenFigiIsinConverter openFigiIsinConverter;
+
+    /** Resolved instrument fields for a BUY/SELL transaction. */
+    public record ResolvedInstrument(String ticker, String name, String description) {}
+
+    /**
+     * Resolves the instrument fields for a BUY/SELL transaction.
+     *
+     * @param tickerOrIsin the raw ticker or ISIN input
+     * @param userName     an optional user-supplied display name (wins over the resolved one)
+     * @param side         the transaction side, used to build the fallback description
+     * @return the resolved fields, or {@code null} when the input is blank (a cash transaction,
+     *         for which the caller keeps its own description/ticker/name).
+     */
+    public ResolvedInstrument resolve(String tickerOrIsin, String userName, TransactionType side) {
+        if (tickerOrIsin == null || tickerOrIsin.isBlank()) {
+            return null; // cash transaction — no instrument
+        }
+
+        String resolvedTicker;
+        String resolvedName;
+        if (OpenFigiIsinConverter.isIsin(tickerOrIsin)) {
+            OpenFigiIsinConverter.TickerResult r = openFigiIsinConverter.resolve(tickerOrIsin);
+            resolvedTicker = r.ticker();   // already falls back to the ISIN itself on failure
+            resolvedName = r.name();
+        } else {
+            resolvedTicker = tickerOrIsin.trim().toUpperCase();
+            resolvedName = null;
+        }
+
+        String effectiveName = (userName != null && !userName.isBlank())
+            ? userName.trim()
+            : resolvedName;
+
+        String description = effectiveName != null
+            ? effectiveName
+            : (side == TransactionType.SELL ? "Vente " : "Achat ") + resolvedTicker;
+
+        return new ResolvedInstrument(resolvedTicker, effectiveName, description);
+    }
+}

--- a/backend/src/main/java/com/picsou/service/ManualTransactionService.java
+++ b/backend/src/main/java/com/picsou/service/ManualTransactionService.java
@@ -1,6 +1,5 @@
 package com.picsou.service;
 
-import com.picsou.adapter.OpenFigiIsinConverter;
 import com.picsou.dto.TransactionRequest;
 import com.picsou.dto.TransactionResponse;
 import com.picsou.exception.ResourceNotFoundException;
@@ -8,7 +7,6 @@ import com.picsou.finary.FinaryPersistenceHelper;
 import com.picsou.model.Account;
 import com.picsou.model.AccountType;
 import com.picsou.model.Transaction;
-import com.picsou.model.TransactionType;
 import com.picsou.repository.AccountRepository;
 import com.picsou.repository.TransactionRepository;
 import lombok.RequiredArgsConstructor;
@@ -26,7 +24,7 @@ public class ManualTransactionService {
     private final TransactionRepository transactionRepository;
     private final HoldingComputeService holdingComputeService;
     private final FinaryPersistenceHelper finaryPersistenceHelper;
-    private final OpenFigiIsinConverter openFigiIsinConverter;
+    private final InstrumentFieldResolver instrumentFieldResolver;
 
     private static final Set<AccountType> INVESTMENT_TYPES =
         Set.of(AccountType.PEA, AccountType.COMPTE_TITRES, AccountType.CRYPTO);
@@ -36,6 +34,8 @@ public class ManualTransactionService {
         Account account = accountRepository.findByIdAndMemberId(accountId, memberId)
             .orElseThrow(() -> ResourceNotFoundException.account(accountId));
 
+        validateFees(req.fees());
+
         Transaction tx = Transaction.builder()
             .account(account)
             .date(req.date())
@@ -44,6 +44,7 @@ public class ManualTransactionService {
             .txType(req.txType())
             .quantity(req.quantity())
             .pricePerUnit(req.pricePerUnit())
+            .fees(req.fees())
             .isManual(true)
             .nativeCurrency(req.currency() != null ? req.currency() : "EUR")
             .build();
@@ -68,12 +69,15 @@ public class ManualTransactionService {
             throw new IllegalArgumentException("Cannot edit a synced transaction");
         }
 
+        validateFees(req.fees());
+
         tx.setDate(req.date());
         tx.setDescription(req.description());
         tx.setAmount(req.amount());
         if (req.txType() != null) tx.setTxType(req.txType());
         if (req.quantity() != null) tx.setQuantity(req.quantity());
         if (req.pricePerUnit() != null) tx.setPricePerUnit(req.pricePerUnit());
+        if (req.fees() != null) tx.setFees(req.fees());
         if (req.currency() != null) tx.setNativeCurrency(req.currency());
         applyInstrumentFields(tx, req);
         transactionRepository.save(tx);
@@ -118,41 +122,25 @@ public class ManualTransactionService {
     }
 
     /**
-     * Normalizes the instrument fields of a BUY/SELL transaction.
-     *
-     * <p>When the ticker field holds an ISIN, it is resolved (via OpenFIGI) to a Yahoo
-     * ticker + display name, so an ISIN entry and the equivalent ticker entry merge into
-     * one position and Yahoo pricing works. A user-supplied {@code name} always wins over
-     * the resolved one. The description is owned here so a raw ISIN never surfaces in the row.
-     *
-     * <p>No-op for cash transactions (they carry no ticker), preserving the caller's description.
+     * Normalizes the instrument fields of a BUY/SELL transaction by delegating to
+     * {@link InstrumentFieldResolver}. No-op for cash transactions (they carry no ticker),
+     * preserving the caller's description.
      */
     private void applyInstrumentFields(Transaction tx, TransactionRequest req) {
-        String input = req.ticker();
-        if (input == null || input.isBlank()) {
+        InstrumentFieldResolver.ResolvedInstrument resolved =
+            instrumentFieldResolver.resolve(req.ticker(), req.name(), tx.getTxType());
+        if (resolved == null) {
             return; // cash transaction — leave description/ticker/name as-is
         }
+        tx.setTicker(resolved.ticker());
+        tx.setName(resolved.name());
+        tx.setDescription(resolved.description());
+    }
 
-        String resolvedTicker;
-        String resolvedName;
-        if (OpenFigiIsinConverter.isIsin(input)) {
-            OpenFigiIsinConverter.TickerResult r = openFigiIsinConverter.resolve(input);
-            resolvedTicker = r.ticker();   // already falls back to the ISIN itself on failure
-            resolvedName = r.name();
-        } else {
-            resolvedTicker = input.trim().toUpperCase();
-            resolvedName = null;
+    private void validateFees(BigDecimal fees) {
+        if (fees != null && fees.signum() < 0) {
+            throw new IllegalArgumentException("Fees cannot be negative");
         }
-
-        String effectiveName = (req.name() != null && !req.name().isBlank())
-            ? req.name().trim()
-            : resolvedName;
-
-        tx.setTicker(resolvedTicker);
-        tx.setName(effectiveName);
-        tx.setDescription(effectiveName != null
-            ? effectiveName
-            : (tx.getTxType() == TransactionType.SELL ? "Vente " : "Achat ") + resolvedTicker);
     }
 
     private void recomputeCashBalance(Account account) {

--- a/backend/src/main/java/com/picsou/service/RealizedPnlService.java
+++ b/backend/src/main/java/com/picsou/service/RealizedPnlService.java
@@ -1,0 +1,137 @@
+package com.picsou.service;
+
+import com.picsou.dto.RealizedPnlResponse;
+import com.picsou.dto.RealizedPnlResponse.ClosedLot;
+import com.picsou.dto.RealizedPnlResponse.TickerRealized;
+import com.picsou.exception.ResourceNotFoundException;
+import com.picsou.model.Account;
+import com.picsou.model.Transaction;
+import com.picsou.model.TransactionType;
+import com.picsou.repository.AccountRepository;
+import com.picsou.repository.TransactionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Computes realized profit/loss on the fly from an account's ordered BUY/SELL transaction stream —
+ * never persisted, mirroring {@code LoanAmortizationService} (the transaction stream is the source
+ * of truth). Uses a moving-average (PMP) cost basis: each BUY adds {@code qty*price + fees} to the
+ * cost pool; each SELL realizes {@code (qty*price - fees) - avgCost*qtySold}. Over-sells are clamped
+ * (no fabricated negative cost) and flagged. All math is in the account's own currency — no re-pricing.
+ *
+ * <p>This is deliberately a separate series from the unrealized {@code HistoryService.buildPnl};
+ * realized gains are never mixed into {@code pnl}/{@code rangePnl}.
+ */
+@Service
+@RequiredArgsConstructor
+public class RealizedPnlService {
+
+    private static final int SCALE = 8;
+
+    private final AccountRepository accountRepository;
+    private final TransactionRepository transactionRepository;
+
+    @Transactional(readOnly = true)
+    public RealizedPnlResponse compute(Long accountId, Long memberId) {
+        Account account = accountRepository.findByIdAndMemberId(accountId, memberId)
+            .orElseThrow(() -> ResourceNotFoundException.account(accountId));
+
+        List<Transaction> stream = transactionRepository.findByAccountIdAndTxTypeInOrderByDateAsc(
+            accountId, List.of(TransactionType.BUY, TransactionType.SELL));
+
+        // Moving-average state per ticker.
+        Map<String, BigDecimal> qtyHeld = new HashMap<>();
+        Map<String, BigDecimal> costPool = new HashMap<>();
+        Map<String, String> latestName = new HashMap<>();
+
+        // Realized accumulators (LinkedHashMap keeps first-sell order for a stable response).
+        Map<String, BigDecimal> realizedByTicker = new LinkedHashMap<>();
+        Map<String, BigDecimal> qtySoldByTicker = new HashMap<>();
+        Map<String, BigDecimal> proceedsByTicker = new HashMap<>();
+        Map<String, BigDecimal> costByTicker = new HashMap<>();
+        Set<String> warnings = new HashSet<>();
+        List<ClosedLot> lots = new ArrayList<>();
+
+        for (Transaction tx : stream) {
+            String ticker = tx.getTicker();
+            if (ticker == null || ticker.isBlank()) {
+                continue;
+            }
+            BigDecimal qty = tx.getQuantity();
+            if (qty == null || qty.signum() <= 0) {
+                continue;
+            }
+            if (tx.getName() != null) {
+                latestName.put(ticker, tx.getName());
+            }
+            BigDecimal price = tx.getPricePerUnit() != null ? tx.getPricePerUnit() : BigDecimal.ZERO;
+            BigDecimal fees = tx.getFees() != null ? tx.getFees() : BigDecimal.ZERO;
+
+            if (tx.getTxType() == TransactionType.BUY) {
+                costPool.merge(ticker, qty.multiply(price).add(fees), BigDecimal::add);
+                qtyHeld.merge(ticker, qty, BigDecimal::add);
+                continue;
+            }
+
+            // SELL — realize against the moving-average cost.
+            BigDecimal held = qtyHeld.getOrDefault(ticker, BigDecimal.ZERO);
+            BigDecimal pool = costPool.getOrDefault(ticker, BigDecimal.ZERO);
+            BigDecimal avgCost = held.signum() > 0
+                ? pool.divide(held, SCALE, RoundingMode.HALF_UP)
+                : BigDecimal.ZERO;
+
+            boolean overSell = qty.compareTo(held) > 0;
+            BigDecimal costedQty = overSell ? held.max(BigDecimal.ZERO) : qty;
+            BigDecimal costOut = scale(avgCost.multiply(costedQty));
+            BigDecimal proceeds = scale(qty.multiply(price).subtract(fees));
+            BigDecimal realized = scale(proceeds.subtract(costOut));
+            if (overSell) {
+                warnings.add(ticker);
+            }
+
+            // Draw down the pool; never let held/pool go negative (no fabricated cost).
+            BigDecimal newHeld = held.subtract(qty);
+            qtyHeld.put(ticker, newHeld.signum() < 0 ? BigDecimal.ZERO : newHeld);
+            BigDecimal newPool = pool.subtract(costOut);
+            costPool.put(ticker, newPool.signum() < 0 ? BigDecimal.ZERO : newPool);
+
+            lots.add(new ClosedLot(ticker, latestName.get(ticker), tx.getDate(), qty, avgCost, proceeds, realized));
+            realizedByTicker.merge(ticker, realized, BigDecimal::add);
+            qtySoldByTicker.merge(ticker, qty, BigDecimal::add);
+            proceedsByTicker.merge(ticker, proceeds, BigDecimal::add);
+            costByTicker.merge(ticker, costOut, BigDecimal::add);
+        }
+
+        List<TickerRealized> byTicker = new ArrayList<>();
+        BigDecimal realizedTotal = BigDecimal.ZERO;
+        for (Map.Entry<String, BigDecimal> e : realizedByTicker.entrySet()) {
+            String ticker = e.getKey();
+            realizedTotal = realizedTotal.add(e.getValue());
+            byTicker.add(new TickerRealized(
+                ticker,
+                latestName.get(ticker),
+                e.getValue(),
+                qtySoldByTicker.get(ticker),
+                proceedsByTicker.get(ticker),
+                costByTicker.get(ticker),
+                warnings.contains(ticker)));
+        }
+
+        return new RealizedPnlResponse(account.getCurrency(), scale(realizedTotal), byTicker, lots);
+    }
+
+    private static BigDecimal scale(BigDecimal v) {
+        return v.setScale(SCALE, RoundingMode.HALF_UP);
+    }
+}

--- a/backend/src/main/java/com/picsou/service/TransactionImportService.java
+++ b/backend/src/main/java/com/picsou/service/TransactionImportService.java
@@ -1,0 +1,255 @@
+package com.picsou.service;
+
+import com.picsou.dto.ColumnMappingDto;
+import com.picsou.dto.CsvDialectDto;
+import com.picsou.dto.TransactionImportPreviewResponse;
+import com.picsou.dto.TransactionImportRequest;
+import com.picsou.dto.TransactionImportResultResponse;
+import com.picsou.dto.TransactionImportResultResponse.RowError;
+import com.picsou.exception.ResourceNotFoundException;
+import com.picsou.imports.TransactionRowMapper;
+import com.picsou.imports.csv.CsvDialect;
+import com.picsou.imports.csv.CsvDialectDetector;
+import com.picsou.imports.csv.CsvReader;
+import com.picsou.imports.csv.CsvValueParser;
+import com.picsou.imports.csv.DecimalStyle;
+import com.picsou.model.Account;
+import com.picsou.model.AccountType;
+import com.picsou.model.Transaction;
+import com.picsou.repository.AccountRepository;
+import com.picsou.repository.TransactionRepository;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Two-phase CSV import of investment transactions into a single target account. Phase one
+ * ({@link #preview}) parses the upload, guesses the dialect + column mapping, and caches the raw
+ * file under a token bound to the account. Phase two ({@link #executeImport}) re-parses with the
+ * user-confirmed dialect, maps each row to a manual BUY/SELL transaction, and recomputes holdings
+ * once. Mirrors {@code FinaryImportService}'s token/cache/TTL shape.
+ */
+@Service
+@RequiredArgsConstructor
+public class TransactionImportService {
+
+    private static final Logger log = LoggerFactory.getLogger(TransactionImportService.class);
+
+    private static final Set<AccountType> INVESTMENT_TYPES =
+        Set.of(AccountType.PEA, AccountType.COMPTE_TITRES, AccountType.CRYPTO);
+
+    private static final int SAMPLE_ROWS = 15;
+
+    private final AccountRepository accountRepository;
+    private final TransactionRepository transactionRepository;
+    private final HoldingComputeService holdingComputeService;
+    private final TransactionRowMapper rowMapper;
+
+    private final ConcurrentHashMap<String, CachedCsv> cache = new ConcurrentHashMap<>();
+
+    record CachedCsv(Long accountId, String content, Instant parsedAt) {}
+
+    // --- Phase 1: preview -------------------------------------------------------------------
+
+    public TransactionImportPreviewResponse preview(Long accountId, Long memberId, MultipartFile file) {
+        getInvestmentAccount(accountId, memberId);
+
+        String content = readContent(file);
+        char delimiter = CsvDialectDetector.detectDelimiter(content);
+        List<List<String>> rows = CsvReader.parse(content, delimiter);
+        if (rows.isEmpty()) {
+            throw new IllegalArgumentException("The file has no rows");
+        }
+
+        DecimalStyle decimal = CsvDialectDetector.detectDecimal(rows);
+        String dateFormat = CsvDialectDetector.detectDateFormat(rows);
+        boolean hasHeader = looksLikeHeader(rows.get(0), decimal);
+
+        List<List<String>> dataRows = hasHeader && rows.size() > 1 ? rows.subList(1, rows.size()) : rows;
+        List<String> detectedColumns = hasHeader ? trimAll(rows.get(0)) : genericColumns(rows);
+        ColumnMappingDto suggestedMapping = hasHeader ? guessMapping(rows.get(0)) : emptyMapping();
+        List<List<String>> sampleRows = dataRows.stream().limit(SAMPLE_ROWS).toList();
+
+        String fileToken = UUID.randomUUID().toString();
+        cache.put(fileToken, new CachedCsv(accountId, content, Instant.now()));
+
+        CsvDialectDto dialect = new CsvDialectDto(String.valueOf(delimiter), decimal.name(), dateFormat);
+        return new TransactionImportPreviewResponse(
+            fileToken, detectedColumns, sampleRows, dataRows.size(), hasHeader, dialect, suggestedMapping);
+    }
+
+    // --- Phase 2: execute -------------------------------------------------------------------
+
+    @Transactional
+    public TransactionImportResultResponse executeImport(Long accountId, Long memberId, TransactionImportRequest req) {
+        Account account = getInvestmentAccount(accountId, memberId);
+
+        CachedCsv cached = cache.get(req.fileToken());
+        if (cached == null) {
+            throw new IllegalArgumentException("Preview expired or invalid -- please re-upload the file");
+        }
+        // Bind the token to its account so a preview cannot be replayed against another account.
+        if (!cached.accountId().equals(accountId)) {
+            throw new IllegalArgumentException("Preview does not belong to this account");
+        }
+
+        CsvDialect dialect = toDialect(req.dialect());
+        List<List<String>> rows = CsvReader.parse(cached.content(), dialect.delimiter());
+        List<List<String>> dataRows = req.hasHeaderRow() && !rows.isEmpty() ? rows.subList(1, rows.size()) : rows;
+
+        List<Transaction> toSave = new ArrayList<>();
+        List<RowError> errors = new ArrayList<>();
+        int rowNumber = req.hasHeaderRow() ? 2 : 1; // 1-based, header is row 1
+
+        for (List<String> row : dataRows) {
+            try {
+                toSave.add(rowMapper.map(row, req.mapping(), dialect,
+                    req.sideValueMap(), req.feesIncludedInAmount(), account));
+            } catch (IllegalArgumentException ex) {
+                errors.add(new RowError(rowNumber, ex.getMessage()));
+            }
+            rowNumber++;
+        }
+
+        if (!toSave.isEmpty()) {
+            transactionRepository.saveAll(toSave);
+            holdingComputeService.recomputeHoldings(account);
+        }
+        cache.remove(req.fileToken());
+
+        log.info("CSV import for account {}: {} imported, {} skipped", accountId, toSave.size(), errors.size());
+        return new TransactionImportResultResponse(toSave.size(), errors.size(), errors);
+    }
+
+    // --- Helpers ----------------------------------------------------------------------------
+
+    private Account getInvestmentAccount(Long accountId, Long memberId) {
+        Account account = accountRepository.findByIdAndMemberId(accountId, memberId)
+            .orElseThrow(() -> ResourceNotFoundException.account(accountId));
+        if (!INVESTMENT_TYPES.contains(account.getType())) {
+            throw new IllegalArgumentException(
+                "CSV transaction import is only available for investment accounts (PEA, CTO, crypto)");
+        }
+        return account;
+    }
+
+    private static String readContent(MultipartFile file) {
+        try {
+            String content = new String(file.getBytes(), StandardCharsets.UTF_8);
+            if (content.isBlank()) {
+                throw new IllegalArgumentException("The file is empty");
+            }
+            return content;
+        } catch (IOException ex) {
+            throw new IllegalArgumentException("Could not read the uploaded file");
+        }
+    }
+
+    private CsvDialect toDialect(CsvDialectDto dto) {
+        char delimiter = (dto == null || dto.delimiter() == null || dto.delimiter().isEmpty())
+            ? ',' : dto.delimiter().charAt(0);
+
+        DecimalStyle decimal = DecimalStyle.DOT;
+        if (dto != null && dto.decimal() != null) {
+            try {
+                decimal = DecimalStyle.valueOf(dto.decimal().trim().toUpperCase());
+            } catch (IllegalArgumentException ignored) {
+                // keep the DOT default
+            }
+        }
+
+        String dateFormat = (dto == null || dto.dateFormat() == null || dto.dateFormat().isBlank())
+            ? "yyyy-MM-dd" : dto.dateFormat().trim();
+        try {
+            DateTimeFormatter.ofPattern(dateFormat);
+        } catch (IllegalArgumentException ex) {
+            throw new IllegalArgumentException("Invalid date format pattern '" + dateFormat + "'");
+        }
+        return new CsvDialect(delimiter, decimal, dateFormat);
+    }
+
+    private static boolean looksLikeHeader(List<String> row, DecimalStyle style) {
+        for (String cell : row) {
+            try {
+                if (CsvValueParser.parseDecimal(cell, style) != null) {
+                    return false; // a numeric cell means this is a data row, not a header
+                }
+            } catch (NumberFormatException ignored) {
+                // non-numeric — consistent with a header cell
+            }
+        }
+        return true;
+    }
+
+    private static List<String> trimAll(List<String> row) {
+        return row.stream().map(c -> c == null ? "" : c.trim()).toList();
+    }
+
+    private static List<String> genericColumns(List<List<String>> rows) {
+        int max = rows.stream().mapToInt(List::size).max().orElse(0);
+        List<String> cols = new ArrayList<>();
+        for (int i = 0; i < max; i++) {
+            cols.add("Column " + (i + 1));
+        }
+        return cols;
+    }
+
+    private static ColumnMappingDto emptyMapping() {
+        return new ColumnMappingDto(null, null, null, null, null, null, null, null, null);
+    }
+
+    private static ColumnMappingDto guessMapping(List<String> header) {
+        Integer date = null, side = null, ticker = null, name = null, quantity = null,
+            unitPrice = null, fees = null, currency = null, amount = null;
+        for (int i = 0; i < header.size(); i++) {
+            String h = header.get(i) == null ? "" : header.get(i).toLowerCase().trim();
+            if (date == null && h.contains("date")) date = i;
+            else if (side == null && (h.contains("sens") || h.contains("side") || h.contains("type")
+                || h.contains("operation") || h.contains("sens")))
+                side = i;
+            else if (ticker == null && (h.contains("isin") || h.contains("ticker") || h.contains("symbol")
+                || h.contains("symbole") || h.contains("valeur") || h.contains("instrument")))
+                ticker = i;
+            else if (name == null && (h.contains("name") || h.contains("nom") || h.contains("libell")
+                || h.contains("designation") || h.contains("label")))
+                name = i;
+            else if (quantity == null && (h.contains("qty") || h.contains("quant") || h.contains("qte")
+                || h.contains("nombre") || h.contains("shares") || h.contains("parts")))
+                quantity = i;
+            else if (fees == null && (h.contains("fee") || h.contains("frais") || h.contains("commission")
+                || h.contains("courtage")))
+                fees = i;
+            else if (unitPrice == null && (h.contains("price") || h.contains("prix") || h.contains("cours")
+                || h.contains("unit")) && !h.contains("total"))
+                unitPrice = i;
+            else if (currency == null && (h.contains("currency") || h.contains("devise")
+                || h.contains("monnaie")))
+                currency = i;
+            else if (amount == null && (h.contains("amount") || h.contains("montant") || h.contains("total")
+                || h.contains("net")))
+                amount = i;
+        }
+        return new ColumnMappingDto(date, side, ticker, name, quantity, unitPrice, fees, currency, amount);
+    }
+
+    /** Evicts cached uploads older than 30 minutes (copy of the Finary importer's TTL sweep). */
+    @Scheduled(fixedDelay = 60_000, initialDelay = 60_000)
+    void cleanupExpiredCache() {
+        Instant cutoff = Instant.now().minusSeconds(1800);
+        cache.entrySet().removeIf(e -> e.getValue().parsedAt().isBefore(cutoff));
+    }
+}

--- a/backend/src/main/java/com/picsou/service/TransactionImportService.java
+++ b/backend/src/main/java/com/picsou/service/TransactionImportService.java
@@ -79,7 +79,9 @@ public class TransactionImportService {
         String dateFormat = CsvDialectDetector.detectDateFormat(rows);
         boolean hasHeader = looksLikeHeader(rows.get(0), decimal);
 
-        List<List<String>> dataRows = hasHeader && rows.size() > 1 ? rows.subList(1, rows.size()) : rows;
+        List<List<String>> dataRows = hasHeader
+            ? (rows.size() > 1 ? rows.subList(1, rows.size()) : List.of())
+            : rows;
         List<String> detectedColumns = hasHeader ? trimAll(rows.get(0)) : genericColumns(rows);
         ColumnMappingDto suggestedMapping = hasHeader ? guessMapping(rows.get(0)) : emptyMapping();
         List<List<String>> sampleRows = dataRows.stream().limit(SAMPLE_ROWS).toList();

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -39,8 +39,10 @@ spring:
 
   servlet:
     multipart:
-      max-file-size: 1MB
-      max-request-size: 1MB
+      # 10MB accommodates multi-year CSV transaction histories; the import endpoint is
+      # member-scoped and IP-throttled, so this does not widen the abuse surface.
+      max-file-size: 10MB
+      max-request-size: 10MB
 
   # Embedded MCP server (Model Context Protocol). Transport is HTTP+SSE — the only transport
   # Spring AI 1.0.3 / MCP SDK 0.10.0 ship (there is no Streamable HTTP on this version). Both

--- a/backend/src/main/resources/db/migration/V53__transaction_fees.sql
+++ b/backend/src/main/resources/db/migration/V53__transaction_fees.sql
@@ -1,0 +1,6 @@
+-- Adds a per-transaction fees column for BUY/SELL rows (PEA/CTO/CRYPTO).
+-- Nullable: existing rows have no recorded fee and are treated as zero downstream
+-- (HoldingComputeService, TransactionAmountCalculator). Fees fold into the PMP
+-- (average buy-in) cost basis on BUY transactions, matching the French PEA tax
+-- convention of including acquisition costs in the cost basis.
+ALTER TABLE transaction ADD COLUMN fees NUMERIC(20, 8) NULL;

--- a/backend/src/test/java/com/picsou/imports/TransactionAmountCalculatorTest.java
+++ b/backend/src/test/java/com/picsou/imports/TransactionAmountCalculatorTest.java
@@ -1,0 +1,57 @@
+package com.picsou.imports;
+
+import com.picsou.model.TransactionType;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TransactionAmountCalculatorTest {
+
+    @Test
+    void buy_isNegativeGrossPlusFees() {
+        // -(10 * 85.20 + 1.00) = -853.00 — a BUY is a cash outflow and fees add to the cost.
+        BigDecimal amount = TransactionAmountCalculator.signedAmount(
+            TransactionType.BUY, new BigDecimal("10"), new BigDecimal("85.20"), new BigDecimal("1.00"));
+        assertThat(amount).isEqualByComparingTo("-853.00");
+    }
+
+    @Test
+    void sell_isPositiveGrossMinusFees() {
+        // +(10 * 92.50 - 1.00) = 924.00 — a SELL is a cash inflow, net of fees.
+        BigDecimal amount = TransactionAmountCalculator.signedAmount(
+            TransactionType.SELL, new BigDecimal("10"), new BigDecimal("92.50"), new BigDecimal("1.00"));
+        assertThat(amount).isEqualByComparingTo("924.00");
+    }
+
+    @Test
+    void nullFees_treatedAsZero() {
+        assertThat(TransactionAmountCalculator.signedAmount(
+            TransactionType.BUY, new BigDecimal("2"), new BigDecimal("50"), null))
+            .isEqualByComparingTo("-100");
+        assertThat(TransactionAmountCalculator.signedAmount(
+            TransactionType.SELL, new BigDecimal("2"), new BigDecimal("50"), null))
+            .isEqualByComparingTo("100");
+    }
+
+    @Test
+    void nullQuantityOrPrice_treatedAsZero() {
+        assertThat(TransactionAmountCalculator.signedAmount(
+            TransactionType.BUY, null, new BigDecimal("50"), new BigDecimal("2")))
+            .isEqualByComparingTo("-2");   // -(0 + 2)
+        assertThat(TransactionAmountCalculator.signedAmount(
+            TransactionType.SELL, new BigDecimal("3"), null, new BigDecimal("1")))
+            .isEqualByComparingTo("-1");   // +(0 - 1)
+    }
+
+    @Test
+    void buyAmount_negated_equalsVwapCostContribution() {
+        // Cross-check the signing seam vs the PMP numerator: -(buyAmount) == qty*price + fees.
+        BigDecimal qty = new BigDecimal("7");
+        BigDecimal price = new BigDecimal("123.45");
+        BigDecimal fees = new BigDecimal("3.30");
+        BigDecimal buyAmount = TransactionAmountCalculator.signedAmount(TransactionType.BUY, qty, price, fees);
+        assertThat(buyAmount.negate()).isEqualByComparingTo(qty.multiply(price).add(fees));
+    }
+}

--- a/backend/src/test/java/com/picsou/imports/TransactionRowMapperTest.java
+++ b/backend/src/test/java/com/picsou/imports/TransactionRowMapperTest.java
@@ -1,0 +1,144 @@
+package com.picsou.imports;
+
+import com.picsou.dto.ColumnMappingDto;
+import com.picsou.imports.csv.CsvDialect;
+import com.picsou.imports.csv.DecimalStyle;
+import com.picsou.model.Account;
+import com.picsou.model.Transaction;
+import com.picsou.model.TransactionType;
+import com.picsou.service.InstrumentFieldResolver;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TransactionRowMapperTest {
+
+    @Mock InstrumentFieldResolver instrumentFieldResolver;
+    TransactionRowMapper mapper;
+
+    private final Account account = Account.builder().id(1L).currency("EUR").build();
+    private final CsvDialect dialect = new CsvDialect(',', DecimalStyle.DOT, "yyyy-MM-dd");
+
+    @BeforeEach
+    void setUp() {
+        mapper = new TransactionRowMapper(instrumentFieldResolver);
+    }
+
+    private void stubResolver() {
+        lenient().when(instrumentFieldResolver.resolve(any(), any(), any()))
+            .thenReturn(new InstrumentFieldResolver.ResolvedInstrument("AAPL", "Apple", "Apple"));
+    }
+
+    // columns: 0=date 1=side 2=ticker 3=qty 4=price 5=fees
+    private ColumnMappingDto mappingWithPrice() {
+        return new ColumnMappingDto(0, 1, 2, null, 3, 4, 5, null, null);
+    }
+
+    @Test
+    void buyRow_signsAmountWithFees() {
+        stubResolver();
+        List<String> row = List.of("2024-01-15", "BUY", "AAPL", "10", "85.20", "1.00");
+
+        Transaction tx = mapper.map(row, mappingWithPrice(), dialect, null, false, account);
+
+        assertThat(tx.getTxType()).isEqualTo(TransactionType.BUY);
+        assertThat(tx.getQuantity()).isEqualByComparingTo("10");
+        assertThat(tx.getPricePerUnit()).isEqualByComparingTo("85.20");
+        assertThat(tx.getFees()).isEqualByComparingTo("1.00");
+        assertThat(tx.getAmount()).isEqualByComparingTo("-853.00"); // -(10*85.20 + 1.00)
+        assertThat(tx.getTicker()).isEqualTo("AAPL");
+        assertThat(tx.isManual()).isTrue();
+        assertThat(tx.getNativeCurrency()).isEqualTo("EUR");
+    }
+
+    @Test
+    void sellRow_signsAmountWithFees() {
+        stubResolver();
+        List<String> row = List.of("2024-06-02", "SELL", "AAPL", "10", "92.50", "1.00");
+
+        Transaction tx = mapper.map(row, mappingWithPrice(), dialect, null, false, account);
+
+        assertThat(tx.getTxType()).isEqualTo(TransactionType.SELL);
+        assertThat(tx.getAmount()).isEqualByComparingTo("924.00"); // +(10*92.50 - 1.00)
+    }
+
+    @Test
+    void sideResolvedFromValueMap() {
+        stubResolver();
+        List<String> row = List.of("2024-01-15", "Achat", "AAPL", "10", "85.20", "0");
+
+        Transaction tx = mapper.map(row, mappingWithPrice(), dialect, Map.of("Achat", "BUY"), false, account);
+
+        assertThat(tx.getTxType()).isEqualTo(TransactionType.BUY);
+    }
+
+    @Test
+    void sideResolvedFromAmountSignWhenNoSideColumn() {
+        stubResolver();
+        // columns: 0=date 1=ticker 2=qty 3=amount ; no side, no unit price
+        ColumnMappingDto mapping = new ColumnMappingDto(0, null, 1, null, 2, null, null, null, 3);
+        List<String> row = List.of("2024-01-15", "AAPL", "10", "-853.00");
+
+        Transaction tx = mapper.map(row, mapping, dialect, null, false, account);
+
+        assertThat(tx.getTxType()).isEqualTo(TransactionType.BUY);      // negative amount = outflow = BUY
+        assertThat(tx.getPricePerUnit()).isEqualByComparingTo("85.30"); // 853 / 10
+    }
+
+    @Test
+    void priceDerivedFromAmountWithFeesIncluded() {
+        stubResolver();
+        // columns: 0=date 1=side 2=ticker 3=qty 4=amount 5=fees ; no unit price
+        ColumnMappingDto mapping = new ColumnMappingDto(0, 1, 2, null, 3, null, 5, null, 4);
+        List<String> row = List.of("2024-01-15", "BUY", "AAPL", "10", "-854.00", "1.00");
+
+        Transaction tx = mapper.map(row, mapping, dialect, null, true, account);
+
+        // amount nets fees: gross = 854 - 1 = 853 → unit price 85.30
+        assertThat(tx.getPricePerUnit()).isEqualByComparingTo("85.30");
+        assertThat(tx.getFees()).isEqualByComparingTo("1.00");
+        assertThat(tx.getAmount()).isEqualByComparingTo("-854.00"); // -(10*85.30 + 1.00)
+    }
+
+    @Test
+    void missingDate_throws() {
+        stubResolver();
+        List<String> row = List.of("", "BUY", "AAPL", "10", "85.20", "1.00");
+
+        assertThatThrownBy(() -> mapper.map(row, mappingWithPrice(), dialect, null, false, account))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("date");
+    }
+
+    @Test
+    void nonPositiveQuantity_throws() {
+        stubResolver();
+        List<String> row = List.of("2024-01-15", "BUY", "AAPL", "0", "85.20", "1.00");
+
+        assertThatThrownBy(() -> mapper.map(row, mappingWithPrice(), dialect, null, false, account))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("quantity");
+    }
+
+    @Test
+    void blankTicker_throws() {
+        when(instrumentFieldResolver.resolve(any(), any(), any())).thenReturn(null);
+        List<String> row = List.of("2024-01-15", "BUY", "", "10", "85.20", "1.00");
+
+        assertThatThrownBy(() -> mapper.map(row, mappingWithPrice(), dialect, null, false, account))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("ticker");
+    }
+}

--- a/backend/src/test/java/com/picsou/imports/TransactionRowMapperTest.java
+++ b/backend/src/test/java/com/picsou/imports/TransactionRowMapperTest.java
@@ -113,6 +113,28 @@ class TransactionRowMapperTest {
     }
 
     @Test
+    void sideSingleLetterAndExplicitTokens() {
+        stubResolver();
+        assertThat(mapper.map(List.of("2024-01-15", "s", "AAPL", "10", "85.20", "0"),
+            mappingWithPrice(), dialect, null, false, account).getTxType()).isEqualTo(TransactionType.SELL);
+        assertThat(mapper.map(List.of("2024-01-15", "Sale", "AAPL", "10", "85.20", "0"),
+            mappingWithPrice(), dialect, null, false, account).getTxType()).isEqualTo(TransactionType.SELL);
+        assertThat(mapper.map(List.of("2024-01-15", "b", "AAPL", "10", "85.20", "0"),
+            mappingWithPrice(), dialect, null, false, account).getTxType()).isEqualTo(TransactionType.BUY);
+    }
+
+    @Test
+    void ambiguousSideWordWithNoAmount_throws() {
+        stubResolver();
+        // "Souscription" starts with 's' but must NOT be read as a sell; with no amount column
+        // the side is genuinely undeterminable.
+        List<String> row = List.of("2024-01-15", "Souscription", "AAPL", "10", "85.20", "0");
+        assertThatThrownBy(() -> mapper.map(row, mappingWithPrice(), dialect, null, false, account))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("BUY/SELL");
+    }
+
+    @Test
     void missingDate_throws() {
         stubResolver();
         List<String> row = List.of("", "BUY", "AAPL", "10", "85.20", "1.00");

--- a/backend/src/test/java/com/picsou/imports/csv/CsvDialectDetectorTest.java
+++ b/backend/src/test/java/com/picsou/imports/csv/CsvDialectDetectorTest.java
@@ -1,0 +1,60 @@
+package com.picsou.imports.csv;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CsvDialectDetectorTest {
+
+    @Test
+    void detectsSemicolonDelimiter() {
+        assertThat(CsvDialectDetector.detectDelimiter("date;side;ticker;qty\n2024-01-01;BUY;AAPL;10")).isEqualTo(';');
+    }
+
+    @Test
+    void detectsCommaDelimiter() {
+        assertThat(CsvDialectDetector.detectDelimiter("date,side,ticker,qty")).isEqualTo(',');
+    }
+
+    @Test
+    void detectsTabDelimiter() {
+        assertThat(CsvDialectDetector.detectDelimiter("date\tside\tticker")).isEqualTo('\t');
+    }
+
+    @Test
+    void detectsCommaDecimalFromFrenchSample() {
+        List<List<String>> rows = List.of(
+            List.of("date", "price"),
+            List.of("2024-01-01", "1 234,56"),
+            List.of("2024-02-01", "85,20"));
+        assertThat(CsvDialectDetector.detectDecimal(rows)).isEqualTo(DecimalStyle.COMMA);
+    }
+
+    @Test
+    void detectsDotDecimalFromExportSample() {
+        List<List<String>> rows = List.of(
+            List.of("date", "price"),
+            List.of("2024-01-01", "1234.56"),
+            List.of("2024-02-01", "85.20"));
+        assertThat(CsvDialectDetector.detectDecimal(rows)).isEqualTo(DecimalStyle.DOT);
+    }
+
+    @Test
+    void detectsDayFirstDateFormat() {
+        List<List<String>> rows = List.of(
+            List.of("date", "x"),
+            List.of("15/03/2024", "a"),
+            List.of("28/03/2024", "b"));
+        assertThat(CsvDialectDetector.detectDateFormat(rows)).isEqualTo("dd/MM/yyyy");
+    }
+
+    @Test
+    void detectsIsoDateFormat() {
+        List<List<String>> rows = List.of(
+            List.of("date", "x"),
+            List.of("2024-03-15", "a"));
+        assertThat(CsvDialectDetector.detectDateFormat(rows)).isEqualTo("yyyy-MM-dd");
+    }
+}

--- a/backend/src/test/java/com/picsou/imports/csv/CsvReaderTest.java
+++ b/backend/src/test/java/com/picsou/imports/csv/CsvReaderTest.java
@@ -1,0 +1,67 @@
+package com.picsou.imports.csv;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CsvReaderTest {
+
+    @Test
+    void parsesCommaDelimited() {
+        List<List<String>> rows = CsvReader.parse("a,b,c\n1,2,3\n", ',');
+        assertThat(rows).containsExactly(List.of("a", "b", "c"), List.of("1", "2", "3"));
+    }
+
+    @Test
+    void parsesSemicolonDelimited() {
+        List<List<String>> rows = CsvReader.parse("a;b;c\n1;2;3", ';');
+        assertThat(rows).containsExactly(List.of("a", "b", "c"), List.of("1", "2", "3"));
+    }
+
+    @Test
+    void parsesTabDelimited() {
+        List<List<String>> rows = CsvReader.parse("a\tb\n1\t2", '\t');
+        assertThat(rows).containsExactly(List.of("a", "b"), List.of("1", "2"));
+    }
+
+    @Test
+    void quotedFieldMayContainTheDelimiter() {
+        List<List<String>> rows = CsvReader.parse("\"Lynch, Peter\",100", ',');
+        assertThat(rows).containsExactly(List.of("Lynch, Peter", "100"));
+    }
+
+    @Test
+    void doubledQuotesAreUnescaped() {
+        List<List<String>> rows = CsvReader.parse("\"a \"\"quoted\"\" word\",b", ',');
+        assertThat(rows).containsExactly(List.of("a \"quoted\" word", "b"));
+    }
+
+    @Test
+    void quotedFieldMayContainNewline() {
+        List<List<String>> rows = CsvReader.parse("\"line1\nline2\",b", ',');
+        assertThat(rows).containsExactly(List.of("line1\nline2", "b"));
+    }
+
+    @Test
+    void stripsLeadingBom() {
+        List<List<String>> rows = CsvReader.parse("\uFEFFa,b", ',');
+        assertThat(rows).containsExactly(List.of("a", "b"));
+    }
+
+    @Test
+    void skipsBlankLinesButKeepsEmptyCells() {
+        List<List<String>> rows = CsvReader.parse("a,b\n\n,,\n1,2\n", ',');
+        assertThat(rows).containsExactly(
+            List.of("a", "b"),
+            List.of("", "", ""),
+            List.of("1", "2"));
+    }
+
+    @Test
+    void handlesCrlfLineEndings() {
+        List<List<String>> rows = CsvReader.parse("a,b\r\n1,2\r\n", ',');
+        assertThat(rows).containsExactly(List.of("a", "b"), List.of("1", "2"));
+    }
+}

--- a/backend/src/test/java/com/picsou/imports/csv/CsvValueParserTest.java
+++ b/backend/src/test/java/com/picsou/imports/csv/CsvValueParserTest.java
@@ -1,0 +1,60 @@
+package com.picsou.imports.csv;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeParseException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class CsvValueParserTest {
+
+    @Test
+    void parsesCommaDecimalWithThousands() {
+        assertThat(CsvValueParser.parseDecimal("1.234,56", DecimalStyle.COMMA)).isEqualByComparingTo("1234.56");
+        assertThat(CsvValueParser.parseDecimal("1 234,56", DecimalStyle.COMMA)).isEqualByComparingTo("1234.56");
+        assertThat(CsvValueParser.parseDecimal("-12,5", DecimalStyle.COMMA)).isEqualByComparingTo("-12.5");
+    }
+
+    @Test
+    void parsesDotDecimalWithThousands() {
+        assertThat(CsvValueParser.parseDecimal("1,234.56", DecimalStyle.DOT)).isEqualByComparingTo("1234.56");
+        assertThat(CsvValueParser.parseDecimal("1234.56", DecimalStyle.DOT)).isEqualByComparingTo("1234.56");
+        assertThat(CsvValueParser.parseDecimal("+7.5", DecimalStyle.DOT)).isEqualByComparingTo("7.5");
+    }
+
+    @Test
+    void stripsCurrencySymbols() {
+        assertThat(CsvValueParser.parseDecimal("85,20 €", DecimalStyle.COMMA)).isEqualByComparingTo("85.20");
+    }
+
+    @Test
+    void blankOrNull_returnsNull() {
+        assertThat(CsvValueParser.parseDecimal(null, DecimalStyle.DOT)).isNull();
+        assertThat(CsvValueParser.parseDecimal("   ", DecimalStyle.DOT)).isNull();
+    }
+
+    @Test
+    void nonNumeric_throws() {
+        assertThatThrownBy(() -> CsvValueParser.parseDecimal("abc", DecimalStyle.DOT))
+            .isInstanceOf(NumberFormatException.class);
+    }
+
+    @Test
+    void parsesDatesByPattern() {
+        assertThat(CsvValueParser.parseDate("15/03/2024", "dd/MM/yyyy")).isEqualTo(LocalDate.of(2024, 3, 15));
+        assertThat(CsvValueParser.parseDate("2024-03-15", "yyyy-MM-dd")).isEqualTo(LocalDate.of(2024, 3, 15));
+    }
+
+    @Test
+    void blankDate_returnsNull() {
+        assertThat(CsvValueParser.parseDate("  ", "yyyy-MM-dd")).isNull();
+    }
+
+    @Test
+    void unparseableDate_throws() {
+        assertThatThrownBy(() -> CsvValueParser.parseDate("2024-13-40", "yyyy-MM-dd"))
+            .isInstanceOf(DateTimeParseException.class);
+    }
+}

--- a/backend/src/test/java/com/picsou/service/HoldingComputeServiceTest.java
+++ b/backend/src/test/java/com/picsou/service/HoldingComputeServiceTest.java
@@ -58,6 +58,20 @@ class HoldingComputeServiceTest {
                 .build();
     }
 
+    private Transaction buyTxWithFees(String ticker, String qty, String price, String fees) {
+        return Transaction.builder()
+                .account(account(1L))
+                .date(LocalDate.of(2024, 1, 1))
+                .description("BUY " + ticker)
+                .amount(BigDecimal.ZERO)
+                .txType(TransactionType.BUY)
+                .ticker(ticker)
+                .quantity(new BigDecimal(qty))
+                .pricePerUnit(price != null ? new BigDecimal(price) : null)
+                .fees(fees != null ? new BigDecimal(fees) : null)
+                .build();
+    }
+
     private Transaction buyTxWithName(String ticker, String qty, String price, String name, LocalDate date) {
         return Transaction.builder()
                 .account(account(1L))
@@ -118,6 +132,72 @@ class HoldingComputeServiceTest {
         assertThat(h.getQuantity()).isEqualByComparingTo("30");
         // VWAP = 5000 / 30 = 166.66666667
         assertThat(h.getAverageBuyIn()).isEqualByComparingTo("166.66666667");
+    }
+
+    @Test
+    void buyWithFees_foldsFeesIntoAverageBuyIn() {
+        Account account = account(1L);
+        // Buy 10 @ 100 with 5 fees → averageBuyIn = (10*100 + 5) / 10 = 100.5 (French PEA PMP convention)
+        Transaction buy = buyTxWithFees("AAPL", "10", "100.00", "5.00");
+
+        when(transactionRepository.findByAccountIdAndTxTypeInOrderByDateAsc(eq(1L), anyList()))
+                .thenReturn(List.of(buy));
+        when(accountHoldingRepository.findByAccount_Id(1L))
+                .thenReturn(List.of());
+
+        holdingComputeService.recomputeHoldings(account);
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<List<AccountHolding>> captor = ArgumentCaptor.forClass(List.class);
+        verify(accountHoldingRepository).saveAll(captor.capture());
+
+        AccountHolding h = captor.getValue().get(0);
+        assertThat(h.getQuantity()).isEqualByComparingTo("10");
+        assertThat(h.getAverageBuyIn()).isEqualByComparingTo("100.50000000");
+    }
+
+    @Test
+    void multipleBuysWithFees_foldsAllFeesIntoVwap() {
+        Account account = account(1L);
+        // (10*100 + 5) + (10*200 + 5) = 1005 + 2005 = 3010 over 20 → 150.5
+        Transaction buy1 = buyTxWithFees("ETH", "10", "100.00", "5.00");
+        Transaction buy2 = buyTxWithFees("ETH", "10", "200.00", "5.00");
+
+        when(transactionRepository.findByAccountIdAndTxTypeInOrderByDateAsc(eq(1L), anyList()))
+                .thenReturn(List.of(buy1, buy2));
+        when(accountHoldingRepository.findByAccount_Id(1L))
+                .thenReturn(List.of());
+
+        holdingComputeService.recomputeHoldings(account);
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<List<AccountHolding>> captor = ArgumentCaptor.forClass(List.class);
+        verify(accountHoldingRepository).saveAll(captor.capture());
+
+        AccountHolding h = captor.getValue().get(0);
+        assertThat(h.getQuantity()).isEqualByComparingTo("20");
+        assertThat(h.getAverageBuyIn()).isEqualByComparingTo("150.50000000");
+    }
+
+    @Test
+    void nullFees_treatedAsZeroInVwap() {
+        Account account = account(1L);
+        // No fees recorded → averageBuyIn = plain VWAP = 100
+        Transaction buy = buyTxWithFees("BTC", "10", "100.00", null);
+
+        when(transactionRepository.findByAccountIdAndTxTypeInOrderByDateAsc(eq(1L), anyList()))
+                .thenReturn(List.of(buy));
+        when(accountHoldingRepository.findByAccount_Id(1L))
+                .thenReturn(List.of());
+
+        holdingComputeService.recomputeHoldings(account);
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<List<AccountHolding>> captor = ArgumentCaptor.forClass(List.class);
+        verify(accountHoldingRepository).saveAll(captor.capture());
+
+        AccountHolding h = captor.getValue().get(0);
+        assertThat(h.getAverageBuyIn()).isEqualByComparingTo("100.00000000");
     }
 
     @Test

--- a/backend/src/test/java/com/picsou/service/InstrumentFieldResolverTest.java
+++ b/backend/src/test/java/com/picsou/service/InstrumentFieldResolverTest.java
@@ -1,0 +1,76 @@
+package com.picsou.service;
+
+import com.picsou.adapter.OpenFigiIsinConverter;
+import com.picsou.model.TransactionType;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class InstrumentFieldResolverTest {
+
+    @Mock OpenFigiIsinConverter openFigiIsinConverter;
+    @InjectMocks InstrumentFieldResolver resolver;
+
+    @Test
+    void blankInput_returnsNull() {
+        assertThat(resolver.resolve(null, null, TransactionType.BUY)).isNull();
+        assertThat(resolver.resolve("   ", "X", TransactionType.SELL)).isNull();
+        verify(openFigiIsinConverter, never()).resolve(any());
+    }
+
+    @Test
+    void isin_resolvesTickerNameAndDescription() {
+        when(openFigiIsinConverter.resolve("IE00B4L5Y983"))
+            .thenReturn(new OpenFigiIsinConverter.TickerResult("IWDA.AS", "iShares Core MSCI World UCITS ETF"));
+
+        InstrumentFieldResolver.ResolvedInstrument r =
+            resolver.resolve("IE00B4L5Y983", null, TransactionType.BUY);
+
+        // ISIN normalized to the Yahoo ticker so positions merge and pricing works.
+        assertThat(r.ticker()).isEqualTo("IWDA.AS");
+        assertThat(r.name()).isEqualTo("iShares Core MSCI World UCITS ETF");
+        // The raw ISIN never surfaces in the description.
+        assertThat(r.description()).isEqualTo("iShares Core MSCI World UCITS ETF");
+    }
+
+    @Test
+    void plainTicker_uppercasedNoResolveAndAchatDescription() {
+        InstrumentFieldResolver.ResolvedInstrument r =
+            resolver.resolve("iwda.as", null, TransactionType.BUY);
+
+        assertThat(r.ticker()).isEqualTo("IWDA.AS");
+        assertThat(r.name()).isNull();
+        assertThat(r.description()).isEqualTo("Achat IWDA.AS");
+        verify(openFigiIsinConverter, never()).resolve(any());
+    }
+
+    @Test
+    void userName_winsOverResolvedName() {
+        when(openFigiIsinConverter.resolve("IE00B4L5Y983"))
+            .thenReturn(new OpenFigiIsinConverter.TickerResult("IWDA.AS", "resolved name"));
+
+        InstrumentFieldResolver.ResolvedInstrument r =
+            resolver.resolve("IE00B4L5Y983", "My World ETF", TransactionType.BUY);
+
+        assertThat(r.ticker()).isEqualTo("IWDA.AS");
+        assertThat(r.name()).isEqualTo("My World ETF");
+        assertThat(r.description()).isEqualTo("My World ETF");
+    }
+
+    @Test
+    void sellSide_buildsVenteDescriptionWhenNoName() {
+        InstrumentFieldResolver.ResolvedInstrument r =
+            resolver.resolve("aapl", null, TransactionType.SELL);
+
+        assertThat(r.description()).isEqualTo("Vente AAPL");
+    }
+}

--- a/backend/src/test/java/com/picsou/service/ManualTransactionServiceTest.java
+++ b/backend/src/test/java/com/picsou/service/ManualTransactionServiceTest.java
@@ -11,9 +11,9 @@ import com.picsou.model.Transaction;
 import com.picsou.model.TransactionType;
 import com.picsou.repository.AccountRepository;
 import com.picsou.repository.TransactionRepository;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -35,7 +35,16 @@ class ManualTransactionServiceTest {
     @Mock FinaryPersistenceHelper finaryPersistenceHelper;
     @Mock OpenFigiIsinConverter openFigiIsinConverter;
 
-    @InjectMocks ManualTransactionService manualTransactionService;
+    ManualTransactionService manualTransactionService;
+
+    @BeforeEach
+    void setUp() {
+        // Inject a REAL InstrumentFieldResolver over the mocked OpenFigiIsinConverter so the
+        // end-to-end ISIN/ticker resolution assertions below exercise the actual logic.
+        manualTransactionService = new ManualTransactionService(
+            accountRepository, transactionRepository, holdingComputeService,
+            finaryPersistenceHelper, new InstrumentFieldResolver(openFigiIsinConverter));
+    }
 
     private Account checkingAccount() {
         return Account.builder()
@@ -347,6 +356,56 @@ class ManualTransactionServiceTest {
         // The raw ISIN must never surface in the transaction row.
         assertThat(result.description()).isEqualTo("iShares Core MSCI World UCITS ETF");
         verify(holdingComputeService).recomputeHoldings(account);
+    }
+
+    @Test
+    void addTransaction_investmentAccount_persistsFees() {
+        Account account = peaAccount();
+        TransactionRequest req = new TransactionRequest(
+            LocalDate.of(2024, 3, 10),
+            "Buy AAPL",
+            new BigDecimal("-1001.50"),
+            TransactionType.BUY,
+            "AAPL",
+            null,
+            new BigDecimal("10"),
+            new BigDecimal("100"),
+            "EUR",
+            new BigDecimal("1.50")
+        );
+
+        when(accountRepository.findByIdAndMemberId(2L, 10L)).thenReturn(Optional.of(account));
+        when(transactionRepository.save(any(Transaction.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        TransactionResponse result = manualTransactionService.addTransaction(2L, 10L, req);
+
+        assertThat(result.fees()).isEqualByComparingTo("1.50");
+        verify(holdingComputeService).recomputeHoldings(account);
+    }
+
+    @Test
+    void addTransaction_negativeFees_throws() {
+        Account account = peaAccount();
+        TransactionRequest req = new TransactionRequest(
+            LocalDate.of(2024, 3, 10),
+            "Buy AAPL",
+            new BigDecimal("-1000"),
+            TransactionType.BUY,
+            "AAPL",
+            null,
+            new BigDecimal("10"),
+            new BigDecimal("100"),
+            "EUR",
+            new BigDecimal("-1")
+        );
+
+        when(accountRepository.findByIdAndMemberId(2L, 10L)).thenReturn(Optional.of(account));
+
+        assertThatThrownBy(() -> manualTransactionService.addTransaction(2L, 10L, req))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("Fees");
+
+        verify(transactionRepository, never()).save(any());
     }
 
     @Test

--- a/backend/src/test/java/com/picsou/service/RealizedPnlServiceTest.java
+++ b/backend/src/test/java/com/picsou/service/RealizedPnlServiceTest.java
@@ -1,0 +1,136 @@
+package com.picsou.service;
+
+import com.picsou.dto.RealizedPnlResponse;
+import com.picsou.model.Account;
+import com.picsou.model.Transaction;
+import com.picsou.model.TransactionType;
+import com.picsou.repository.AccountRepository;
+import com.picsou.repository.TransactionRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class RealizedPnlServiceTest {
+
+    @Mock AccountRepository accountRepository;
+    @Mock TransactionRepository transactionRepository;
+    @InjectMocks RealizedPnlService service;
+
+    private Account account(String currency) {
+        return Account.builder().id(1L).name("PEA").currency(currency).build();
+    }
+
+    private Transaction buy(String ticker, String qty, String price, String fees) {
+        return Transaction.builder()
+            .account(account("EUR"))
+            .date(LocalDate.of(2024, 1, 1))
+            .txType(TransactionType.BUY)
+            .ticker(ticker).name(ticker)
+            .quantity(new BigDecimal(qty))
+            .pricePerUnit(new BigDecimal(price))
+            .fees(fees == null ? null : new BigDecimal(fees))
+            .amount(BigDecimal.ZERO)
+            .build();
+    }
+
+    private Transaction sell(String ticker, String qty, String price, String fees) {
+        return Transaction.builder()
+            .account(account("EUR"))
+            .date(LocalDate.of(2024, 6, 1))
+            .txType(TransactionType.SELL)
+            .ticker(ticker).name(ticker)
+            .quantity(new BigDecimal(qty))
+            .pricePerUnit(new BigDecimal(price))
+            .fees(fees == null ? null : new BigDecimal(fees))
+            .amount(BigDecimal.ZERO)
+            .build();
+    }
+
+    private RealizedPnlResponse compute(Account account, Transaction... txs) {
+        when(accountRepository.findByIdAndMemberId(1L, 10L)).thenReturn(Optional.of(account));
+        when(transactionRepository.findByAccountIdAndTxTypeInOrderByDateAsc(eq(1L), anyList()))
+            .thenReturn(List.of(txs));
+        return service.compute(1L, 10L);
+    }
+
+    @Test
+    void buyThenPartialSell_realizesGainAgainstAverageCost() {
+        // BUY 10 @ 100 → avg 100. SELL 4 @ 150 → proceeds 600, cost 400, realized 200.
+        RealizedPnlResponse r = compute(account("EUR"), buy("AAPL", "10", "100", null), sell("AAPL", "4", "150", null));
+
+        assertThat(r.realizedTotal()).isEqualByComparingTo("200");
+        assertThat(r.lots()).hasSize(1);
+        assertThat(r.byTicker()).hasSize(1);
+        assertThat(r.byTicker().get(0).ticker()).isEqualTo("AAPL");
+        assertThat(r.byTicker().get(0).quantitySold()).isEqualByComparingTo("4");
+        assertThat(r.byTicker().get(0).realized()).isEqualByComparingTo("200");
+        assertThat(r.byTicker().get(0).warning()).isFalse();
+    }
+
+    @Test
+    void multipleBuys_averageCostThenFullClose() {
+        // BUY 10 @ 100 + BUY 10 @ 200 → avg 150. SELL 20 @ 180 → proceeds 3600, cost 3000, realized 600.
+        RealizedPnlResponse r = compute(account("EUR"),
+            buy("ETF", "10", "100", null), buy("ETF", "10", "200", null), sell("ETF", "20", "180", null));
+
+        assertThat(r.realizedTotal()).isEqualByComparingTo("600");
+    }
+
+    @Test
+    void buyFeesRaiseCost_sellFeesReduceProceeds() {
+        // BUY 10 @ 100 fees 5 → avg 100.5. SELL 10 @ 120 fees 5 → proceeds 1195, cost 1005, realized 190.
+        RealizedPnlResponse r = compute(account("EUR"),
+            buy("VWCE", "10", "100", "5"), sell("VWCE", "10", "120", "5"));
+
+        assertThat(r.realizedTotal()).isEqualByComparingTo("190");
+        assertThat(r.lots().get(0).avgCost()).isEqualByComparingTo("100.5");
+        assertThat(r.lots().get(0).proceeds()).isEqualByComparingTo("1195");
+    }
+
+    @Test
+    void overSell_clampsCostAndFlagsWarning() {
+        // BUY 5 @ 100 → avg 100. SELL 8 @ 120 → proceeds 960, cost only for 5 units = 500, realized 460.
+        RealizedPnlResponse r = compute(account("EUR"), buy("BTC", "5", "100", null), sell("BTC", "8", "120", null));
+
+        assertThat(r.realizedTotal()).isEqualByComparingTo("460");
+        assertThat(r.byTicker().get(0).warning()).isTrue();
+    }
+
+    @Test
+    void sellWithNoPriorBuy_realizesWholeProceedsWithWarning() {
+        RealizedPnlResponse r = compute(account("EUR"), sell("SOL", "3", "50", null));
+
+        assertThat(r.realizedTotal()).isEqualByComparingTo("150");
+        assertThat(r.byTicker().get(0).warning()).isTrue();
+    }
+
+    @Test
+    void onlyBuys_noRealizedPnl() {
+        RealizedPnlResponse r = compute(account("EUR"), buy("AAPL", "10", "100", null));
+
+        assertThat(r.realizedTotal()).isEqualByComparingTo("0");
+        assertThat(r.byTicker()).isEmpty();
+        assertThat(r.lots()).isEmpty();
+    }
+
+    @Test
+    void responseUsesAccountCurrency() {
+        RealizedPnlResponse r = compute(account("USD"), buy("AAPL", "1", "100", null), sell("AAPL", "1", "110", null));
+
+        assertThat(r.currency()).isEqualTo("USD");
+        assertThat(r.realizedTotal()).isEqualByComparingTo("10");
+    }
+}

--- a/backend/src/test/java/com/picsou/service/TransactionImportServiceTest.java
+++ b/backend/src/test/java/com/picsou/service/TransactionImportServiceTest.java
@@ -130,6 +130,18 @@ class TransactionImportServiceTest {
     }
 
     @Test
+    void preview_headerOnlyFile_reportsZeroDataRows() {
+        when(accountRepository.findByIdAndMemberId(2L, 10L)).thenReturn(Optional.of(pea()));
+
+        TransactionImportPreviewResponse preview =
+            service.preview(2L, 10L, file("date,side,ticker,quantity,price,fees\n"));
+
+        assertThat(preview.hasHeaderRow()).isTrue();
+        assertThat(preview.totalRows()).isZero();
+        assertThat(preview.sampleRows()).isEmpty();
+    }
+
+    @Test
     void executeImport_expiredToken_throws() {
         when(accountRepository.findByIdAndMemberId(2L, 10L)).thenReturn(Optional.of(pea()));
         TransactionImportRequest req =

--- a/backend/src/test/java/com/picsou/service/TransactionImportServiceTest.java
+++ b/backend/src/test/java/com/picsou/service/TransactionImportServiceTest.java
@@ -1,0 +1,175 @@
+package com.picsou.service;
+
+import com.picsou.dto.ColumnMappingDto;
+import com.picsou.dto.CsvDialectDto;
+import com.picsou.dto.TransactionImportPreviewResponse;
+import com.picsou.dto.TransactionImportRequest;
+import com.picsou.dto.TransactionImportResultResponse;
+import com.picsou.exception.ResourceNotFoundException;
+import com.picsou.imports.TransactionRowMapper;
+import com.picsou.model.Account;
+import com.picsou.model.AccountType;
+import com.picsou.model.Transaction;
+import com.picsou.repository.AccountRepository;
+import com.picsou.repository.TransactionRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.mock.web.MockMultipartFile;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TransactionImportServiceTest {
+
+    @Mock AccountRepository accountRepository;
+    @Mock TransactionRepository transactionRepository;
+    @Mock HoldingComputeService holdingComputeService;
+    @Mock InstrumentFieldResolver instrumentFieldResolver;
+
+    TransactionImportService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new TransactionImportService(accountRepository, transactionRepository,
+            holdingComputeService, new TransactionRowMapper(instrumentFieldResolver));
+    }
+
+    private Account pea() {
+        return Account.builder().id(2L).type(AccountType.PEA).currency("EUR").build();
+    }
+
+    private MockMultipartFile file(String content) {
+        return new MockMultipartFile("file", "trades.csv", "text/csv", content.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static final String CSV =
+        "date,side,ticker,quantity,price,fees\n" +
+        "2024-01-15,BUY,AAPL,10,85.20,1.00\n" +
+        "2024-06-02,SELL,AAPL,10,92.50,1.00\n";
+
+    private ColumnMappingDto mapping() {
+        return new ColumnMappingDto(0, 1, 2, null, 3, 4, 5, null, null);
+    }
+
+    private CsvDialectDto dialect() {
+        return new CsvDialectDto(",", "DOT", "yyyy-MM-dd");
+    }
+
+    @Test
+    void preview_detectsColumnsAndCachesToken() {
+        when(accountRepository.findByIdAndMemberId(2L, 10L)).thenReturn(Optional.of(pea()));
+
+        TransactionImportPreviewResponse preview = service.preview(2L, 10L, file(CSV));
+
+        assertThat(preview.hasHeaderRow()).isTrue();
+        assertThat(preview.detectedColumns())
+            .containsExactly("date", "side", "ticker", "quantity", "price", "fees");
+        assertThat(preview.totalRows()).isEqualTo(2);
+        assertThat(preview.fileToken()).isNotBlank();
+        assertThat(preview.suggestedMapping().date()).isEqualTo(0);
+        assertThat(preview.suggestedMapping().quantity()).isEqualTo(3);
+        assertThat(preview.suggestedMapping().fees()).isEqualTo(5);
+    }
+
+    @Test
+    void executeImport_savesRowsAndRecomputesOnce() {
+        when(accountRepository.findByIdAndMemberId(2L, 10L)).thenReturn(Optional.of(pea()));
+        when(instrumentFieldResolver.resolve(any(), any(), any()))
+            .thenReturn(new InstrumentFieldResolver.ResolvedInstrument("AAPL", "Apple", "Apple"));
+
+        String token = service.preview(2L, 10L, file(CSV)).fileToken();
+        TransactionImportRequest req =
+            new TransactionImportRequest(token, mapping(), dialect(), true, false, null);
+
+        TransactionImportResultResponse result = service.executeImport(2L, 10L, req);
+
+        assertThat(result.imported()).isEqualTo(2);
+        assertThat(result.skipped()).isZero();
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<List<Transaction>> captor = ArgumentCaptor.forClass(List.class);
+        verify(transactionRepository).saveAll(captor.capture());
+        assertThat(captor.getValue()).hasSize(2);
+        verify(holdingComputeService, times(1)).recomputeHoldings(any());
+    }
+
+    @Test
+    void executeImport_reportsPerRowErrorsAndStillImportsValidRows() {
+        when(accountRepository.findByIdAndMemberId(2L, 10L)).thenReturn(Optional.of(pea()));
+        when(instrumentFieldResolver.resolve(any(), any(), any()))
+            .thenReturn(new InstrumentFieldResolver.ResolvedInstrument("AAPL", "Apple", "Apple"));
+
+        // second data row has a non-numeric quantity → skipped, first row imported
+        String csv = "date,side,ticker,quantity,price,fees\n"
+            + "2024-01-15,BUY,AAPL,10,85.20,1.00\n"
+            + "2024-02-15,BUY,AAPL,oops,85.20,1.00\n";
+        String token = service.preview(2L, 10L, file(csv)).fileToken();
+        TransactionImportRequest req =
+            new TransactionImportRequest(token, mapping(), dialect(), true, false, null);
+
+        TransactionImportResultResponse result = service.executeImport(2L, 10L, req);
+
+        assertThat(result.imported()).isEqualTo(1);
+        assertThat(result.skipped()).isEqualTo(1);
+        assertThat(result.errors()).hasSize(1);
+        assertThat(result.errors().get(0).rowNumber()).isEqualTo(3); // header=1, first data=2, bad=3
+    }
+
+    @Test
+    void executeImport_expiredToken_throws() {
+        when(accountRepository.findByIdAndMemberId(2L, 10L)).thenReturn(Optional.of(pea()));
+        TransactionImportRequest req =
+            new TransactionImportRequest("nope", mapping(), dialect(), true, false, null);
+
+        assertThatThrownBy(() -> service.executeImport(2L, 10L, req))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("expired");
+    }
+
+    @Test
+    void executeImport_tokenBoundToAnotherAccount_throws() {
+        when(accountRepository.findByIdAndMemberId(2L, 10L)).thenReturn(Optional.of(pea()));
+        Account otherCto = Account.builder().id(3L).type(AccountType.COMPTE_TITRES).currency("EUR").build();
+        when(accountRepository.findByIdAndMemberId(3L, 10L)).thenReturn(Optional.of(otherCto));
+
+        String token = service.preview(2L, 10L, file(CSV)).fileToken(); // bound to account 2
+        TransactionImportRequest req =
+            new TransactionImportRequest(token, mapping(), dialect(), true, false, null);
+
+        assertThatThrownBy(() -> service.executeImport(3L, 10L, req))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("does not belong");
+    }
+
+    @Test
+    void preview_nonInvestmentAccount_throws() {
+        Account checking = Account.builder().id(9L).type(AccountType.CHECKING).currency("EUR").build();
+        when(accountRepository.findByIdAndMemberId(9L, 10L)).thenReturn(Optional.of(checking));
+
+        assertThatThrownBy(() -> service.preview(9L, 10L, file("date\n2024-01-01")))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("investment");
+    }
+
+    @Test
+    void preview_foreignAccount_throws() {
+        when(accountRepository.findByIdAndMemberId(99L, 10L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.preview(99L, 10L, file("date\n2024-01-01")))
+            .isInstanceOf(ResourceNotFoundException.class);
+    }
+}

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -38,6 +38,7 @@
 | 2026-05-31 | [ETF composition from issuer holdings files (no auth)](./decisions/2026-05-31-etf-composition-issuer-holdings.md) | ⚠️ Superseded |
 | 2026-06-01 | [ETF composition via Boursorama (single source)](./decisions/2026-06-01-etf-composition-via-boursorama.md) | Active |
 | 2026-06-05 | [Access-key auth + embedded MCP server](./decisions/2026-06-05-access-key-auth-and-embedded-mcp.md) | Active |
+| 2026-07-11 | [Realized P&L: average-cost, computed on the fly](./decisions/2026-07-11-realized-pnl-average-cost-on-the-fly.md) | Active |
 
 ## Feature notes
 
@@ -62,6 +63,8 @@
 | Live prices (holdings) | 2026-05-19 | [live-prices-holdings.md](./features/live-prices-holdings.md) |
 | Security Insight (asset type + ETF composition) | 2026-06-02 | [security-insight.md](./features/security-insight.md) |
 | Finary import + auto-sync | 2026-04-21 | [finary-import.md](./features/finary-import.md) |
+| CSV transaction import (investment accounts) | 2026-07-11 | [csv-transaction-import.md](./features/csv-transaction-import.md) |
+| Realized P&L on closed positions | 2026-07-11 | [realized-pnl.md](./features/realized-pnl.md) |
 | Manual transactions + holdings derivation | 2026-04-21 | [manual-transactions.md](./features/manual-transactions.md) |
 | BoursoBank sync ⏸ disabled in 1.0.0 | 2026-04-26 | [bourso-bank.md](./features/bourso-bank.md) |
 | Accounts overview (PnL chart + summary card + filters) | 2026-04-13 | [accounts-overview.md](./features/accounts-overview.md) |

--- a/docs/decisions/2026-07-11-realized-pnl-average-cost-on-the-fly.md
+++ b/docs/decisions/2026-07-11-realized-pnl-average-cost-on-the-fly.md
@@ -1,0 +1,58 @@
+# ADR: Realized P&L uses average-cost (PMP) and is computed on the fly
+
+> Date: 2026-07-11
+> Status: ✅ Active
+
+## Context
+
+Issue #38 asks to show gain/loss on **closed** positions. Nothing computed this today: a fully-sold
+position is deleted by `HoldingComputeService` and only unrealized P&L on open holdings exists. Two
+design questions had real alternatives: (1) which cost-basis method to realize gains against, and
+(2) whether to persist the result or recompute it.
+
+## Decision
+
+Compute realized P&L **on the fly** from the ordered BUY/SELL transaction stream, using a
+**moving-average (PMP) cost basis** (buy fees included in cost, sell fees netted from proceeds), in
+the account's own currency. Expose it as its **own** read-only series
+(`GET /api/accounts/{id}/realized-pnl`), never mixed into `pnl`/`rangePnl`. Nothing is persisted.
+
+## Alternatives considered
+
+### Cost basis: FIFO / specific-lot
+
+- **Pros**: Matches some tax regimes (e.g. US) and per-lot reporting.
+- **Cons**: The transaction stream carries **no lot identifiers**, so lots would be an arbitrary
+  reconstruction. Diverges from the existing `averageBuyIn` (already average-cost) and from the
+  French PEA convention (PMP).
+
+### Persist realized gains in a table
+
+- **Pros**: Cheap reads; a fixed audit trail.
+- **Cons**: A second source of truth to keep in sync — every BUY/SELL/fee edit would have to
+  invalidate/recompute it. Needs a migration and a backfill. Sync bugs waiting to happen.
+
+## Reasoning
+
+Average-cost is already the house convention (`HoldingComputeService.averageBuyIn`, `HoldingDedup`)
+and the correct French PEA method, and it's the only method the data actually supports. Computing on
+the fly mirrors the ratified `2026-04-26-loan-amortization-on-the-fly` ADR: the formula over the
+source rows is the single source of truth, so any edit reflects on the next GET with no migration,
+no cache, and no invalidation — a single ordered pass is cheap.
+
+## Trade-offs accepted
+
+- **Open PMP vs realized PMP can differ slightly.** Open holdings use a *global* VWAP over all buys;
+  realized P&L uses a *moving* average recomputed at each sell. They coincide for a buy-then-sell
+  sequence but diverge on interleaved buy→sell→buy. Accepted for consistency with the PEA method and
+  the existing open-position cost basis.
+- **No lot-level tax reporting** (no FIFO / specific-lot).
+- Recomputed on every request (bounded: one pass over an account's BUY/SELL rows).
+
+## Consequences
+
+- New `RealizedPnlService` (no entity, no migration), `RealizedPnlResponse`, and a member-scoped GET.
+- `HistoryService.buildPnl` is untouched — the separation-of-series invariant from
+  `dashboard-liabilities-separation.md` holds.
+- Over-sells clamp (no fabricated negative cost) and flag a warning rather than throwing.
+- Feature note: [realized-pnl.md](../features/realized-pnl.md).

--- a/docs/features/csv-transaction-import.md
+++ b/docs/features/csv-transaction-import.md
@@ -1,0 +1,89 @@
+# Feature: CSV transaction import (investment accounts)
+
+> Last updated: 2026-07-11
+
+## Context
+
+Users want to seed a PEA/CTO (or crypto) account with their broker's trade history without
+re-keying every line ([issue #38](https://github.com/Zoeille/picsou-finance/issues/38)). This
+adds a two-phase, per-account CSV importer that accepts any broker layout — the user maps the
+columns — and writes manual BUY/SELL transactions, folding per-trade fees into the cost basis.
+
+## How it works
+
+Two phases, modelled on the Finary XLSX importer but mapping **columns** into an
+**already-selected account** (not mapping accounts):
+
+1. **Preview** — the raw file is uploaded, the dialect (delimiter / decimal / date format) is
+   sniffed, a best-guess column mapping is built from the header names, and the raw file is cached
+   under a `fileToken` **bound to the target account** (30-min TTL). The response returns the
+   detected columns, a sample of rows, and the guesses — all overridable in the wizard.
+2. **Execute** — the client echoes the `fileToken` plus the (possibly user-adjusted) mapping and
+   dialect. The raw file is **re-parsed** with the confirmed dialect, each row is mapped to a
+   manual BUY/SELL transaction, valid rows are bulk-inserted (`is_manual = true`), and holdings are
+   recomputed **once**. Invalid rows are reported per-row rather than failing the whole file.
+
+### Key files
+
+- `backend/src/main/java/com/picsou/imports/csv/` — `CsvReader` (RFC-4180, configurable delimiter),
+  `CsvDialectDetector` (delimiter/decimal/date sniffing), `CsvValueParser` (`BigDecimal`/`LocalDate`
+  parsing), `CsvDialect` + `DecimalStyle`. Dependency-free; symmetric with the GDPR `CsvWriter`.
+- `backend/src/main/java/com/picsou/imports/TransactionRowMapper.java` — one row → unsaved
+  `Transaction`; reuses `InstrumentFieldResolver` (ISIN→ticker) and `TransactionAmountCalculator`
+  (signed amount incl. fees).
+- `backend/src/main/java/com/picsou/service/TransactionImportService.java` — preview/execute + the
+  `fileToken` cache and its `@Scheduled` TTL sweep.
+- `backend/src/main/java/com/picsou/controller/TransactionImportController.java` —
+  `POST /api/accounts/{id}/transactions/import/preview` (multipart) and
+  `POST /api/accounts/{id}/transactions/import` (JSON, `201`). Member-scoped + `syncBuckets` throttle.
+- `frontend/src/components/shared/ImportTransactionsModal.tsx` — the 3-step wizard.
+- `frontend/src/features/accounts/{api,hooks}.ts` — `importPreview` / `importExecute` + hooks.
+
+### Flow
+
+```
+upload CSV ─► preview() ─► detect dialect + guess mapping ─► cache raw file @token(account)
+                                                                     │
+user adjusts mapping/dialect ◄───────────────────────────────────────┘
+        │
+        ▼
+execute(token, mapping, dialect) ─► re-parse ─► map rows ─► saveAll(is_manual) ─► recomputeHoldings()
+```
+
+## Technical choices
+
+| Choice | Why | Rejected alternative |
+|--------|-----|----------------------|
+| Hand-rolled `CsvReader` (no lib) | Matches the existing hand-rolled `CsvWriter`; the hard part (delimiter/decimal/date sniffing) isn't solved by a lib anyway | opencsv / Commons-CSV |
+| Column-mapping wizard | Works for any broker export without a per-broker parser | Fixed template · per-broker native parsers |
+| Cache the **raw file**, re-parse on execute | The user can change the delimiter after preview; caching parsed rows would be stale | Cache parsed rows |
+| Token bound to the account | A preview cannot be replayed against another account | Bare token |
+| Tolerant per-row errors | One bad line shouldn't sink a multi-year import | All-or-nothing transaction |
+
+## Gotchas / Pitfalls
+
+- **French broker exports** commonly use `;` delimiter and `,` decimals (`1 234,56`). The detector
+  handles both; the user can override delimiter, decimal style, and date format in the wizard.
+- **ISINs must be resolved to tickers at import time** (`InstrumentFieldResolver`) or Yahoo pricing
+  never populates and an ISIN row won't merge with the equivalent ticker row.
+- **Amount signing lives in one place** (`TransactionAmountCalculator`, mirrored in the TS modal):
+  BUY `= −(qty·price + fees)`, SELL `= +(qty·price − fees)`. Fees also fold into the PMP — see
+  [manual-transactions.md](manual-transactions.md).
+- The importer only accepts **investment** accounts (PEA / COMPTE_TITRES / CRYPTO); anything else → 400.
+- Multipart limit was raised to **10 MB** (`application.yml`) for multi-year histories; the endpoint
+  is member-scoped and throttled.
+- Demo mode returns `{}` for unhandled endpoints — UI consumers must guard accordingly.
+
+## Tests
+
+- `CsvReaderTest`, `CsvDialectDetectorTest`, `CsvValueParserTest` — parsing / sniffing.
+- `TransactionRowMapperTest` — sign+fees, ISIN resolution, amount-derived price, bad rows.
+- `TransactionImportServiceTest` — happy path, expired token, **token↔account binding**,
+  non-investment (400), foreign account (404), per-row error reporting.
+- `ImportTransactionsModal.test.tsx` — preview → mapping → import request → result.
+
+## Links
+
+- Sibling importer: [finary-import.md](finary-import.md) · [trade-republic.md](trade-republic.md)
+- [manual-transactions.md](manual-transactions.md) · [ISIN_TO_TICKER_CONVERSION.md](ISIN_TO_TICKER_CONVERSION.md)
+- Ticket: [issue #38](https://github.com/Zoeille/picsou-finance/issues/38)

--- a/docs/features/manual-transactions.md
+++ b/docs/features/manual-transactions.md
@@ -25,6 +25,19 @@ CREATE INDEX idx_transaction_account_manual ON transaction(account_id, is_manual
 
 Existing synced transactions have `is_manual = false`. The original `type` column (Finary raw category string) is untouched.
 
+### Per-trade fees column (V53 migration)
+
+```sql
+ALTER TABLE transaction ADD COLUMN fees NUMERIC(20,8) NULL;  -- null = zero downstream
+```
+
+Optional broker/transaction fees on a BUY/SELL. Fees **fold into the PMP cost basis** (French PEA
+convention: acquisition costs raise the cost basis) — see *Holdings derivation* below. The signed
+`amount` also accounts for fees: BUY `= −(qty·price + fees)`, SELL `= +(qty·price − fees)`,
+centralised in `TransactionAmountCalculator` and mirrored by the frontend modal. Added for the CSV
+importer ([csv-transaction-import.md](csv-transaction-import.md)) and exposed as an optional field on
+the manual add/edit form.
+
 ### Security name column (V36 migration)
 
 A later migration adds a first-class label for derived positions:
@@ -67,7 +80,7 @@ Manual transactions on a **synced** cash account (`account.isManual = false` —
 
 1. Fetches all BUY/SELL transactions for the account, ordered by date ASC.
 2. Groups by ticker: `net quantity = Σ(BUY qty) − Σ(SELL qty)`.
-3. Computes `averageBuyIn` as VWAP across all BUY transactions for each ticker.
+3. Computes `averageBuyIn` as VWAP across all BUY transactions for each ticker, **fees included**: `Σ(qty·price + fees) / Σ(qty)` (null fees treated as zero). SELL rows never affect the average.
 4. Upserts `AccountHolding` for tickers where `qty > 0`.
 5. Deletes `AccountHolding` for tickers where `qty ≤ 0`.
 6. Labels each surviving position with the **most recent** transaction (date ASC, last write wins) that carries a non-blank `name`. The update is guarded by a null check, so a nameless manual transaction never erases a name already set by bank sync (OpenFIGI).
@@ -96,7 +109,7 @@ All sync services (`FinaryPersistenceHelper`, `BoursoSyncService`) now call `tra
 - Date, DEPOSIT/WITHDRAWAL toggle, Description, Amount (always positive — toggle sets sign)
 
 **Investment accounts (PEA, COMPTE_TITRES, CRYPTO):**
-- Date, BUY/SELL toggle, **Ticker ou ISIN** (a ticker like `IWDA.AS` or a 12-char ISIN like `IE00B4L5Y983`), Name (auto-filled from existing holdings when the ticker matches; otherwise resolved from the ISIN backend-side), Quantity, Price per unit, Total (read-only)
+- Date, BUY/SELL toggle, **Ticker ou ISIN** (a ticker like `IWDA.AS` or a 12-char ISIN like `IE00B4L5Y983`), Name (auto-filled from existing holdings when the ticker matches; otherwise resolved from the ISIN backend-side), Quantity, Price per unit, **Fees (optional, folded into the PMP)**, Total (read-only)
 
 The Transactions list shows a "Manuel" badge on manual entries and a delete button (only for manual entries).
 
@@ -110,7 +123,10 @@ After submit, `useAddTransaction` / `useDeleteTransaction` hooks invalidate the 
 | `db/migration/V36__transaction_security_name.sql` | Adds `transaction.name` (position label) |
 | `model/TransactionType.java` | Enum (DEPOSIT, WITHDRAWAL, BUY, SELL, DIVIDEND, FEE) |
 | `service/HoldingComputeService.java` | Derives holdings (qty, VWAP, **name**) from BUY/SELL transactions |
-| `service/ManualTransactionService.java` | Orchestrates add/edit/delete + re-derivation; resolves ISIN and owns the BUY/SELL description (`applyInstrumentFields`) |
+| `service/ManualTransactionService.java` | Orchestrates add/edit/delete + re-derivation; persists `fees`; delegates ISIN/ticker/description to `InstrumentFieldResolver` |
+| `service/InstrumentFieldResolver.java` | Shared ISIN→ticker/name + BUY/SELL description builder (reused by the CSV importer) |
+| `imports/TransactionAmountCalculator.java` | Single source of truth for the signed `amount` incl. fees |
+| `db/migration/V53__transaction_fees.sql` | Adds `transaction.fees` (folds into the PMP) |
 | `adapter/OpenFigiIsinConverter.java` | `isIsin()` detection + `resolve()` ISIN→ticker+name (shared with bank sync) |
 | `controller/AccountController.java` | POST/DELETE `/accounts/{id}/transactions` |
 | `repository/TransactionRepository.java` | `deleteByAccountIdAndIsManualFalse`, `sumAmountByAccountId`, `findByAccountIdAndTxTypeInOrderByDateAsc` |

--- a/docs/features/realized-pnl.md
+++ b/docs/features/realized-pnl.md
@@ -1,0 +1,70 @@
+# Feature: Realized P&L on closed positions
+
+> Last updated: 2026-07-11
+
+## Context
+
+The portfolio view only shows **open** holdings, so once a position is fully sold it disappears and
+its gain/loss is invisible — you could only infer it from the raw transaction list
+([issue #38](https://github.com/Zoeille/picsou-finance/issues/38)). This adds a realized P&L series
+computed from the transaction stream, surfaced as a "realized gains" section on the account page.
+
+## How it works
+
+`RealizedPnlService.compute(accountId, memberId)` walks the account's BUY/SELL transactions in date
+order and maintains a **moving-average (PMP) cost basis** per ticker:
+
+- **BUY**: `costPool += qty·price + fees`, `qtyHeld += qty` (buy fees are part of the cost).
+- **SELL**: `avgCost = costPool / qtyHeld`; `proceeds = qty·price − fees`;
+  `realized = proceeds − avgCost·qtySold`; then draw the pool down by `avgCost·qtySold`.
+
+An over-sell (selling more than is held, or with no prior buy) clamps the costed quantity to what's
+held — no fabricated negative cost — and flags a per-ticker `warning`. Everything is in the
+**account's own currency**; there is **no re-pricing / FX**, so the numbers can't drift with market
+data. Nothing is persisted — the transaction stream is the source of truth (same posture as
+`LoanAmortizationService`).
+
+### Key files
+
+- `backend/src/main/java/com/picsou/service/RealizedPnlService.java` — the moving-average pass.
+- `backend/src/main/java/com/picsou/dto/RealizedPnlResponse.java` — `currency`, `realizedTotal`,
+  `byTicker[]`, `lots[]`.
+- `AccountController#getRealizedPnl` — `GET /api/accounts/{id}/realized-pnl` (member-scoped, read-only).
+- `frontend/src/components/shared/RealizedPnlSection.tsx` — closed-lot table + green/red total.
+- `frontend/src/features/accounts/hooks.ts#useRealizedPnl`.
+
+## Technical choices
+
+| Choice | Why | Rejected alternative |
+|--------|-----|----------------------|
+| Moving-average (PMP) cost | Matches French PEA convention and the existing `averageBuyIn` | FIFO / specific-lot (no lot ids in the stream) |
+| Compute on the fly | Stream is the source of truth; any edit reflects on next GET; no migration/invalidation | Persist a `realized_gain` table |
+| Own series, separate endpoint | The `pnl`/`rangePnl` series are unrealized and debt-neutral by invariant | Fold into `buildPnl` |
+| Account currency, no re-pricing | Prices are EUR-only and skipped-never-fabricated; historical proceeds are known | Re-price with live/FX rates |
+
+See ADR [2026-07-11-realized-pnl-average-cost-on-the-fly](../decisions/2026-07-11-realized-pnl-average-cost-on-the-fly.md).
+
+## Gotchas / Pitfalls
+
+- **`HoldingComputeService` deletes a holding when net qty ≤ 0.** Realized P&L reads the transaction
+  stream, so it still computes for a position that no longer has a holding row — that is exactly the
+  data this feature recovers.
+- **Open PMP vs realized PMP can differ slightly.** Open holdings use a *global* VWAP over all buys
+  (`HoldingComputeService`), while realized P&L uses a *moving* average recomputed at each sell. They
+  coincide for a buy-then-sell sequence but diverge on interleaved buy→sell→buy. Accepted; documented
+  in the ADR.
+- **Do not re-mix realized into `pnl`.** Per [dashboard-liabilities-separation.md](dashboard-liabilities-separation.md),
+  performance series stay distinct.
+- The frontend guards `data.lots` (demo mode returns `{}` for unhandled endpoints).
+
+## Tests
+
+- `RealizedPnlServiceTest` — partial/full close, fee folding, over-sell (clamp + warning),
+  sell-without-buy, account currency, buys-only (empty).
+- `RealizedPnlSection.test.tsx` — green/red total, hidden when no lots.
+
+## Links
+
+- ADR: [realized-pnl-average-cost-on-the-fly](../decisions/2026-07-11-realized-pnl-average-cost-on-the-fly.md)
+- [live-prices-holdings.md](live-prices-holdings.md) · [dashboard-liabilities-separation.md](dashboard-liabilities-separation.md)
+- Ticket: [issue #38](https://github.com/Zoeille/picsou-finance/issues/38)

--- a/frontend/src/components/shared/AddTransactionModal.test.tsx
+++ b/frontend/src/components/shared/AddTransactionModal.test.tsx
@@ -1,0 +1,63 @@
+import '@testing-library/jest-dom'
+import { describe, it, expect, vi, beforeAll } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { AddTransactionModal } from './AddTransactionModal'
+
+// jsdom lacks matchMedia, which DateInput probes for the touch/native date picker.
+beforeAll(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: (query: string) => ({
+      matches: false, media: query, onchange: null,
+      addEventListener: () => {}, removeEventListener: () => {},
+      addListener: () => {}, removeListener: () => {}, dispatchEvent: () => false,
+    }),
+  })
+})
+
+vi.mock('@tanstack/react-query', () => ({
+  useQuery: () => ({ data: undefined }),
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, opts?: unknown) => (typeof opts === 'string' ? opts : key),
+    i18n: { language: 'en', resolvedLanguage: 'en' },
+  }),
+}))
+
+function fillInvestment({ qty, price, fees }: { qty: string; price: string; fees: string }) {
+  fireEvent.change(screen.getByPlaceholderText('accounts.tickerOrIsinPlaceholder'), { target: { value: 'AAPL' } })
+  // NumericInput renders type="text" inputMode="decimal": quantity, unit price, fees in order.
+  const numeric = document.querySelectorAll('input[inputmode="decimal"]')
+  fireEvent.change(numeric[0], { target: { value: qty } })
+  fireEvent.change(numeric[1], { target: { value: price } })
+  fireEvent.change(numeric[2], { target: { value: fees } })
+}
+
+describe('AddTransactionModal fees', () => {
+  it('BUY amount includes fees: -(qty*price + fees)', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined)
+    render(<AddTransactionModal open onOpenChange={vi.fn()} accountId={2} accountType="PEA" onSubmit={onSubmit} />)
+
+    fillInvestment({ qty: '10', price: '100', fees: '5' })
+    fireEvent.click(screen.getByRole('button', { name: 'common.create' }))
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledOnce())
+    expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({
+      txType: 'BUY', quantity: 10, pricePerUnit: 100, fees: 5, amount: -1005,
+    }))
+  })
+
+  it('SELL amount nets fees: +(qty*price - fees)', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined)
+    render(<AddTransactionModal open onOpenChange={vi.fn()} accountId={2} accountType="PEA" onSubmit={onSubmit} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'accounts.sell' }))
+    fillInvestment({ qty: '10', price: '100', fees: '5' })
+    fireEvent.click(screen.getByRole('button', { name: 'common.create' }))
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledOnce())
+    expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({ txType: 'SELL', amount: 995, fees: 5 }))
+  })
+})

--- a/frontend/src/components/shared/AddTransactionModal.tsx
+++ b/frontend/src/components/shared/AddTransactionModal.tsx
@@ -96,6 +96,7 @@ function TransactionForm({ onOpenChange, accountId, accountType, onSubmit, isLoa
   const [name, setName] = useState(() => (isInvestmentTx ? (initialValues?.name ?? '') : ''))
   const [quantity, setQuantity] = useState(() => (isInvestmentTx && initialValues?.quantity != null ? String(initialValues.quantity) : ''))
   const [pricePerUnit, setPricePerUnit] = useState(() => (isInvestmentTx && initialValues?.pricePerUnit != null ? String(initialValues.pricePerUnit) : ''))
+  const [fees, setFees] = useState(() => (isInvestmentTx && initialValues?.fees != null ? String(initialValues.fees) : ''))
 
   // Auto-fill the name from an existing holding when the ticker matches —
   // done in the change handler (not an effect) so it stays out of render.
@@ -119,7 +120,10 @@ function TransactionForm({ onOpenChange, accountId, accountType, onSubmit, isLoa
     if (isInvestment) {
       const qty = parseAmount(quantity)
       const price = parseAmount(pricePerUnit)
-      const amount = investType === 'BUY' ? -(qty * price) : (qty * price)
+      const feeVal = parseAmount(fees) || 0
+      // Sign convention mirrors the backend TransactionAmountCalculator: fees add to a BUY's
+      // cash outflow and reduce a SELL's proceeds, and fold into the PMP cost basis.
+      const amount = investType === 'BUY' ? -(qty * price + feeVal) : (qty * price - feeVal)
       data = {
         date,
         description: name || (investType === 'BUY' ? `Achat ${ticker}` : `Vente ${ticker}`),
@@ -129,6 +133,7 @@ function TransactionForm({ onOpenChange, accountId, accountType, onSubmit, isLoa
         name: name.trim() || undefined,
         quantity: qty,
         pricePerUnit: price,
+        fees: feeVal || undefined,
       }
     } else {
       const raw = parseAmount(cashAmount)
@@ -188,6 +193,10 @@ function TransactionForm({ onOpenChange, accountId, accountType, onSubmit, isLoa
           <div className="space-y-1">
             <Label>{t('holdings.unitPrice')}</Label>
             <NumericInput value={pricePerUnit} onChange={e => setPricePerUnit(e.target.value)} required />
+          </div>
+          <div className="space-y-1">
+            <Label>{t('accounts.fees')} <span className="text-muted-foreground text-xs">({t('common.optional')})</span></Label>
+            <NumericInput value={fees} onChange={e => setFees(e.target.value)} />
           </div>
           <p className="text-sm text-muted-foreground">
             {t('accounts.total')}: {total != null && Number.isFinite(total) ? formatCurrency(total, 'EUR', locale) : '—'}

--- a/frontend/src/components/shared/ImportTransactionsModal.test.tsx
+++ b/frontend/src/components/shared/ImportTransactionsModal.test.tsx
@@ -1,0 +1,72 @@
+import '@testing-library/jest-dom'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { ImportTransactionsModal } from './ImportTransactionsModal'
+import type { TransactionImportPreviewResponse } from '@/types/api'
+
+const previewMutate = vi.fn()
+const executeMutate = vi.fn()
+
+vi.mock('@/features/accounts/hooks', () => ({
+  usePreviewImport: () => ({ mutateAsync: previewMutate, isPending: false }),
+  useExecuteImport: () => ({ mutateAsync: executeMutate, isPending: false }),
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, opts?: unknown) => (typeof opts === 'string' ? opts : key),
+    i18n: { language: 'en', resolvedLanguage: 'en' },
+  }),
+}))
+
+const PREVIEW: TransactionImportPreviewResponse = {
+  fileToken: 'tok-1',
+  detectedColumns: ['Date', 'Sens', 'ISIN', 'Quantite', 'Cours', 'Frais'],
+  sampleRows: [['15/01/2024', 'Achat', 'IE00B4L5Y983', '10', '85,20', '1,00']],
+  totalRows: 1,
+  hasHeaderRow: true,
+  dialect: { delimiter: ';', decimal: 'COMMA', dateFormat: 'dd/MM/yyyy' },
+  suggestedMapping: { date: 0, side: 1, tickerOrIsin: 2, name: null, quantity: 3, unitPrice: 4, fees: 5, currency: null, amount: null },
+}
+
+function uploadFile() {
+  const input = document.querySelector('input[type="file"]') as HTMLInputElement
+  const file = new File(['csv'], 'trades.csv', { type: 'text/csv' })
+  fireEvent.change(input, { target: { files: [file] } })
+}
+
+describe('ImportTransactionsModal', () => {
+  beforeEach(() => {
+    previewMutate.mockReset()
+    executeMutate.mockReset()
+  })
+
+  it('previews the file then renders the detected columns for mapping', async () => {
+    previewMutate.mockResolvedValue(PREVIEW)
+    render(<ImportTransactionsModal open onOpenChange={vi.fn()} accountId={2} />)
+
+    uploadFile()
+
+    // Step 2 renders the mapping UI with the detected columns.
+    expect(await screen.findByText('import.mapColumns')).toBeInTheDocument()
+    expect(screen.getAllByText('ISIN').length).toBeGreaterThan(0)
+    expect(previewMutate).toHaveBeenCalledOnce()
+  })
+
+  it('sends the assembled import request and shows the result', async () => {
+    previewMutate.mockResolvedValue(PREVIEW)
+    executeMutate.mockResolvedValue({ imported: 2, skipped: 0, errors: [] })
+    render(<ImportTransactionsModal open onOpenChange={vi.fn()} accountId={2} />)
+
+    uploadFile()
+    await screen.findByText('import.mapColumns')
+
+    fireEvent.click(screen.getByRole('button', { name: 'import.import' }))
+
+    await waitFor(() => expect(executeMutate).toHaveBeenCalledOnce())
+    expect(executeMutate).toHaveBeenCalledWith(
+      expect.objectContaining({ fileToken: 'tok-1', hasHeaderRow: true, feesIncludedInAmount: false }),
+    )
+    expect(await screen.findByText('import.rowsImported')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/shared/ImportTransactionsModal.tsx
+++ b/frontend/src/components/shared/ImportTransactionsModal.tsx
@@ -1,0 +1,285 @@
+import { useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { Label } from '@/components/ui/label'
+import { cn } from '@/lib/utils'
+import { extractErrorMessage } from '@/lib/errors'
+import { Loader2, Upload, CheckCircle2, AlertCircle } from 'lucide-react'
+import type {
+  ColumnMappingDto,
+  CsvDialectDto,
+  TransactionImportPreviewResponse,
+  TransactionImportResultResponse,
+} from '@/types/api'
+import { usePreviewImport, useExecuteImport } from '@/features/accounts/hooks'
+
+interface ImportTransactionsModalProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  accountId: number
+}
+
+type MappingField = keyof ColumnMappingDto
+const MAPPING_FIELDS: { key: MappingField; optional: boolean }[] = [
+  { key: 'date', optional: false },
+  { key: 'side', optional: true },
+  { key: 'tickerOrIsin', optional: false },
+  { key: 'name', optional: true },
+  { key: 'quantity', optional: false },
+  { key: 'unitPrice', optional: true },
+  { key: 'fees', optional: true },
+  { key: 'currency', optional: true },
+  { key: 'amount', optional: true },
+]
+
+const SELECT_CLASS =
+  'flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm focus:outline-none focus:ring-1 focus:ring-ring'
+
+export function ImportTransactionsModal({ open, onOpenChange, accountId }: ImportTransactionsModalProps) {
+  const { t } = useTranslation()
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-3xl">
+        <DialogHeader>
+          <DialogTitle>{t('import.title')}</DialogTitle>
+        </DialogHeader>
+        {open && <ImportWizard accountId={accountId} onOpenChange={onOpenChange} />}
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function ImportWizard({ accountId, onOpenChange }: { accountId: number; onOpenChange: (o: boolean) => void }) {
+  const { t } = useTranslation()
+  const fileInputRef = useRef<HTMLInputElement>(null)
+  const [dragOver, setDragOver] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const [preview, setPreview] = useState<TransactionImportPreviewResponse | null>(null)
+  const [mapping, setMapping] = useState<ColumnMappingDto | null>(null)
+  const [dialect, setDialect] = useState<CsvDialectDto | null>(null)
+  const [hasHeaderRow, setHasHeaderRow] = useState(true)
+  const [feesIncluded, setFeesIncluded] = useState(false)
+  const [result, setResult] = useState<TransactionImportResultResponse | null>(null)
+
+  const previewMutation = usePreviewImport(accountId)
+  const executeMutation = useExecuteImport(accountId)
+
+  async function handleFile(file: File) {
+    setError(null)
+    try {
+      const res = await previewMutation.mutateAsync(file)
+      setPreview(res)
+      setMapping(res.suggestedMapping)
+      setDialect(res.dialect)
+      setHasHeaderRow(res.hasHeaderRow)
+    } catch (err) {
+      setError(extractErrorMessage(err, t('common.error')))
+    }
+  }
+
+  async function handleImport() {
+    if (!preview || !mapping || !dialect) return
+    setError(null)
+    try {
+      const res = await executeMutation.mutateAsync({
+        fileToken: preview.fileToken,
+        mapping,
+        dialect,
+        hasHeaderRow,
+        feesIncludedInAmount: feesIncluded,
+      })
+      setResult(res)
+    } catch (err) {
+      setError(extractErrorMessage(err, t('common.error')))
+    }
+  }
+
+  // --- Step 3: result ---
+  if (result) {
+    return (
+      <div className="space-y-4">
+        <div className="flex items-center gap-2 text-emerald-500">
+          <CheckCircle2 className="size-5" />
+          <span className="font-medium">{t('import.rowsImported', { count: result.imported })}</span>
+        </div>
+        {result.skipped > 0 && (
+          <div className="space-y-2">
+            <div className="flex items-center gap-2 text-red-500">
+              <AlertCircle className="size-5" />
+              <span className="font-medium">{t('import.rowsSkipped', { count: result.skipped })}</span>
+            </div>
+            <ul className="max-h-40 space-y-1 overflow-y-auto rounded-md border border-border bg-muted/40 p-2 text-sm">
+              {result.errors.map((e, i) => (
+                <li key={i} className="text-muted-foreground">
+                  {t('import.rowLabel', { row: e.rowNumber })}: {e.message}
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+        <DialogFooter>
+          <Button onClick={() => onOpenChange(false)}>{t('common.done')}</Button>
+        </DialogFooter>
+      </div>
+    )
+  }
+
+  // --- Step 1: upload ---
+  if (!preview) {
+    return (
+      <div className="space-y-4">
+        <div
+          className={cn(
+            'flex flex-col items-center justify-center gap-2 rounded-lg border-2 border-dashed p-8 text-center transition-colors',
+            dragOver ? 'border-primary bg-primary/5' : 'border-border',
+          )}
+          onDragOver={e => { e.preventDefault(); setDragOver(true) }}
+          onDragLeave={() => setDragOver(false)}
+          onDrop={e => {
+            e.preventDefault()
+            setDragOver(false)
+            const file = e.dataTransfer.files?.[0]
+            if (file) handleFile(file)
+          }}
+        >
+          <Upload className="size-8 text-muted-foreground" />
+          <p className="text-sm text-muted-foreground">{t('import.uploadHint')}</p>
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept=".csv,text/csv"
+            className="hidden"
+            onChange={e => {
+              const file = e.target.files?.[0]
+              if (file) handleFile(file)
+            }}
+          />
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            disabled={previewMutation.isPending}
+            onClick={() => fileInputRef.current?.click()}
+          >
+            {previewMutation.isPending && <Loader2 className="mr-2 size-4 animate-spin" />}
+            {t('import.chooseFile')}
+          </Button>
+        </div>
+        {error && <p className="text-sm text-destructive">{error}</p>}
+        <DialogFooter>
+          <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>{t('common.cancel')}</Button>
+        </DialogFooter>
+      </div>
+    )
+  }
+
+  // --- Step 2: map columns & review ---
+  const columns = preview.detectedColumns
+  const setField = (key: MappingField, value: number | null) =>
+    setMapping(m => (m ? { ...m, [key]: value } : m))
+
+  return (
+    <div className="space-y-4">
+      {/* Dialect controls */}
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+        <div className="space-y-1">
+          <Label>{t('import.delimiter')}</Label>
+          <select
+            className={SELECT_CLASS}
+            value={dialect?.delimiter ?? ','}
+            onChange={e => setDialect(d => (d ? { ...d, delimiter: e.target.value } : d))}
+          >
+            <option value=",">{t('import.delimiterComma')}</option>
+            <option value=";">{t('import.delimiterSemicolon')}</option>
+            <option value={'\t'}>{t('import.delimiterTab')}</option>
+          </select>
+        </div>
+        <div className="space-y-1">
+          <Label>{t('import.decimal')}</Label>
+          <select
+            className={SELECT_CLASS}
+            value={dialect?.decimal ?? 'DOT'}
+            onChange={e => setDialect(d => (d ? { ...d, decimal: e.target.value as 'DOT' | 'COMMA' } : d))}
+          >
+            <option value="DOT">1.23</option>
+            <option value="COMMA">1,23</option>
+          </select>
+        </div>
+        <div className="space-y-1">
+          <Label>{t('import.dateFormat')}</Label>
+          <select
+            className={SELECT_CLASS}
+            value={dialect?.dateFormat ?? 'yyyy-MM-dd'}
+            onChange={e => setDialect(d => (d ? { ...d, dateFormat: e.target.value } : d))}
+          >
+            {['yyyy-MM-dd', 'dd/MM/yyyy', 'MM/dd/yyyy', 'dd.MM.yyyy', 'dd-MM-yyyy'].map(f => (
+              <option key={f} value={f}>{f}</option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      {/* Column mapping */}
+      <div>
+        <p className="mb-2 text-sm font-medium">{t('import.mapColumns')}</p>
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+          {MAPPING_FIELDS.map(({ key, optional }) => (
+            <div key={key} className="space-y-1">
+              <Label className="text-xs">
+                {t(`import.field.${key}`)}
+                {optional && <span className="text-muted-foreground"> ({t('common.optional')})</span>}
+              </Label>
+              <select
+                className={SELECT_CLASS}
+                value={mapping?.[key] ?? ''}
+                onChange={e => setField(key, e.target.value === '' ? null : Number(e.target.value))}
+              >
+                <option value="">{t('import.none')}</option>
+                {columns.map((c, i) => (
+                  <option key={i} value={i}>{c}</option>
+                ))}
+              </select>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <label className="flex items-center gap-2 text-sm">
+        <input type="checkbox" checked={feesIncluded} onChange={e => setFeesIncluded(e.target.checked)} />
+        {t('import.feesIncluded')}
+      </label>
+
+      {/* Preview table */}
+      <div>
+        <p className="mb-2 text-sm font-medium">{t('import.preview')} ({t('import.rowsTotal', { count: preview.totalRows })})</p>
+        <div className="max-h-48 overflow-auto rounded-md border border-border">
+          <table className="w-full text-xs">
+            <thead className="sticky top-0 bg-muted">
+              <tr>{columns.map((c, i) => <th key={i} className="px-2 py-1 text-left font-medium">{c}</th>)}</tr>
+            </thead>
+            <tbody>
+              {preview.sampleRows.map((row, ri) => (
+                <tr key={ri} className="border-t border-border">
+                  {columns.map((_, ci) => <td key={ci} className="px-2 py-1 text-muted-foreground">{row[ci] ?? ''}</td>)}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      {error && <p className="text-sm text-destructive">{error}</p>}
+
+      <DialogFooter>
+        <Button type="button" variant="outline" onClick={() => setPreview(null)}>{t('import.back')}</Button>
+        <Button type="button" onClick={handleImport} disabled={executeMutation.isPending}>
+          {executeMutation.isPending && <Loader2 className="mr-2 size-4 animate-spin" />}
+          {t('import.import')}
+        </Button>
+      </DialogFooter>
+    </div>
+  )
+}

--- a/frontend/src/components/shared/RealizedPnlSection.test.tsx
+++ b/frontend/src/components/shared/RealizedPnlSection.test.tsx
@@ -1,0 +1,56 @@
+import '@testing-library/jest-dom'
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { RealizedPnlSection } from './RealizedPnlSection'
+import type { RealizedPnlResponse } from '@/types/api'
+
+let realizedData: RealizedPnlResponse | undefined
+
+vi.mock('@/features/accounts/hooks', () => ({
+  useRealizedPnl: () => ({ data: realizedData }),
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, opts?: unknown) => (typeof opts === 'string' ? opts : key),
+    i18n: { language: 'en', resolvedLanguage: 'en' },
+  }),
+}))
+
+function withData(partial: Partial<RealizedPnlResponse>): RealizedPnlResponse {
+  return { currency: 'EUR', realizedTotal: 0, byTicker: [], lots: [], ...partial }
+}
+
+describe('RealizedPnlSection', () => {
+  it('renders nothing when there are no closed lots', () => {
+    realizedData = withData({ lots: [] })
+    const { container } = render(<RealizedPnlSection accountId={2} />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('renders nothing when data is missing (demo empty-object fallback)', () => {
+    realizedData = undefined
+    const { container } = render(<RealizedPnlSection accountId={2} />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('shows a green total and the closed lot when realized gains are positive', () => {
+    realizedData = withData({
+      realizedTotal: 512,
+      lots: [{ ticker: 'AAPL', name: 'Apple', date: '2024-05-14', quantity: 8, avgCost: 125, proceeds: 1512, realized: 512 }],
+    })
+    const { container } = render(<RealizedPnlSection accountId={2} />)
+    expect(screen.getByText('AAPL')).toBeInTheDocument()
+    expect(container.querySelector('.text-emerald-500')).toBeTruthy()
+    expect(container.querySelector('.text-red-500')).toBeFalsy()
+  })
+
+  it('shows a red total when realized P&L is negative', () => {
+    realizedData = withData({
+      realizedTotal: -90,
+      lots: [{ ticker: 'TSLA', name: 'Tesla', date: '2024-09-02', quantity: 3, avgCost: 250, proceeds: 660, realized: -90 }],
+    })
+    const { container } = render(<RealizedPnlSection accountId={2} />)
+    expect(container.querySelector('.text-red-500')).toBeTruthy()
+  })
+})

--- a/frontend/src/components/shared/RealizedPnlSection.tsx
+++ b/frontend/src/components/shared/RealizedPnlSection.tsx
@@ -1,0 +1,90 @@
+import { useTranslation } from 'react-i18next'
+import { CurrencyDisplay } from '@/components/shared/CurrencyDisplay'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { cn, localeFromLanguage } from '@/lib/utils'
+import { TrendingDown, TrendingUp } from 'lucide-react'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import { useRealizedPnl } from '@/features/accounts/hooks'
+
+interface RealizedPnlSectionProps {
+  accountId: number
+  /** Only investment accounts have realized P&L; skip the query otherwise. */
+  enabled?: boolean
+}
+
+/**
+ * Realized gains/losses on closed (fully or partially sold) positions. Surfaces the P&L that
+ * vanishes from the holdings view once a position is sold. Renders nothing until there is at
+ * least one sell.
+ */
+export function RealizedPnlSection({ accountId, enabled = true }: RealizedPnlSectionProps) {
+  const { t, i18n } = useTranslation()
+  const locale = localeFromLanguage(i18n.resolvedLanguage ?? i18n.language)
+  const { data } = useRealizedPnl(accountId, enabled)
+
+  // Defensive: demo mode returns {} for unhandled endpoints, so guard `lots` too.
+  if (!data || !data.lots || data.lots.length === 0) return null
+
+  const { currency, realizedTotal, lots } = data
+  const positive = realizedTotal >= 0
+
+  const formatDate = (iso: string) => {
+    const d = new Date(iso)
+    return Number.isNaN(d.getTime()) ? iso : d.toLocaleDateString(locale)
+  }
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between space-y-0">
+        <CardTitle className="text-base">{t('realized.title')}</CardTitle>
+        <div className={cn('flex items-center gap-1.5 font-medium', positive ? 'text-emerald-500' : 'text-red-500')}>
+          {positive ? <TrendingUp className="size-4" /> : <TrendingDown className="size-4" />}
+          <CurrencyDisplay value={realizedTotal} currency={currency} showSign />
+        </div>
+      </CardHeader>
+      <CardContent>
+        <div className="overflow-x-auto">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>{t('holdings.ticker')}</TableHead>
+                <TableHead>{t('holdings.name')}</TableHead>
+                <TableHead>{t('accounts.transactionDate')}</TableHead>
+                <TableHead className="text-right">{t('realized.qtySold')}</TableHead>
+                <TableHead className="text-right">{t('realized.avgCost')}</TableHead>
+                <TableHead className="text-right">{t('realized.proceeds')}</TableHead>
+                <TableHead className="text-right">{t('realized.realizedGains')}</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {lots.map((lot, i) => (
+                <TableRow key={`${lot.ticker}-${lot.date}-${i}`}>
+                  <TableCell className="font-mono font-medium">{lot.ticker}</TableCell>
+                  <TableCell>{lot.name ?? lot.ticker}</TableCell>
+                  <TableCell>{formatDate(lot.date)}</TableCell>
+                  <TableCell className="text-right">{lot.quantity}</TableCell>
+                  <TableCell className="text-right">
+                    <CurrencyDisplay value={lot.avgCost} currency={currency} className="text-sm" />
+                  </TableCell>
+                  <TableCell className="text-right">
+                    <CurrencyDisplay value={lot.proceeds} currency={currency} className="text-sm" />
+                  </TableCell>
+                  <TableCell className={cn('text-right', lot.realized >= 0 ? 'text-emerald-500' : 'text-red-500')}>
+                    <CurrencyDisplay value={lot.realized} currency={currency} showSign className="text-sm" />
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/frontend/src/demo/data/transactions.ts
+++ b/frontend/src/demo/data/transactions.ts
@@ -1,6 +1,6 @@
 import type { Transaction } from '@/types/api'
 
-const t = (fields: Omit<Transaction, 'isManual' | 'txType' | 'ticker' | 'name' | 'quantity' | 'pricePerUnit'>): Transaction => ({
+const t = (fields: Omit<Transaction, 'isManual' | 'txType' | 'ticker' | 'name' | 'quantity' | 'pricePerUnit' | 'fees'>): Transaction => ({
   ...fields,
   isManual: false,
   txType: null,
@@ -8,6 +8,7 @@ const t = (fields: Omit<Transaction, 'isManual' | 'txType' | 'ticker' | 'name' |
   name: null,
   quantity: null,
   pricePerUnit: null,
+  fees: null,
 })
 
 export const mockTransactions: Record<number, Transaction[]> = {

--- a/frontend/src/demo/index.ts
+++ b/frontend/src/demo/index.ts
@@ -67,6 +67,46 @@ for (let i = 1; i <= 7; i++) {
   handlers.set(key('GET', `/accounts/${i}/transactions`), () => mockTransactions[i] ?? [])
 }
 
+// Realized P&L on closed positions. PEA (id=2) shows a green + a red closed lot;
+// the other holding accounts report nothing realized yet.
+handlers.set(key('GET', '/accounts/2/realized-pnl'), () => ({
+  currency: 'EUR',
+  realizedTotal: 420.5,
+  byTicker: [
+    { ticker: 'AAPL', name: 'Apple Inc.', realized: 512, quantitySold: 8, proceeds: 1512, costBasis: 1000, warning: false },
+    { ticker: 'TSLA', name: 'Tesla Inc.', realized: -91.5, quantitySold: 3, proceeds: 660, costBasis: 751.5, warning: false },
+  ],
+  lots: [
+    { ticker: 'AAPL', name: 'Apple Inc.', date: '2024-05-14', quantity: 8, avgCost: 125, proceeds: 1512, realized: 512 },
+    { ticker: 'TSLA', name: 'Tesla Inc.', date: '2024-09-02', quantity: 3, avgCost: 250.5, proceeds: 660, realized: -91.5 },
+  ],
+}))
+for (const i of [3, 6]) {
+  handlers.set(key('GET', `/accounts/${i}/realized-pnl`), () => ({
+    currency: 'EUR', realizedTotal: 0, byTicker: [], lots: [],
+  }))
+}
+
+// CSV transaction import wizard (holding accounts). Preview returns a French-style
+// sample (semicolon delimiter, comma decimals); execute reports a canned result.
+for (const i of [2, 3, 6]) {
+  handlers.set(key('POST', `/accounts/${i}/transactions/import/preview`), () => ({
+    fileToken: 'demo-token',
+    detectedColumns: ['Date', 'Sens', 'ISIN', 'Quantité', 'Cours', 'Frais'],
+    sampleRows: [
+      ['15/01/2024', 'Achat', 'IE00B4L5Y983', '10', '85,20', '1,00'],
+      ['02/06/2024', 'Vente', 'IE00B4L5Y983', '10', '92,50', '1,00'],
+    ],
+    totalRows: 2,
+    hasHeaderRow: true,
+    dialect: { delimiter: ';', decimal: 'COMMA', dateFormat: 'dd/MM/yyyy' },
+    suggestedMapping: { date: 0, side: 1, tickerOrIsin: 2, name: null, quantity: 3, unitPrice: 4, fees: 5, currency: null, amount: null },
+  }))
+  handlers.set(key('POST', `/accounts/${i}/transactions/import`), () => ({
+    imported: 2, skipped: 0, errors: [],
+  }))
+}
+
 // Security insight (asset type + ETF composition). Mirrors the backend
 // SecurityInsightResponse: { ticker, assetType, composition | null }.
 const demoStockTickers = ['AAPL', 'MSFT', 'AMZN', 'NVDA']

--- a/frontend/src/features/accounts/api.ts
+++ b/frontend/src/features/accounts/api.ts
@@ -1,5 +1,5 @@
 import { api } from '@/lib/api-client'
-import type { Account, AccountRequest, BalanceSnapshot, DebtRequest, DebtInfo, HoldingResponse, LoanScheduleResponse, RealEstateMetadataRequest, RealEstateMetadata, SecurityInsight, Transaction, TransactionRequest } from '@/types/api'
+import type { Account, AccountRequest, BalanceSnapshot, DebtRequest, DebtInfo, HoldingResponse, LoanScheduleResponse, RealEstateMetadataRequest, RealEstateMetadata, RealizedPnlResponse, SecurityInsight, Transaction, TransactionImportPreviewResponse, TransactionImportRequest, TransactionImportResultResponse, TransactionRequest } from '@/types/api'
 
 export const accountsApi = {
   list: () => api.get<Account[]>('/accounts').then(r => r.data),
@@ -41,4 +41,16 @@ export const accountsApi = {
     api.put<HoldingResponse>(`/accounts/${accountId}/holdings/${ticker}`, data).then(r => r.data),
   deleteHolding: (accountId: number, ticker: string) =>
     api.delete(`/accounts/${accountId}/holdings/${ticker}`),
+  importPreview: (id: number, file: File) => {
+    const form = new FormData()
+    form.append('file', file)
+    return api.post<TransactionImportPreviewResponse>(
+      `/accounts/${id}/transactions/import/preview`, form,
+      { headers: { 'Content-Type': 'multipart/form-data' } },
+    ).then(r => r.data)
+  },
+  importExecute: (id: number, data: TransactionImportRequest) =>
+    api.post<TransactionImportResultResponse>(`/accounts/${id}/transactions/import`, data).then(r => r.data),
+  realizedPnl: (id: number) =>
+    api.get<RealizedPnlResponse>(`/accounts/${id}/realized-pnl`).then(r => r.data),
 }

--- a/frontend/src/features/accounts/hooks.ts
+++ b/frontend/src/features/accounts/hooks.ts
@@ -1,6 +1,6 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { accountsApi } from './api'
-import type { AccountRequest, Account, DebtRequest, HoldingResponse, RealEstateMetadataRequest, TransactionRequest } from '@/types/api'
+import type { AccountRequest, Account, DebtRequest, HoldingResponse, RealEstateMetadataRequest, TransactionImportRequest, TransactionRequest } from '@/types/api'
 import { QUERY_STALE_TIMES } from '@/lib/constants'
 
 export interface HoldingWithAccount extends HoldingResponse {
@@ -350,6 +350,40 @@ export function useDeleteHolding(accountId: number) {
       queryClient.invalidateQueries({ queryKey: ['accounts', accountId] })
       queryClient.invalidateQueries({ queryKey: ['dashboard'] })
     },
+  })
+}
+
+// ---------------------------------------------------------------------------
+// CSV transaction import + realized P&L
+// ---------------------------------------------------------------------------
+
+export function usePreviewImport(accountId: number) {
+  return useMutation({
+    mutationFn: (file: File) => accountsApi.importPreview(accountId, file),
+  })
+}
+
+export function useExecuteImport(accountId: number) {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (data: TransactionImportRequest) => accountsApi.importExecute(accountId, data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['accounts', accountId, 'transactions'] })
+      queryClient.invalidateQueries({ queryKey: ['accounts', accountId, 'holdings'] })
+      queryClient.invalidateQueries({ queryKey: ['accounts', accountId, 'history'] })
+      queryClient.invalidateQueries({ queryKey: ['accounts', accountId, 'realized-pnl'] })
+      queryClient.invalidateQueries({ queryKey: ['accounts', accountId] })
+      queryClient.invalidateQueries({ queryKey: ['dashboard'] })
+    },
+  })
+}
+
+export function useRealizedPnl(accountId: number, enabled = true) {
+  return useQuery({
+    queryKey: ['accounts', accountId, 'realized-pnl'],
+    queryFn: () => accountsApi.realizedPnl(accountId),
+    staleTime: QUERY_STALE_TIMES.accountDetail,
+    enabled: enabled && !!accountId,
   })
 }
 

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -27,7 +27,8 @@
     "yes": "Ja",
     "no": "Nein",
     "today": "Heute",
-    "currency": "EUR"
+    "currency": "EUR",
+    "done": "Fertig"
   },
   "nav": {
     "dashboard": "Dashboard",
@@ -179,7 +180,8 @@
       "CRYPTO": "Krypto",
       "REAL_ESTATE": "Immobilien",
       "DEBTS": "Schulden"
-    }
+    },
+    "fees": "Gebühren"
   },
   "accountTypes": {
     "checking": "Girokonto",
@@ -1080,5 +1082,45 @@
       "loginFallback": "Zur Anmeldung",
       "loggingIn": "Du wirst angemeldet..."
     }
+  },
+  "import": {
+    "importCsv": "CSV importieren",
+    "title": "Transaktionen aus CSV importieren",
+    "uploadHint": "CSV-Datei hierher ziehen oder auswählen",
+    "chooseFile": "Datei auswählen",
+    "mapColumns": "Spalten zuordnen",
+    "delimiter": "Trennzeichen",
+    "delimiterComma": "Komma (,)",
+    "delimiterSemicolon": "Semikolon (;)",
+    "delimiterTab": "Tabulator",
+    "decimal": "Dezimaltrennzeichen",
+    "dateFormat": "Datumsformat",
+    "feesIncluded": "Gebühren sind bereits im Betrag enthalten",
+    "preview": "Vorschau",
+    "rowsTotal": "{{count}} Zeilen",
+    "none": "— keine —",
+    "back": "Zurück",
+    "import": "Importieren",
+    "rowsImported": "{{count}} Transaktionen importiert",
+    "rowsSkipped": "{{count}} Zeilen übersprungen",
+    "rowLabel": "Zeile {{row}}",
+    "field": {
+      "date": "Datum",
+      "side": "Kauf / Verkauf",
+      "tickerOrIsin": "Ticker / ISIN",
+      "name": "Name",
+      "quantity": "Menge",
+      "unitPrice": "Stückpreis",
+      "fees": "Gebühren",
+      "currency": "Währung",
+      "amount": "Betrag"
+    }
+  },
+  "realized": {
+    "title": "Realisierte Gewinne",
+    "realizedGains": "Realisiert",
+    "proceeds": "Erlös",
+    "avgCost": "Ø-Kosten",
+    "qtySold": "Verk. Menge"
   }
 }

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -27,7 +27,8 @@
     "yes": "Yes",
     "no": "No",
     "today": "Today",
-    "currency": "EUR"
+    "currency": "EUR",
+    "done": "Done"
   },
   "nav": {
     "dashboard": "Dashboard",
@@ -186,7 +187,8 @@
       "CRYPTO": "Crypto",
       "REAL_ESTATE": "Real estate",
       "DEBTS": "Debts"
-    }
+    },
+    "fees": "Fees"
   },
   "accountTypes": {
     "checking": "Checking",
@@ -310,12 +312,31 @@
         "real_estate": "Real Estate"
       },
       "countryNames": {
-        "US": "United States", "NL": "Netherlands", "CA": "Canada", "FR": "France",
-        "GB": "United Kingdom", "DE": "Germany", "CH": "Switzerland", "IE": "Ireland",
-        "JP": "Japan", "CN": "China", "LU": "Luxembourg", "AU": "Australia",
-        "ES": "Spain", "IT": "Italy", "SE": "Sweden", "DK": "Denmark", "HK": "Hong Kong",
-        "KR": "South Korea", "TW": "Taiwan", "IN": "India", "BR": "Brazil", "BE": "Belgium",
-        "FI": "Finland", "NO": "Norway", "SG": "Singapore"
+        "US": "United States",
+        "NL": "Netherlands",
+        "CA": "Canada",
+        "FR": "France",
+        "GB": "United Kingdom",
+        "DE": "Germany",
+        "CH": "Switzerland",
+        "IE": "Ireland",
+        "JP": "Japan",
+        "CN": "China",
+        "LU": "Luxembourg",
+        "AU": "Australia",
+        "ES": "Spain",
+        "IT": "Italy",
+        "SE": "Sweden",
+        "DK": "Denmark",
+        "HK": "Hong Kong",
+        "KR": "South Korea",
+        "TW": "Taiwan",
+        "IN": "India",
+        "BR": "Brazil",
+        "BE": "Belgium",
+        "FI": "Finland",
+        "NO": "Norway",
+        "SG": "Singapore"
       }
     }
   },
@@ -658,16 +679,46 @@
     "revokeTitle": "Revoke this key?",
     "revokeDescription": "Any MCP client using this key loses access immediately. This can't be undone.",
     "scopes": {
-      "accounts_read": { "label": "Accounts", "desc": "View accounts, balances, holdings and history" },
-      "transactions_read": { "label": "Transactions", "desc": "View transactions" },
-      "goals_read": { "label": "Goals", "desc": "View savings goals" },
-      "dashboard_read": { "label": "Dashboard", "desc": "View net worth, dashboard and P&L" },
-      "prices_read": { "label": "Prices", "desc": "Look up asset prices" },
-      "family_read": { "label": "Family", "desc": "View the shared family dashboard" },
-      "accounts_write": { "label": "Accounts", "desc": "Create and edit manual accounts, balances and holdings" },
-      "transactions_write": { "label": "Transactions", "desc": "Add, edit and delete manual transactions" },
-      "goals_write": { "label": "Goals", "desc": "Create, edit and delete goals and contributions" },
-      "sync_trigger": { "label": "Sync", "desc": "Refresh existing bank, crypto and broker connections" }
+      "accounts_read": {
+        "label": "Accounts",
+        "desc": "View accounts, balances, holdings and history"
+      },
+      "transactions_read": {
+        "label": "Transactions",
+        "desc": "View transactions"
+      },
+      "goals_read": {
+        "label": "Goals",
+        "desc": "View savings goals"
+      },
+      "dashboard_read": {
+        "label": "Dashboard",
+        "desc": "View net worth, dashboard and P&L"
+      },
+      "prices_read": {
+        "label": "Prices",
+        "desc": "Look up asset prices"
+      },
+      "family_read": {
+        "label": "Family",
+        "desc": "View the shared family dashboard"
+      },
+      "accounts_write": {
+        "label": "Accounts",
+        "desc": "Create and edit manual accounts, balances and holdings"
+      },
+      "transactions_write": {
+        "label": "Transactions",
+        "desc": "Add, edit and delete manual transactions"
+      },
+      "goals_write": {
+        "label": "Goals",
+        "desc": "Create, edit and delete goals and contributions"
+      },
+      "sync_trigger": {
+        "label": "Sync",
+        "desc": "Refresh existing bank, crypto and broker connections"
+      }
     }
   },
   "admin": {
@@ -1038,5 +1089,45 @@
       "loginFallback": "Go to login",
       "loggingIn": "Logging you in..."
     }
+  },
+  "import": {
+    "importCsv": "Import CSV",
+    "title": "Import transactions from CSV",
+    "uploadHint": "Drag & drop a CSV file here, or choose one",
+    "chooseFile": "Choose a file",
+    "mapColumns": "Map columns",
+    "delimiter": "Delimiter",
+    "delimiterComma": "Comma (,)",
+    "delimiterSemicolon": "Semicolon (;)",
+    "delimiterTab": "Tab",
+    "decimal": "Decimal separator",
+    "dateFormat": "Date format",
+    "feesIncluded": "Fees are already included in the amount",
+    "preview": "Preview",
+    "rowsTotal": "{{count}} rows",
+    "none": "— none —",
+    "back": "Back",
+    "import": "Import",
+    "rowsImported": "{{count}} transactions imported",
+    "rowsSkipped": "{{count}} rows skipped",
+    "rowLabel": "Row {{row}}",
+    "field": {
+      "date": "Date",
+      "side": "Buy / Sell",
+      "tickerOrIsin": "Ticker / ISIN",
+      "name": "Name",
+      "quantity": "Quantity",
+      "unitPrice": "Unit price",
+      "fees": "Fees",
+      "currency": "Currency",
+      "amount": "Amount"
+    }
+  },
+  "realized": {
+    "title": "Realized gains",
+    "realizedGains": "Realized",
+    "proceeds": "Proceeds",
+    "avgCost": "Avg cost",
+    "qtySold": "Qty sold"
   }
 }

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -27,7 +27,8 @@
     "yes": "Sí",
     "no": "No",
     "today": "Hoy",
-    "currency": "EUR"
+    "currency": "EUR",
+    "done": "Hecho"
   },
   "nav": {
     "dashboard": "Panel",
@@ -179,7 +180,8 @@
       "CRYPTO": "Cripto",
       "REAL_ESTATE": "Inmobiliario",
       "DEBTS": "Deudas"
-    }
+    },
+    "fees": "Comisiones"
   },
   "accountTypes": {
     "checking": "Cuenta corriente",
@@ -1080,5 +1082,45 @@
       "loginFallback": "Ir al inicio de sesión",
       "loggingIn": "Iniciando tu sesión..."
     }
+  },
+  "import": {
+    "importCsv": "Importar CSV",
+    "title": "Importar transacciones desde CSV",
+    "uploadHint": "Arrastra y suelta un archivo CSV aquí, o elige uno",
+    "chooseFile": "Elegir un archivo",
+    "mapColumns": "Asignar columnas",
+    "delimiter": "Separador",
+    "delimiterComma": "Coma (,)",
+    "delimiterSemicolon": "Punto y coma (;)",
+    "delimiterTab": "Tabulación",
+    "decimal": "Separador decimal",
+    "dateFormat": "Formato de fecha",
+    "feesIncluded": "Las comisiones ya están incluidas en el importe",
+    "preview": "Vista previa",
+    "rowsTotal": "{{count}} filas",
+    "none": "— ninguna —",
+    "back": "Atrás",
+    "import": "Importar",
+    "rowsImported": "{{count}} transacciones importadas",
+    "rowsSkipped": "{{count}} filas omitidas",
+    "rowLabel": "Fila {{row}}",
+    "field": {
+      "date": "Fecha",
+      "side": "Compra / Venta",
+      "tickerOrIsin": "Ticker / ISIN",
+      "name": "Nombre",
+      "quantity": "Cantidad",
+      "unitPrice": "Precio unitario",
+      "fees": "Comisiones",
+      "currency": "Moneda",
+      "amount": "Importe"
+    }
+  },
+  "realized": {
+    "title": "Plusvalías realizadas",
+    "realizedGains": "Realizado",
+    "proceeds": "Ingresos",
+    "avgCost": "Coste medio",
+    "qtySold": "Cant. vendida"
   }
 }

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -27,7 +27,8 @@
     "yes": "Oui",
     "no": "Non",
     "today": "Aujourd'hui",
-    "currency": "EUR"
+    "currency": "EUR",
+    "done": "Terminé"
   },
   "nav": {
     "dashboard": "Tableau de bord",
@@ -186,7 +187,8 @@
       "CRYPTO": "Crypto",
       "REAL_ESTATE": "Immobilier",
       "DEBTS": "Dettes"
-    }
+    },
+    "fees": "Frais"
   },
   "accountTypes": {
     "checking": "Compte courant",
@@ -310,12 +312,31 @@
         "real_estate": "Immobilier"
       },
       "countryNames": {
-        "US": "États-Unis", "NL": "Pays-Bas", "CA": "Canada", "FR": "France",
-        "GB": "Royaume-Uni", "DE": "Allemagne", "CH": "Suisse", "IE": "Irlande",
-        "JP": "Japon", "CN": "Chine", "LU": "Luxembourg", "AU": "Australie",
-        "ES": "Espagne", "IT": "Italie", "SE": "Suède", "DK": "Danemark", "HK": "Hong Kong",
-        "KR": "Corée du Sud", "TW": "Taïwan", "IN": "Inde", "BR": "Brésil", "BE": "Belgique",
-        "FI": "Finlande", "NO": "Norvège", "SG": "Singapour"
+        "US": "États-Unis",
+        "NL": "Pays-Bas",
+        "CA": "Canada",
+        "FR": "France",
+        "GB": "Royaume-Uni",
+        "DE": "Allemagne",
+        "CH": "Suisse",
+        "IE": "Irlande",
+        "JP": "Japon",
+        "CN": "Chine",
+        "LU": "Luxembourg",
+        "AU": "Australie",
+        "ES": "Espagne",
+        "IT": "Italie",
+        "SE": "Suède",
+        "DK": "Danemark",
+        "HK": "Hong Kong",
+        "KR": "Corée du Sud",
+        "TW": "Taïwan",
+        "IN": "Inde",
+        "BR": "Brésil",
+        "BE": "Belgique",
+        "FI": "Finlande",
+        "NO": "Norvège",
+        "SG": "Singapour"
       }
     }
   },
@@ -658,16 +679,46 @@
     "revokeTitle": "Révoquer cette clé ?",
     "revokeDescription": "Tout client MCP utilisant cette clé perd l'accès immédiatement. Action irréversible.",
     "scopes": {
-      "accounts_read": { "label": "Comptes", "desc": "Voir les comptes, soldes, positions et historique" },
-      "transactions_read": { "label": "Transactions", "desc": "Voir les transactions" },
-      "goals_read": { "label": "Objectifs", "desc": "Voir les objectifs d'épargne" },
-      "dashboard_read": { "label": "Tableau de bord", "desc": "Voir le patrimoine, le tableau de bord et les +/- values" },
-      "prices_read": { "label": "Cours", "desc": "Consulter les cours des actifs" },
-      "family_read": { "label": "Famille", "desc": "Voir le tableau de bord familial partagé" },
-      "accounts_write": { "label": "Comptes", "desc": "Créer et modifier comptes manuels, soldes et positions" },
-      "transactions_write": { "label": "Transactions", "desc": "Ajouter, modifier et supprimer des transactions manuelles" },
-      "goals_write": { "label": "Objectifs", "desc": "Créer, modifier et supprimer objectifs et contributions" },
-      "sync_trigger": { "label": "Synchronisation", "desc": "Rafraîchir les connexions bancaires, crypto et courtier existantes" }
+      "accounts_read": {
+        "label": "Comptes",
+        "desc": "Voir les comptes, soldes, positions et historique"
+      },
+      "transactions_read": {
+        "label": "Transactions",
+        "desc": "Voir les transactions"
+      },
+      "goals_read": {
+        "label": "Objectifs",
+        "desc": "Voir les objectifs d'épargne"
+      },
+      "dashboard_read": {
+        "label": "Tableau de bord",
+        "desc": "Voir le patrimoine, le tableau de bord et les +/- values"
+      },
+      "prices_read": {
+        "label": "Cours",
+        "desc": "Consulter les cours des actifs"
+      },
+      "family_read": {
+        "label": "Famille",
+        "desc": "Voir le tableau de bord familial partagé"
+      },
+      "accounts_write": {
+        "label": "Comptes",
+        "desc": "Créer et modifier comptes manuels, soldes et positions"
+      },
+      "transactions_write": {
+        "label": "Transactions",
+        "desc": "Ajouter, modifier et supprimer des transactions manuelles"
+      },
+      "goals_write": {
+        "label": "Objectifs",
+        "desc": "Créer, modifier et supprimer objectifs et contributions"
+      },
+      "sync_trigger": {
+        "label": "Synchronisation",
+        "desc": "Rafraîchir les connexions bancaires, crypto et courtier existantes"
+      }
     }
   },
   "admin": {
@@ -1038,5 +1089,45 @@
       "loginFallback": "Aller à la connexion",
       "loggingIn": "Connexion en cours..."
     }
+  },
+  "import": {
+    "importCsv": "Importer CSV",
+    "title": "Importer des transactions depuis un CSV",
+    "uploadHint": "Glissez-déposez un fichier CSV ici, ou choisissez-en un",
+    "chooseFile": "Choisir un fichier",
+    "mapColumns": "Associer les colonnes",
+    "delimiter": "Séparateur",
+    "delimiterComma": "Virgule (,)",
+    "delimiterSemicolon": "Point-virgule (;)",
+    "delimiterTab": "Tabulation",
+    "decimal": "Séparateur décimal",
+    "dateFormat": "Format de date",
+    "feesIncluded": "Les frais sont déjà inclus dans le montant",
+    "preview": "Aperçu",
+    "rowsTotal": "{{count}} lignes",
+    "none": "— aucune —",
+    "back": "Retour",
+    "import": "Importer",
+    "rowsImported": "{{count}} transactions importées",
+    "rowsSkipped": "{{count}} lignes ignorées",
+    "rowLabel": "Ligne {{row}}",
+    "field": {
+      "date": "Date",
+      "side": "Achat / Vente",
+      "tickerOrIsin": "Ticker / ISIN",
+      "name": "Nom",
+      "quantity": "Quantité",
+      "unitPrice": "Prix unitaire",
+      "fees": "Frais",
+      "currency": "Devise",
+      "amount": "Montant"
+    }
+  },
+  "realized": {
+    "title": "Plus-values réalisées",
+    "realizedGains": "Réalisé",
+    "proceeds": "Produit",
+    "avgCost": "PMP",
+    "qtySold": "Qté vendue"
   }
 }

--- a/frontend/src/pages/accounts/AccountDetailPage.tsx
+++ b/frontend/src/pages/accounts/AccountDetailPage.tsx
@@ -10,8 +10,10 @@ import { useHistory } from '@/features/history/hooks'
 import { BalanceHistoryChart } from '@/components/shared/BalanceHistoryChart'
 import { NetWorthChart } from '@/components/shared/NetWorthChart'
 import { HoldingsTable } from '@/components/shared/HoldingsTable'
+import { RealizedPnlSection } from '@/components/shared/RealizedPnlSection'
 import { TransactionsList } from '@/components/shared/TransactionsList'
 import { AddTransactionModal } from '@/components/shared/AddTransactionModal'
+import { ImportTransactionsModal } from '@/components/shared/ImportTransactionsModal'
 import { EditHoldingModal } from '@/components/shared/EditHoldingModal'
 import { MonthEndBalanceModal } from '@/components/shared/MonthEndBalanceModal'
 import { CurrencyDisplay } from '@/components/shared/CurrencyDisplay'
@@ -21,7 +23,7 @@ import { LoanDetailSection } from '@/components/loan/LoanDetailSection'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Skeleton } from '@/components/ui/skeleton'
-import { ArrowLeft, Calendar, TrendingUp, TrendingDown } from 'lucide-react'
+import { ArrowLeft, Calendar, TrendingUp, TrendingDown, Upload } from 'lucide-react'
 import { formatLocalDate } from '@/lib/utils'
 import { accountTypeLabelKey } from '@/lib/constants'
 import { type TimeRange } from '@/components/shared/TimeRangeSelector'
@@ -48,6 +50,7 @@ export function AccountDetailPage() {
 
   const [showHistory, setShowHistory] = useState(false)
   const [showAddTx, setShowAddTx] = useState(false)
+  const [showImport, setShowImport] = useState(false)
   const [editingTx, setEditingTx] = useState<Transaction | null>(null)
   const [editingHolding, setEditingHolding] = useState<HoldingResponse | null>(null)
   const [range, setRange] = useState<TimeRange>('1Y')
@@ -195,14 +198,25 @@ export function AccountDetailPage() {
         )
       )}
 
+      {/* Realized P&L on closed positions (investment accounts only) */}
+      {showHoldings && <RealizedPnlSection accountId={accountId} enabled={showHoldings} />}
+
       {/* Transactions */}
       {!isLoan && (transactions ? (
         <>
           <div className="flex items-center justify-between mb-3">
             <h3 className="text-base font-semibold">{t('accounts.transactions')}</h3>
-            <Button size="sm" variant="outline" onClick={() => setShowAddTx(true)}>
-              + Ajouter
-            </Button>
+            <div className="flex items-center gap-2">
+              {showHoldings && (
+                <Button size="sm" variant="outline" onClick={() => setShowImport(true)}>
+                  <Upload className="mr-1.5 size-4" />
+                  {t('import.importCsv')}
+                </Button>
+              )}
+              <Button size="sm" variant="outline" onClick={() => setShowAddTx(true)}>
+                + {t('common.add')}
+              </Button>
+            </div>
           </div>
           <TransactionsList
             transactions={transactions}
@@ -249,6 +263,15 @@ export function AccountDetailPage() {
           accountType={account.type}
           onSubmit={async (data) => { await addTxMutation.mutateAsync(data) }}
           isLoading={addTxMutation.isPending}
+        />
+      )}
+
+      {/* Import CSV modal (investment accounts) */}
+      {account && showHoldings && (
+        <ImportTransactionsModal
+          open={showImport}
+          onOpenChange={setShowImport}
+          accountId={account.id}
         />
       )}
 

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -343,6 +343,7 @@ export interface Transaction {
   name: string | null
   quantity: number | null
   pricePerUnit: number | null
+  fees: number | null
 }
 
 export interface TransactionRequest {
@@ -355,4 +356,84 @@ export interface TransactionRequest {
   quantity?: number
   pricePerUnit?: number
   currency?: string
+  fees?: number         // per-trade fees, folded into the PMP cost basis
+}
+
+// --- CSV transaction import (two-phase wizard) ---
+
+export interface CsvDialectDto {
+  delimiter: string
+  decimal: 'DOT' | 'COMMA'
+  dateFormat: string
+}
+
+export interface ColumnMappingDto {
+  date: number | null
+  side: number | null
+  tickerOrIsin: number | null
+  name: number | null
+  quantity: number | null
+  unitPrice: number | null
+  fees: number | null
+  currency: number | null
+  amount: number | null
+}
+
+export interface TransactionImportPreviewResponse {
+  fileToken: string
+  detectedColumns: string[]
+  sampleRows: string[][]
+  totalRows: number
+  hasHeaderRow: boolean
+  dialect: CsvDialectDto
+  suggestedMapping: ColumnMappingDto
+}
+
+export interface TransactionImportRequest {
+  fileToken: string
+  mapping: ColumnMappingDto
+  dialect: CsvDialectDto
+  hasHeaderRow: boolean
+  feesIncludedInAmount: boolean
+  sideValueMap?: Record<string, string>
+}
+
+export interface ImportRowError {
+  rowNumber: number
+  message: string
+}
+
+export interface TransactionImportResultResponse {
+  imported: number
+  skipped: number
+  errors: ImportRowError[]
+}
+
+// --- Realized P&L (closed positions) ---
+
+export interface RealizedLot {
+  ticker: string
+  name: string | null
+  date: string
+  quantity: number
+  avgCost: number
+  proceeds: number
+  realized: number
+}
+
+export interface TickerRealized {
+  ticker: string
+  name: string | null
+  realized: number
+  quantitySold: number
+  proceeds: number
+  costBasis: number
+  warning: boolean
+}
+
+export interface RealizedPnlResponse {
+  currency: string
+  realizedTotal: number
+  byTicker: TickerRealized[]
+  lots: RealizedLot[]
 }


### PR DESCRIPTION
Closes #38.

Two features requested in the issue, for PEA/CTO (and crypto) accounts:

## 1. CSV import of investment transactions (with fees)
A **two-phase, per-account** import wizard (modelled on the Finary importer, but mapping *columns* into an already-selected account):
- **Upload → preview**: sniffs the dialect (delimiter `,`/`;`/tab, decimal `1.23`/`1,23`, date format), guesses the column mapping, and caches the raw file under a token **bound to the account** (30-min TTL).
- **Map → import**: the user confirms/overrides mapping + dialect, the file is re-parsed, each row becomes a manual BUY/SELL, valid rows are bulk-inserted and holdings recomputed once. Bad rows are reported per-row, not fatal.
- Dependency-free RFC-4180 reader (symmetric with the existing `CsvWriter`); ISINs resolved to tickers at import time via the shared `InstrumentFieldResolver`.
- `POST /api/accounts/{id}/transactions/import/preview` + `/import` (member-scoped, throttled, 201).

## 2. Per-trade fees, folded into the PMP
- New `transaction.fees` column (migration **V53**). Fees fold into the average buy-in: `averageBuyIn = Σ(qty·price + fees) / Σ(qty)` (French PEA convention). Amount signing (fees in on BUY, out on SELL) centralised in `TransactionAmountCalculator` and mirrored by the manual-entry modal, which gains an optional **Fees** field.

## 3. Realized P&L on closed positions
- Today a fully-sold position is deleted and its gain/loss disappears from the portfolio. New `RealizedPnlService` computes it **on the fly** from the ordered BUY/SELL stream (moving-average/PMP cost, account currency, no re-pricing), exposed at `GET /api/accounts/{id}/realized-pnl` as a **separate** series (never mixed into `pnl`).
- New **Realized gains** section on the account page (closed-lot table + green/red total).
- ADR records the two decisions (average-cost vs FIFO; compute-on-the-fly vs persist).

## Verification
- Backend: **526** tests green (`mvn test`), incl. new CSV parser/detector/mapper, fees→PMP, realized-P&L (partial/full close, over-sell clamp+warning, sell-without-buy, currency), and import service (token↔account binding, non-investment 400, foreign 404).
- Frontend: **95** vitest green (8 new), `bun run build` / `typecheck` / `lint` clean.
- BE↔FE DTO field names cross-checked (exact match for import + realized).
- Docs: two feature notes + ADR + `manual-transactions.md`/`INDEX.md` updates.

> ⚠️ Not run here (no browser in the CI env): the live demo-mode click-through. To smoke manually: `cd frontend && VITE_DEMO_MODE=true bun run dev`, open a PEA account → "Import CSV" wizard + "Realized gains" section (demo account 2 seeds one green + one red closed lot).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added two-phase CSV transaction import for investment accounts, including dialect/header/mapping preview, import execution, per-row error reporting, and import throttling.
  * Added realized profit/loss for closed positions with per-ticker and lot breakdowns (including over-sell warnings) plus a new account “realized gains” section.
  * Added optional per-trade fees for manual entries and CSV imports; fees now affect cost basis and are included in CSV/JSON transaction exports.
* **Documentation**
  * Updated docs with the realized P&L calculation approach and the CSV import + fees user workflow, including a new ADR.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->