### PR TITLE
fix(crypto): replace deprecated cloudflare-eth RPC with publicnode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   RPC was deprecated and started returning an HTTP 200 JSON-RPC error for
   `eth_getBalance`, which the adapter read as a 0 balance — wallets appeared to
   sync but showed nothing. Switched to `ethereum-rpc.publicnode.com`.
+- **On-chain wallet adapters no longer report a false 0 on RPC failure.** Both
+  the Ethereum and Solana adapters read the JSON-RPC `result` with `path(...)`,
+  which turned an `error` payload (rate-limit, deprecated method, node outage)
+  into a silent 0 balance rather than a sync error. They now validate the
+  envelope — a present `error`, a missing `result`, or an empty response throws
+  and surfaces as a `422` sync failure instead of corrupting the balance. A
+  genuinely empty wallet still reads 0. On Solana this covers both the native
+  SOL and the SPL-token call, and sync failures now preserve their root cause in
+  the logs.
 
 ## [1.0.13] — 2026-07-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   genuinely empty wallet still reads 0. On Solana this covers both the native
   SOL and the SPL-token call, and sync failures now preserve their root cause in
   the logs.
+- **Wallet sync distinguishes bugs from routine RPC failures.** `WalletSyncService`
+  now logs unexpected errors (NPE, etc.) at `ERROR` with a full stacktrace instead
+  of a one-line `WARN`, so a real bug can't hide as a transient sync; the friendly
+  `422` shown to the user is unchanged. A malformed SPL token balance or an
+  unexpected token-list shape is logged and skipped (SOL and other tokens still
+  sync) rather than silently dropped, and a malformed Ethereum hex balance now
+  fails the sync with a clear message instead of an opaque error. Batch resync
+  (`resyncAll`) reports per-wallet outcomes, so the scheduler logs which wallets
+  failed and the MCP wallet-sync tool answers with the real success count.
 
 ## [1.0.13] — 2026-07-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   fails the sync with a clear message instead of an opaque error. Batch resync
   (`resyncAll`) reports per-wallet outcomes, so the scheduler logs which wallets
   failed and the MCP wallet-sync tool answers with the real success count.
+  `WalletRpcException` now also has a dedicated `GlobalExceptionHandler` mapping
+  (generic `422`) as defense-in-depth, so a bad RPC response can never surface as a
+  raw `500` even on an unwrapped call path.
 
 ## [1.0.13] — 2026-07-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   shows the backend's debt-neutral gain/loss, and a new Liabilities card lists
   loans separately.
 
+### Fixed
+
+- **Ethereum wallet balances sync again.** The hard-coded `cloudflare-eth.com`
+  RPC was deprecated and started returning an HTTP 200 JSON-RPC error for
+  `eth_getBalance`, which the adapter read as a 0 balance — wallets appeared to
+  sync but showed nothing. Switched to `ethereum-rpc.publicnode.com`.
+
 ## [1.0.13] — 2026-07-07
 
 ### Changed

--- a/backend/src/main/java/com/picsou/adapter/EthereumWalletAdapter.java
+++ b/backend/src/main/java/com/picsou/adapter/EthereumWalletAdapter.java
@@ -2,6 +2,7 @@ package com.picsou.adapter;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.picsou.adapter.util.JsonRpcResponse;
+import com.picsou.exception.WalletRpcException;
 import com.picsou.port.WalletPort;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -60,10 +61,29 @@ public class EthereumWalletAdapter implements WalletPort {
 
         JsonNode result = JsonRpcResponse.requireResult(response, "Ethereum eth_getBalance");
         String hexBalance = result.asText();
-        BigInteger wei = new BigInteger(hexBalance.substring(2), 16);
+        BigInteger wei = parseHexWei(hexBalance);
         BigDecimal eth = new BigDecimal(wei).divide(WEI_PER_ETH, 18, RoundingMode.HALF_UP);
 
         log.info("Ethereum balance for {}: {} ETH", address, eth);
         return List.of(new WalletBalance("ETH", eth));
+    }
+
+    /**
+     * Parses a {@code 0x}-prefixed hex wei string. A malformed value (missing
+     * prefix, non-hex digits) is treated as a broken RPC response — throwing
+     * rather than letting a raw {@link NumberFormatException} surface as an
+     * opaque 500.
+     */
+    private static BigInteger parseHexWei(String hexBalance) {
+        if (hexBalance == null || !hexBalance.startsWith("0x")) {
+            throw new WalletRpcException(
+                "Ethereum eth_getBalance: malformed hex balance '" + hexBalance + "'");
+        }
+        try {
+            return new BigInteger(hexBalance.substring(2), 16);
+        } catch (NumberFormatException ex) {
+            throw new WalletRpcException(
+                "Ethereum eth_getBalance: malformed hex balance '" + hexBalance + "'");
+        }
     }
 }

--- a/backend/src/main/java/com/picsou/adapter/EthereumWalletAdapter.java
+++ b/backend/src/main/java/com/picsou/adapter/EthereumWalletAdapter.java
@@ -19,7 +19,7 @@ import java.util.Map;
 public class EthereumWalletAdapter implements WalletPort {
 
     private static final Logger log = LoggerFactory.getLogger(EthereumWalletAdapter.class);
-    private static final String RPC_URL = "https://cloudflare-eth.com";
+    private static final String RPC_URL = "https://ethereum-rpc.publicnode.com";
     private static final BigDecimal WEI_PER_ETH = new BigDecimal("1000000000000000000");
 
     private final WebClient webClient;

--- a/backend/src/main/java/com/picsou/adapter/EthereumWalletAdapter.java
+++ b/backend/src/main/java/com/picsou/adapter/EthereumWalletAdapter.java
@@ -1,6 +1,7 @@
 package com.picsou.adapter;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.picsou.adapter.util.JsonRpcResponse;
 import com.picsou.port.WalletPort;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -25,10 +26,15 @@ public class EthereumWalletAdapter implements WalletPort {
     private final WebClient webClient;
 
     public EthereumWalletAdapter() {
-        this.webClient = WebClient.builder()
+        this(WebClient.builder()
             .baseUrl(RPC_URL)
             .defaultHeader("Content-Type", "application/json")
-            .build();
+            .build());
+    }
+
+    // Package-private seam for tests: inject a WebClient backed by an ExchangeFunction.
+    EthereumWalletAdapter(WebClient webClient) {
+        this.webClient = webClient;
     }
 
     @Override
@@ -52,12 +58,8 @@ public class EthereumWalletAdapter implements WalletPort {
             .timeout(Duration.ofSeconds(10))
             .block();
 
-        if (response == null) {
-            log.warn("Ethereum RPC returned null for address {}", address);
-            return List.of(new WalletBalance("ETH", BigDecimal.ZERO));
-        }
-
-        String hexBalance = response.path("result").asText("0x0");
+        JsonNode result = JsonRpcResponse.requireResult(response, "Ethereum eth_getBalance");
+        String hexBalance = result.asText();
         BigInteger wei = new BigInteger(hexBalance.substring(2), 16);
         BigDecimal eth = new BigDecimal(wei).divide(WEI_PER_ETH, 18, RoundingMode.HALF_UP);
 

--- a/backend/src/main/java/com/picsou/adapter/SolanaWalletAdapter.java
+++ b/backend/src/main/java/com/picsou/adapter/SolanaWalletAdapter.java
@@ -1,6 +1,7 @@
 package com.picsou.adapter;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.picsou.adapter.util.JsonRpcResponse;
 import com.picsou.port.WalletPort;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -36,10 +37,15 @@ public class SolanaWalletAdapter implements WalletPort {
     private final WebClient webClient;
 
     public SolanaWalletAdapter() {
-        this.webClient = WebClient.builder()
+        this(WebClient.builder()
             .baseUrl(RPC_URL)
             .defaultHeader("Content-Type", "application/json")
-            .build();
+            .build());
+    }
+
+    // Package-private seam for tests: inject a WebClient backed by an ExchangeFunction.
+    SolanaWalletAdapter(WebClient webClient) {
+        this.webClient = webClient;
     }
 
     @Override
@@ -70,12 +76,8 @@ public class SolanaWalletAdapter implements WalletPort {
             .timeout(Duration.ofSeconds(10))
             .block();
 
-        if (response == null) {
-            log.warn("Solana RPC returned null for address {}", address);
-            return new WalletBalance("SOL", BigDecimal.ZERO);
-        }
-
-        long lamports = response.path("result").path("value").asLong(0);
+        JsonNode result = JsonRpcResponse.requireResult(response, "Solana getBalance");
+        long lamports = result.path("value").asLong(0);
         BigDecimal sol = new BigDecimal(lamports).divide(LAMPORTS_PER_SOL, 9, RoundingMode.HALF_UP);
 
         log.info("Solana balance for {}: {} SOL", address, sol);
@@ -106,12 +108,9 @@ public class SolanaWalletAdapter implements WalletPort {
             .timeout(Duration.ofSeconds(10))
             .block();
 
-        if (response == null) {
-            log.warn("Solana SPL RPC returned null for address {}", address);
-            return List.of();
-        }
-
-        JsonNode accounts = response.path("result").path("value");
+        JsonNode accounts = JsonRpcResponse
+            .requireResult(response, "Solana getTokenAccountsByOwner")
+            .path("value");
         if (!accounts.isArray()) {
             return List.of();
         }

--- a/backend/src/main/java/com/picsou/adapter/SolanaWalletAdapter.java
+++ b/backend/src/main/java/com/picsou/adapter/SolanaWalletAdapter.java
@@ -112,6 +112,7 @@ public class SolanaWalletAdapter implements WalletPort {
             .requireResult(response, "Solana getTokenAccountsByOwner")
             .path("value");
         if (!accounts.isArray()) {
+            log.warn("Solana getTokenAccountsByOwner returned non-array 'value': {}", accounts);
             return List.of();
         }
 
@@ -127,6 +128,11 @@ public class SolanaWalletAdapter implements WalletPort {
             try {
                 amount = new BigDecimal(uiAmount);
             } catch (NumberFormatException ex) {
+                // Corrupt balance from the RPC: skip this one token but log
+                // loudly rather than dropping it silently. Failing the whole
+                // sync over one bad field would also hide the SOL balance and
+                // every other token.
+                log.error("Failed to parse SPL token balance for mint {}: '{}'", mint, uiAmount, ex);
                 continue;
             }
             if (amount.signum() <= 0) continue;

--- a/backend/src/main/java/com/picsou/adapter/util/JsonRpcResponse.java
+++ b/backend/src/main/java/com/picsou/adapter/util/JsonRpcResponse.java
@@ -1,0 +1,49 @@
+package com.picsou.adapter.util;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.picsou.exception.WalletRpcException;
+
+/**
+ * Validation for JSON-RPC 2.0 responses shared by the on-chain wallet adapters.
+ *
+ * <p>A response is only usable when it carries a {@code result} and no
+ * {@code error}. The adapters previously read {@code response.path("result")},
+ * which returns a non-null {@code MissingNode} when {@code result} is absent —
+ * so a JSON-RPC error payload silently defaulted to a 0 balance. This helper
+ * uses {@link JsonNode#get(String)} (null when absent) to tell a <em>missing</em>
+ * result apart from a <em>legitimate zero</em> one, and throws instead of masking
+ * the failure.
+ */
+public final class JsonRpcResponse {
+
+    private JsonRpcResponse() {
+    }
+
+    /**
+     * Validates a JSON-RPC 2.0 envelope and returns its {@code result} node.
+     *
+     * @param response the parsed body, or {@code null} if the call returned nothing
+     * @param context  short diagnostic label, e.g. {@code "Ethereum eth_getBalance"}
+     * @return the present {@code result} node (a {@code TextNode} for ETH, an
+     *         {@code ObjectNode} for SOL); callers may safely navigate it with
+     *         {@code path(...)}
+     * @throws WalletRpcException if {@code response} is null, carries a non-null
+     *         {@code error}, or has a missing/null {@code result}
+     */
+    public static JsonNode requireResult(JsonNode response, String context) {
+        if (response == null) {
+            throw new WalletRpcException(context + ": RPC returned no response");
+        }
+        JsonNode error = response.get("error");
+        if (error != null && !error.isNull()) {
+            throw new WalletRpcException(context + ": RPC error "
+                + error.path("code").asText("?") + " - "
+                + error.path("message").asText("unknown"));
+        }
+        JsonNode result = response.get("result");
+        if (result == null || result.isNull()) {
+            throw new WalletRpcException(context + ": RPC response missing 'result'");
+        }
+        return result;
+    }
+}

--- a/backend/src/main/java/com/picsou/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/picsou/exception/GlobalExceptionHandler.java
@@ -41,6 +41,17 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
         return ProblemDetail.forStatusAndDetail(HttpStatus.UNPROCESSABLE_ENTITY, ex.getMessage());
     }
 
+    // Defense-in-depth: WalletSyncService.sync() already catches WalletRpcException and
+    // re-wraps it into a SyncException with a friendly per-chain message. This backstop
+    // only fires if some future WalletPort caller forgets to wrap it -- so a bad RPC
+    // response can never surface as a raw 500 with a leaked technical message.
+    @ExceptionHandler(WalletRpcException.class)
+    ProblemDetail handleWalletRpc(WalletRpcException ex) {
+        log.warn("Wallet RPC error: {}", ex.getMessage());
+        return ProblemDetail.forStatusAndDetail(HttpStatus.UNPROCESSABLE_ENTITY,
+            "Could not reach the blockchain network. Please try again later.");
+    }
+
     @ExceptionHandler(BadCredentialsException.class)
     ProblemDetail handleBadCredentials(BadCredentialsException ex) {
         return ProblemDetail.forStatusAndDetail(HttpStatus.UNAUTHORIZED, "Invalid credentials");

--- a/backend/src/main/java/com/picsou/exception/WalletRpcException.java
+++ b/backend/src/main/java/com/picsou/exception/WalletRpcException.java
@@ -1,0 +1,14 @@
+package com.picsou.exception;
+
+/**
+ * Raised when a blockchain JSON-RPC endpoint returns an error, an empty
+ * envelope, or a response missing its {@code result}. Unchecked so wallet
+ * adapters keep the {@code WalletPort} signature; {@code WalletSyncService}
+ * catches it and re-wraps into a {@link SyncException} (HTTP 422). This exists
+ * to stop adapters from silently reporting a 0 balance on RPC failure.
+ */
+public class WalletRpcException extends RuntimeException {
+    public WalletRpcException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/picsou/exception/WalletRpcException.java
+++ b/backend/src/main/java/com/picsou/exception/WalletRpcException.java
@@ -6,6 +6,14 @@ package com.picsou.exception;
  * adapters keep the {@code WalletPort} signature; {@code WalletSyncService}
  * catches it and re-wraps into a {@link SyncException} (HTTP 422). This exists
  * to stop adapters from silently reporting a 0 balance on RPC failure.
+ *
+ * <p>This is a <em>technical</em> adapter-level signal, not a business
+ * exception — it deliberately carries no user-facing message and is normally
+ * wrapped by the service into a friendly {@code SyncException}. As a
+ * defense-in-depth backstop, {@code GlobalExceptionHandler} also maps it to a
+ * generic {@code 422} so a future {@code WalletPort} caller that forgets to
+ * wrap it cannot surface a raw {@code 500}. See
+ * {@code docs/conventions/error-handling.md}.
  */
 public class WalletRpcException extends RuntimeException {
     public WalletRpcException(String message) {

--- a/backend/src/main/java/com/picsou/mcp/tools/SyncTools.java
+++ b/backend/src/main/java/com/picsou/mcp/tools/SyncTools.java
@@ -80,7 +80,14 @@ public class SyncTools {
             + "Does not add a new wallet.")
     @RequiresScope(Scopes.SYNC_TRIGGER)
     public String triggerCryptoWalletSync() {
-        walletSyncService.resyncAll(userContext.currentMemberId());
-        return "Crypto wallet sync triggered for your existing wallets.";
+        WalletSyncService.ResyncSummary summary = walletSyncService.resyncAll(userContext.currentMemberId());
+        if (summary.total() == 0) {
+            return "No on-chain wallets to sync.";
+        }
+        String result = "Crypto wallet sync: " + summary.succeeded() + "/" + summary.total() + " succeeded.";
+        if (!summary.failed().isEmpty()) {
+            result += " Failed: " + summary.failed().stream().map(Enum::name).collect(java.util.stream.Collectors.joining(", ")) + ".";
+        }
+        return result;
     }
 }

--- a/backend/src/main/java/com/picsou/service/SchedulerService.java
+++ b/backend/src/main/java/com/picsou/service/SchedulerService.java
@@ -99,7 +99,11 @@ public class SchedulerService {
             }
 
             try {
-                walletSyncService.resyncAll(memberId);
+                WalletSyncService.ResyncSummary walletSummary = walletSyncService.resyncAll(memberId);
+                if (!walletSummary.failed().isEmpty()) {
+                    log.warn("Daily wallet sync for member {}: {}/{} succeeded, failed chains: {}",
+                        memberId, walletSummary.succeeded(), walletSummary.total(), walletSummary.failed());
+                }
             } catch (Exception ex) {
                 log.error("Daily wallet sync failed for member {}", memberId, ex);
             }

--- a/backend/src/main/java/com/picsou/service/WalletSyncService.java
+++ b/backend/src/main/java/com/picsou/service/WalletSyncService.java
@@ -78,7 +78,9 @@ public class WalletSyncService {
 
         try {
             List<WalletBalance> balances = adapter.fetchBalances(wallet.getAddress());
-            if (balances == null || balances.isEmpty()) {
+            // WalletPort.fetchBalances contracts a non-null list with at least the native
+            // asset; isEmpty() stays only as a cheap guard against a misbehaving adapter.
+            if (balances.isEmpty()) {
                 throw new SyncException("Adapter returned no balances for " + wallet.getChain());
             }
 

--- a/backend/src/main/java/com/picsou/service/WalletSyncService.java
+++ b/backend/src/main/java/com/picsou/service/WalletSyncService.java
@@ -125,7 +125,7 @@ public class WalletSyncService {
 
         } catch (Exception ex) {
             log.warn("Wallet sync failed for {} {}: {}", wallet.getChain(), wallet.getAddress(), ex.getMessage());
-            throw new SyncException("Could not sync your " + wallet.getChain() + " wallet. Please try again later.");
+            throw new SyncException("Could not sync your " + wallet.getChain() + " wallet. Please try again later.", ex);
         }
     }
 

--- a/backend/src/main/java/com/picsou/service/WalletSyncService.java
+++ b/backend/src/main/java/com/picsou/service/WalletSyncService.java
@@ -3,6 +3,7 @@ package com.picsou.service;
 import com.picsou.dto.AccountResponse;
 import com.picsou.exception.ResourceNotFoundException;
 import com.picsou.exception.SyncException;
+import com.picsou.exception.WalletRpcException;
 import com.picsou.model.*;
 import com.picsou.port.WalletPort;
 import com.picsou.port.WalletPort.WalletBalance;
@@ -18,6 +19,7 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.Instant;
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -123,8 +125,15 @@ public class WalletSyncService {
 
             return accountService.toResponse(account);
 
-        } catch (Exception ex) {
+        } catch (WalletRpcException | SyncException ex) {
+            // Expected external failure (bad RPC response, no balances): a routine
+            // sync problem, not a bug. Keep the friendly 422 the user sees.
             log.warn("Wallet sync failed for {} {}: {}", wallet.getChain(), wallet.getAddress(), ex.getMessage());
+            throw new SyncException("Could not sync your " + wallet.getChain() + " wallet. Please try again later.", ex);
+        } catch (Exception ex) {
+            // Anything else (NPE, ClassCastException...) is a genuine bug -- log it
+            // at ERROR with the full stacktrace so it doesn't hide as a transient sync.
+            log.error("Unexpected error during wallet sync for {} {}", wallet.getChain(), wallet.getAddress(), ex);
             throw new SyncException("Could not sync your " + wallet.getChain() + " wallet. Please try again later.", ex);
         }
     }
@@ -140,15 +149,20 @@ public class WalletSyncService {
         log.info("Removed wallet {} and associated account", walletId);
     }
 
-    public void resyncAll(Long memberId) {
+    public ResyncSummary resyncAll(Long memberId) {
         List<WalletAddress> wallets = walletRepository.findAllByMemberId(memberId);
+        int succeeded = 0;
+        List<Chain> failed = new ArrayList<>();
         for (WalletAddress wallet : wallets) {
             try {
                 sync(wallet.getId(), memberId);
+                succeeded++;
             } catch (Exception ex) {
-                log.warn("Wallet resync failed for {} {}: {}", wallet.getChain(), wallet.getAddress(), ex.getMessage());
+                log.error("Wallet resync failed for {} {}", wallet.getChain(), wallet.getAddress(), ex);
+                failed.add(wallet.getChain());
             }
         }
+        return new ResyncSummary(wallets.size(), succeeded, failed);
     }
 
     @Transactional(readOnly = true)
@@ -197,4 +211,7 @@ public class WalletSyncService {
 
     public record WalletStatusResponse(
         Long id, Chain chain, String address, String label, java.time.Instant lastSyncedAt) {}
+
+    /** Outcome of a batch resync: how many wallets were tried, how many synced, and which chains failed. */
+    public record ResyncSummary(int total, int succeeded, List<Chain> failed) {}
 }

--- a/backend/src/test/java/com/picsou/adapter/EthereumWalletAdapterTest.java
+++ b/backend/src/test/java/com/picsou/adapter/EthereumWalletAdapterTest.java
@@ -28,6 +28,15 @@ class EthereumWalletAdapterTest {
         return new EthereumWalletAdapter(WebClient.builder().exchangeFunction(exchange).build());
     }
 
+    private EthereumWalletAdapter adapterReturningNoBody() {
+        // An empty body maps to Mono.empty(), so .block() yields a null response --
+        // the timeout / dropped-connection case.
+        ExchangeFunction exchange = request -> Mono.just(ClientResponse.create(HttpStatus.OK)
+            .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+            .build());
+        return new EthereumWalletAdapter(WebClient.builder().exchangeFunction(exchange).build());
+    }
+
     @Test
     void fetchBalances_parsesHexWeiIntoEth() {
         // 0xDE0B6B3A7640000 = 10^18 wei = 1 ETH
@@ -71,5 +80,34 @@ class EthereumWalletAdapterTest {
         assertThatThrownBy(() -> adapter.fetchBalances(ADDRESS))
             .isInstanceOf(WalletRpcException.class)
             .hasMessageContaining("missing 'result'");
+    }
+
+    @Test
+    void fetchBalances_throws_onNullResponseBody() {
+        var adapter = adapterReturningNoBody();
+
+        assertThatThrownBy(() -> adapter.fetchBalances(ADDRESS))
+            .isInstanceOf(WalletRpcException.class)
+            .hasMessageContaining("no response");
+    }
+
+    @Test
+    void fetchBalances_throws_onMalformedHexDigits() {
+        var adapter = adapterReturning("""
+            {"jsonrpc":"2.0","id":1,"result":"0xINVALID"}""");
+
+        assertThatThrownBy(() -> adapter.fetchBalances(ADDRESS))
+            .isInstanceOf(WalletRpcException.class)
+            .hasMessageContaining("malformed hex");
+    }
+
+    @Test
+    void fetchBalances_throws_onMissingHexPrefix() {
+        var adapter = adapterReturning("""
+            {"jsonrpc":"2.0","id":1,"result":"12345"}""");
+
+        assertThatThrownBy(() -> adapter.fetchBalances(ADDRESS))
+            .isInstanceOf(WalletRpcException.class)
+            .hasMessageContaining("malformed hex");
     }
 }

--- a/backend/src/test/java/com/picsou/adapter/EthereumWalletAdapterTest.java
+++ b/backend/src/test/java/com/picsou/adapter/EthereumWalletAdapterTest.java
@@ -1,0 +1,75 @@
+package com.picsou.adapter;
+
+import com.picsou.exception.WalletRpcException;
+import com.picsou.port.WalletPort.WalletBalance;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.web.reactive.function.client.ClientResponse;
+import org.springframework.web.reactive.function.client.ExchangeFunction;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class EthereumWalletAdapterTest {
+
+    private static final String ADDRESS = "0x1111111111111111111111111111111111111111";
+
+    private EthereumWalletAdapter adapterReturning(String json) {
+        ExchangeFunction exchange = request -> Mono.just(ClientResponse.create(HttpStatus.OK)
+            .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+            .body(json)
+            .build());
+        return new EthereumWalletAdapter(WebClient.builder().exchangeFunction(exchange).build());
+    }
+
+    @Test
+    void fetchBalances_parsesHexWeiIntoEth() {
+        // 0xDE0B6B3A7640000 = 10^18 wei = 1 ETH
+        var adapter = adapterReturning("""
+            {"jsonrpc":"2.0","id":1,"result":"0xDE0B6B3A7640000"}""");
+
+        List<WalletBalance> balances = adapter.fetchBalances(ADDRESS);
+
+        assertThat(balances).singleElement().satisfies(b -> {
+            assertThat(b.symbol()).isEqualTo("ETH");
+            assertThat(b.amount()).isEqualByComparingTo(BigDecimal.ONE);
+        });
+    }
+
+    @Test
+    void fetchBalances_returnsZero_forLegitimateEmptyWallet() {
+        var adapter = adapterReturning("""
+            {"jsonrpc":"2.0","id":1,"result":"0x0"}""");
+
+        List<WalletBalance> balances = adapter.fetchBalances(ADDRESS);
+
+        assertThat(balances).singleElement().satisfies(b ->
+            assertThat(b.amount()).isEqualByComparingTo(BigDecimal.ZERO));
+    }
+
+    @Test
+    void fetchBalances_throws_onRpcError() {
+        var adapter = adapterReturning("""
+            {"jsonrpc":"2.0","id":1,"error":{"code":-32000,"message":"rate limited"}}""");
+
+        assertThatThrownBy(() -> adapter.fetchBalances(ADDRESS))
+            .isInstanceOf(WalletRpcException.class)
+            .hasMessageContaining("rate limited");
+    }
+
+    @Test
+    void fetchBalances_throws_onMissingResult() {
+        var adapter = adapterReturning("""
+            {"jsonrpc":"2.0","id":1}""");
+
+        assertThatThrownBy(() -> adapter.fetchBalances(ADDRESS))
+            .isInstanceOf(WalletRpcException.class)
+            .hasMessageContaining("missing 'result'");
+    }
+}

--- a/backend/src/test/java/com/picsou/adapter/SolanaWalletAdapterTest.java
+++ b/backend/src/test/java/com/picsou/adapter/SolanaWalletAdapterTest.java
@@ -44,6 +44,25 @@ class SolanaWalletAdapterTest {
     private static final String RPC_ERROR = """
         {"jsonrpc":"2.0","id":1,"error":{"code":-32000,"message":"rate limited"}}""";
 
+    // getBalance result present but without a 'value' field.
+    private static final String SOL_NO_VALUE = """
+        {"jsonrpc":"2.0","id":1,"result":{}}""";
+
+    // 'value' is an object, not the expected array (malformed structure).
+    private static final String TOKENS_NON_ARRAY = """
+        {"jsonrpc":"2.0","id":2,"result":{"value":{"unexpected":"shape"}}}""";
+
+    // One good USDC account plus a known-mint (USDT) account with a garbage balance.
+    private static final String TOKENS_USDC_AND_MALFORMED = """
+        {"jsonrpc":"2.0","id":2,"result":{"value":[
+          {"account":{"data":{"parsed":{"info":{
+            "mint":"EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "tokenAmount":{"uiAmountString":"50"}}}}}},
+          {"account":{"data":{"parsed":{"info":{
+            "mint":"Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB",
+            "tokenAmount":{"uiAmountString":"not-a-number"}}}}}}
+        ]}}""";
+
     /**
      * {@code fetchBalances} issues two sequential POSTs to the same URL
      * (getBalance, then getTokenAccountsByOwner), so responses are returned in
@@ -108,5 +127,49 @@ class SolanaWalletAdapterTest {
         assertThatThrownBy(() -> adapter.fetchBalances(ADDRESS))
             .isInstanceOf(WalletRpcException.class)
             .hasMessageContaining("rate limited");
+    }
+
+    @Test
+    void fetchBalances_returnsSolOnly_whenTokenValueNotArray() {
+        // Malformed (non-array) token 'value' is logged and treated as no tokens,
+        // but the SOL balance still comes through -- non-fatal.
+        var adapter = adapterReturning(SOL_1, TOKENS_NON_ARRAY);
+
+        List<WalletBalance> balances = adapter.fetchBalances(ADDRESS);
+
+        assertThat(balances).singleElement().satisfies(b -> {
+            assertThat(b.symbol()).isEqualTo("SOL");
+            assertThat(b.amount()).isEqualByComparingTo(BigDecimal.ONE);
+        });
+    }
+
+    @Test
+    void fetchBalances_skipsMalformedToken_keepsSolAndGoodTokens() {
+        // A garbage uiAmountString on one known-mint token is skipped (logged),
+        // not fatal: SOL and the other valid token still come back.
+        var adapter = adapterReturning(SOL_1, TOKENS_USDC_AND_MALFORMED);
+
+        List<WalletBalance> balances = adapter.fetchBalances(ADDRESS);
+
+        assertThat(balances).hasSize(2);
+        assertThat(balances).anySatisfy(b -> assertThat(b.symbol()).isEqualTo("SOL"));
+        assertThat(balances).anySatisfy(b -> {
+            assertThat(b.symbol()).isEqualTo("USDC");
+            assertThat(b.amount()).isEqualByComparingTo(new BigDecimal("50"));
+        });
+        assertThat(balances).noneSatisfy(b -> assertThat(b.symbol()).isEqualTo("USDT"));
+    }
+
+    @Test
+    void fetchBalances_returnsZeroSol_whenResultHasNoValueField() {
+        // A present result object missing 'value' is not an error -- defaults to 0.
+        var adapter = adapterReturning(SOL_NO_VALUE, TOKENS_EMPTY);
+
+        List<WalletBalance> balances = adapter.fetchBalances(ADDRESS);
+
+        assertThat(balances).singleElement().satisfies(b -> {
+            assertThat(b.symbol()).isEqualTo("SOL");
+            assertThat(b.amount()).isEqualByComparingTo(BigDecimal.ZERO);
+        });
     }
 }

--- a/backend/src/test/java/com/picsou/adapter/SolanaWalletAdapterTest.java
+++ b/backend/src/test/java/com/picsou/adapter/SolanaWalletAdapterTest.java
@@ -1,0 +1,112 @@
+package com.picsou.adapter;
+
+import com.picsou.exception.WalletRpcException;
+import com.picsou.port.WalletPort.WalletBalance;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.web.reactive.function.client.ClientResponse;
+import org.springframework.web.reactive.function.client.ExchangeFunction;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class SolanaWalletAdapterTest {
+
+    private static final String ADDRESS = "So11111111111111111111111111111111111111112";
+
+    private static final String SOL_1 = """
+        {"jsonrpc":"2.0","id":1,"result":{"value":1000000000}}""";
+
+    private static final String SOL_ZERO = """
+        {"jsonrpc":"2.0","id":1,"result":{"value":0}}""";
+
+    private static final String TOKENS_EMPTY = """
+        {"jsonrpc":"2.0","id":2,"result":{"value":[]}}""";
+
+    // One USDC account (50 USDC) plus one unknown mint that must be dropped.
+    private static final String TOKENS_USDC_AND_UNKNOWN = """
+        {"jsonrpc":"2.0","id":2,"result":{"value":[
+          {"account":{"data":{"parsed":{"info":{
+            "mint":"EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "tokenAmount":{"uiAmountString":"50"}}}}}},
+          {"account":{"data":{"parsed":{"info":{
+            "mint":"UnknownMint1111111111111111111111111111111",
+            "tokenAmount":{"uiAmountString":"999"}}}}}}
+        ]}}""";
+
+    private static final String RPC_ERROR = """
+        {"jsonrpc":"2.0","id":1,"error":{"code":-32000,"message":"rate limited"}}""";
+
+    /**
+     * {@code fetchBalances} issues two sequential POSTs to the same URL
+     * (getBalance, then getTokenAccountsByOwner), so responses are returned in
+     * call order rather than routed by URL.
+     */
+    private SolanaWalletAdapter adapterReturning(String... jsonInOrder) {
+        AtomicInteger index = new AtomicInteger();
+        ExchangeFunction exchange = request -> {
+            String body = jsonInOrder[index.getAndIncrement()];
+            return Mono.just(ClientResponse.create(HttpStatus.OK)
+                .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                .body(body)
+                .build());
+        };
+        return new SolanaWalletAdapter(WebClient.builder().exchangeFunction(exchange).build());
+    }
+
+    @Test
+    void fetchBalances_returnsSolAndKnownTokens_dropsUnknownMint() {
+        var adapter = adapterReturning(SOL_1, TOKENS_USDC_AND_UNKNOWN);
+
+        List<WalletBalance> balances = adapter.fetchBalances(ADDRESS);
+
+        assertThat(balances).hasSize(2);
+        assertThat(balances.get(0).symbol()).isEqualTo("SOL");
+        assertThat(balances.get(0).amount()).isEqualByComparingTo(BigDecimal.ONE);
+        assertThat(balances).anySatisfy(b -> {
+            assertThat(b.symbol()).isEqualTo("USDC");
+            assertThat(b.amount()).isEqualByComparingTo(new BigDecimal("50"));
+        });
+        assertThat(balances).noneSatisfy(b ->
+            assertThat(b.amount()).isEqualByComparingTo(new BigDecimal("999")));
+    }
+
+    @Test
+    void fetchBalances_returnsZeroSol_forLegitimateEmptyWallet() {
+        var adapter = adapterReturning(SOL_ZERO, TOKENS_EMPTY);
+
+        List<WalletBalance> balances = adapter.fetchBalances(ADDRESS);
+
+        assertThat(balances).singleElement().satisfies(b -> {
+            assertThat(b.symbol()).isEqualTo("SOL");
+            assertThat(b.amount()).isEqualByComparingTo(BigDecimal.ZERO);
+        });
+    }
+
+    @Test
+    void fetchBalances_throws_whenGetBalanceReturnsRpcError() {
+        var adapter = adapterReturning(RPC_ERROR, TOKENS_EMPTY);
+
+        assertThatThrownBy(() -> adapter.fetchBalances(ADDRESS))
+            .isInstanceOf(WalletRpcException.class)
+            .hasMessageContaining("rate limited");
+    }
+
+    @Test
+    void fetchBalances_throws_whenTokenCallReturnsRpcError() {
+        // SOL succeeds but the SPL-token call errors -- fail the whole sync
+        // rather than silently under-reporting stablecoin holdings.
+        var adapter = adapterReturning(SOL_1, RPC_ERROR);
+
+        assertThatThrownBy(() -> adapter.fetchBalances(ADDRESS))
+            .isInstanceOf(WalletRpcException.class)
+            .hasMessageContaining("rate limited");
+    }
+}

--- a/backend/src/test/java/com/picsou/adapter/util/JsonRpcResponseTest.java
+++ b/backend/src/test/java/com/picsou/adapter/util/JsonRpcResponseTest.java
@@ -1,0 +1,87 @@
+package com.picsou.adapter.util;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.picsou.exception.WalletRpcException;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class JsonRpcResponseTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private static JsonNode parse(String json) {
+        try {
+            return MAPPER.readTree(json);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    void requireResult_returnsResultNode_whenPresent() {
+        JsonNode result = JsonRpcResponse.requireResult(
+            parse("{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":\"0xDE0B6B3A7640000\"}"), "ctx");
+
+        assertThat(result.asText()).isEqualTo("0xDE0B6B3A7640000");
+    }
+
+    @Test
+    void requireResult_allowsLegitimateHexZero() {
+        JsonNode result = JsonRpcResponse.requireResult(
+            parse("{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":\"0x0\"}"), "ctx");
+
+        assertThat(result.asText()).isEqualTo("0x0");
+    }
+
+    @Test
+    void requireResult_allowsLegitimateNumericZero() {
+        JsonNode result = JsonRpcResponse.requireResult(
+            parse("{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"value\":0}}"), "ctx");
+
+        assertThat(result.path("value").asLong(-1)).isZero();
+    }
+
+    @Test
+    void requireResult_allowsEmptyArrayResult() {
+        JsonNode result = JsonRpcResponse.requireResult(
+            parse("{\"jsonrpc\":\"2.0\",\"id\":2,\"result\":{\"value\":[]}}"), "ctx");
+
+        assertThat(result.path("value").isArray()).isTrue();
+        assertThat(result.path("value")).isEmpty();
+    }
+
+    @Test
+    void requireResult_throws_whenResponseIsNull() {
+        assertThatThrownBy(() -> JsonRpcResponse.requireResult(null, "ctx"))
+            .isInstanceOf(WalletRpcException.class)
+            .hasMessageContaining("no response");
+    }
+
+    @Test
+    void requireResult_throws_onRpcError() {
+        assertThatThrownBy(() -> JsonRpcResponse.requireResult(
+            parse("{\"jsonrpc\":\"2.0\",\"id\":1,\"error\":{\"code\":-32000,\"message\":\"rate limited\"}}"), "ctx"))
+            .isInstanceOf(WalletRpcException.class)
+            .hasMessageContaining("-32000")
+            .hasMessageContaining("rate limited");
+    }
+
+    @Test
+    void requireResult_throws_whenResultMissing() {
+        assertThatThrownBy(() -> JsonRpcResponse.requireResult(
+            parse("{\"jsonrpc\":\"2.0\",\"id\":1}"), "ctx"))
+            .isInstanceOf(WalletRpcException.class)
+            .hasMessageContaining("missing 'result'");
+    }
+
+    @Test
+    void requireResult_throws_whenResultIsExplicitNull() {
+        assertThatThrownBy(() -> JsonRpcResponse.requireResult(
+            parse("{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":null}"), "ctx"))
+            .isInstanceOf(WalletRpcException.class)
+            .hasMessageContaining("missing 'result'");
+    }
+}

--- a/backend/src/test/java/com/picsou/mcp/tools/SyncToolsTest.java
+++ b/backend/src/test/java/com/picsou/mcp/tools/SyncToolsTest.java
@@ -64,6 +64,8 @@ class SyncToolsTest {
     @Test
     void triggerCryptoWalletSync_resyncsWalletsForCurrentMember() {
         when(userContext.currentMemberId()).thenReturn(MID);
+        when(walletSyncService.resyncAll(MID))
+            .thenReturn(new WalletSyncService.ResyncSummary(1, 1, java.util.List.of()));
 
         tools.triggerCryptoWalletSync();
 

--- a/backend/src/test/java/com/picsou/service/WalletSyncServiceTest.java
+++ b/backend/src/test/java/com/picsou/service/WalletSyncServiceTest.java
@@ -13,6 +13,7 @@ import com.picsou.repository.FamilyMemberRepository;
 import com.picsou.repository.WalletAddressRepository;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -24,8 +25,10 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -67,6 +70,46 @@ class WalletSyncServiceTest {
 
         // Failure surfaced before the wallet was persisted as synced.
         verify(walletRepository, never()).save(any());
+    }
+
+    @Test
+    void sync_persistsHoldingsAndSnapshot_onSuccess() {
+        WalletAddress wallet = wallet(1L, Chain.SOLANA, "SoLaNa");
+        when(walletRepository.findByIdAndMemberId(1L, MEMBER_ID)).thenReturn(Optional.of(wallet));
+
+        WalletPort adapter = mock(WalletPort.class);
+        when(adapter.chain()).thenReturn("SOLANA");
+        when(adapter.fetchBalances(any())).thenReturn(List.of(
+            new WalletBalance("SOL", BigDecimal.ONE),
+            new WalletBalance("USDC", new BigDecimal("50"))));
+
+        // 1 SOL @ 20 EUR + 50 USDC @ 1 EUR = 70.00 EUR.
+        when(priceService.refreshPrices(any()))
+            .thenReturn(Map.of("SOL", new BigDecimal("20"), "USDC", new BigDecimal("1")));
+        when(accountRepository.findByExternalAccountIdAndMemberId(any(), any())).thenReturn(Optional.empty());
+        when(familyMemberRepository.findById(MEMBER_ID)).thenReturn(Optional.of(mock(FamilyMember.class)));
+        Account savedAccount = mock(Account.class);
+        when(savedAccount.getId()).thenReturn(100L);
+        when(accountRepository.save(any())).thenReturn(savedAccount);
+
+        WalletSyncService service = serviceWith(adapter);
+
+        service.sync(1L, MEMBER_ID);
+
+        // The response is built from the resolved account.
+        verify(accountService).toResponse(savedAccount);
+
+        // One holding per priced, positive balance.
+        verify(accountService, times(2)).upsertHolding(eq(100L), eq(MEMBER_ID), any(), any(), any(), any());
+
+        // Snapshot balance is the summed EUR value -- guards the conversion math.
+        ArgumentCaptor<BigDecimal> balanceEur = ArgumentCaptor.forClass(BigDecimal.class);
+        verify(accountService).upsertSnapshot(eq(savedAccount), balanceEur.capture(), any());
+        assertThat(balanceEur.getValue()).isEqualByComparingTo("70.00");
+
+        // lastSyncedAt was stamped and the wallet persisted.
+        verify(walletRepository).save(wallet);
+        assertThat(wallet.getLastSyncedAt()).isNotNull();
     }
 
     @Test

--- a/backend/src/test/java/com/picsou/service/WalletSyncServiceTest.java
+++ b/backend/src/test/java/com/picsou/service/WalletSyncServiceTest.java
@@ -1,0 +1,130 @@
+package com.picsou.service;
+
+import com.picsou.exception.SyncException;
+import com.picsou.exception.WalletRpcException;
+import com.picsou.model.Account;
+import com.picsou.model.Chain;
+import com.picsou.model.FamilyMember;
+import com.picsou.model.WalletAddress;
+import com.picsou.port.WalletPort;
+import com.picsou.port.WalletPort.WalletBalance;
+import com.picsou.repository.AccountRepository;
+import com.picsou.repository.FamilyMemberRepository;
+import com.picsou.repository.WalletAddressRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class WalletSyncServiceTest {
+
+    private static final Long MEMBER_ID = 1L;
+
+    @Mock WalletAddressRepository walletRepository;
+    @Mock AccountRepository accountRepository;
+    @Mock FamilyMemberRepository familyMemberRepository;
+    @Mock AccountService accountService;
+    @Mock PriceService priceService;
+
+    private WalletSyncService serviceWith(WalletPort... adapters) {
+        return new WalletSyncService(
+            List.of(adapters), walletRepository, accountRepository,
+            familyMemberRepository, accountService, priceService);
+    }
+
+    private static WalletAddress wallet(Long id, Chain chain, String address) {
+        return WalletAddress.builder().id(id).chain(chain).address(address).build();
+    }
+
+    @Test
+    void sync_wrapsRpcErrorInSyncException_andDoesNotMarkWalletSynced() {
+        WalletAddress wallet = wallet(1L, Chain.ETHEREUM, "0xabc");
+        when(walletRepository.findByIdAndMemberId(1L, MEMBER_ID)).thenReturn(Optional.of(wallet));
+
+        WalletPort adapter = mock(WalletPort.class);
+        when(adapter.chain()).thenReturn("ETHEREUM");
+        when(adapter.fetchBalances(any())).thenThrow(new WalletRpcException("Ethereum eth_getBalance: RPC error"));
+
+        WalletSyncService service = serviceWith(adapter);
+
+        assertThatThrownBy(() -> service.sync(1L, MEMBER_ID))
+            .isInstanceOf(SyncException.class)
+            .hasCauseInstanceOf(WalletRpcException.class);
+
+        // Failure surfaced before the wallet was persisted as synced.
+        verify(walletRepository, never()).save(any());
+    }
+
+    @Test
+    void sync_throwsSyncException_whenAdapterReturnsNoBalances() {
+        WalletAddress wallet = wallet(1L, Chain.ETHEREUM, "0xabc");
+        when(walletRepository.findByIdAndMemberId(1L, MEMBER_ID)).thenReturn(Optional.of(wallet));
+
+        WalletPort adapter = mock(WalletPort.class);
+        when(adapter.chain()).thenReturn("ETHEREUM");
+        when(adapter.fetchBalances(any())).thenReturn(List.of());
+
+        WalletSyncService service = serviceWith(adapter);
+
+        assertThatThrownBy(() -> service.sync(1L, MEMBER_ID))
+            .isInstanceOf(SyncException.class);
+    }
+
+    @Test
+    void resyncAll_reportsFailedChain_andKeepsSyncingOthers() {
+        WalletAddress eth = wallet(1L, Chain.ETHEREUM, "0xabc");
+        WalletAddress sol = wallet(2L, Chain.SOLANA, "SoLaNa");
+        when(walletRepository.findAllByMemberId(MEMBER_ID)).thenReturn(List.of(eth, sol));
+        when(walletRepository.findByIdAndMemberId(1L, MEMBER_ID)).thenReturn(Optional.of(eth));
+        when(walletRepository.findByIdAndMemberId(2L, MEMBER_ID)).thenReturn(Optional.of(sol));
+
+        // ETH adapter succeeds; SOL adapter errors.
+        WalletPort ethAdapter = mock(WalletPort.class);
+        when(ethAdapter.chain()).thenReturn("ETHEREUM");
+        when(ethAdapter.fetchBalances(any())).thenReturn(List.of(new WalletBalance("ETH", BigDecimal.ONE)));
+        WalletPort solAdapter = mock(WalletPort.class);
+        when(solAdapter.chain()).thenReturn("SOLANA");
+        when(solAdapter.fetchBalances(any())).thenThrow(new WalletRpcException("Solana getBalance: RPC error"));
+
+        // Happy-path wiring for the ETH sync.
+        when(priceService.refreshPrices(any())).thenReturn(Map.of("ETH", new BigDecimal("2000")));
+        when(accountRepository.findByExternalAccountIdAndMemberId(any(), any())).thenReturn(Optional.empty());
+        when(familyMemberRepository.findById(MEMBER_ID)).thenReturn(Optional.of(mock(FamilyMember.class)));
+        Account savedAccount = mock(Account.class);
+        when(savedAccount.getId()).thenReturn(100L);
+        when(accountRepository.save(any())).thenReturn(savedAccount);
+
+        WalletSyncService service = serviceWith(ethAdapter, solAdapter);
+
+        WalletSyncService.ResyncSummary summary = service.resyncAll(MEMBER_ID);
+
+        assertThat(summary.total()).isEqualTo(2);
+        assertThat(summary.succeeded()).isEqualTo(1);
+        assertThat(summary.failed()).containsExactly(Chain.SOLANA);
+    }
+
+    @Test
+    void resyncAll_returnsEmptySummary_whenNoWallets() {
+        when(walletRepository.findAllByMemberId(MEMBER_ID)).thenReturn(List.of());
+
+        WalletSyncService.ResyncSummary summary = serviceWith().resyncAll(MEMBER_ID);
+
+        assertThat(summary.total()).isZero();
+        assertThat(summary.succeeded()).isZero();
+        assertThat(summary.failed()).isEmpty();
+    }
+}

--- a/docs/conventions/error-handling.md
+++ b/docs/conventions/error-handling.md
@@ -5,7 +5,8 @@
 ```
 RuntimeException
   +-- ResourceNotFoundException      404 NOT_FOUND
-  +-- SyncException                  502 BAD_GATEWAY
+  +-- SyncException                  422 UNPROCESSABLE_ENTITY
+  +-- WalletRpcException             422 UNPROCESSABLE_ENTITY (adapter-level, see below)
   +-- BadCredentialsException        401 UNAUTHORIZED   (Spring Security)
   +-- IllegalArgumentException       400 BAD_REQUEST
   +-- MethodArgumentNotValidException 422 UNPROCESSABLE_ENTITY (via @Valid)
@@ -32,7 +33,8 @@ A `@RestControllerAdvice` that extends `ResponseEntityExceptionHandler`. Returns
 | Handler method | Exception | Status | Detail |
 |---------------|-----------|--------|--------|
 | `handleNotFound` | `ResourceNotFoundException` | 404 | `ex.getMessage()` |
-| `handleSync` | `SyncException` | 502 | `ex.getMessage()` (logged at WARN) |
+| `handleSync` | `SyncException` | 422 | `ex.getMessage()` (logged at WARN) |
+| `handleWalletRpc` | `WalletRpcException` | 422 | generic `"Could not reach the blockchain network…"` (logged at WARN) |
 | `handleBadCredentials` | `BadCredentialsException` | 401 | `"Invalid credentials"` |
 | `handleIllegalArgument` | `IllegalArgumentException` | 400 | `ex.getMessage()` |
 | `handleMethodArgumentNotValid` | `MethodArgumentNotValidException` | 422 | Field map under `"errors"` key |
@@ -95,6 +97,12 @@ Logged at WARN level so upstream flakiness is trackable without alert fatigue.
 - **Never create an `AppException` base class** — each exception type extends `RuntimeException` directly.
 - **Never expose stack traces to clients** — the generic 500 handler returns "An unexpected error occurred".
 - **Never throw business exceptions from adapters** — wrap external errors in `SyncException`.
+  The one sanctioned exception is `WalletRpcException`: a *technical* signal (no user-facing
+  message) a wallet adapter throws when a blockchain JSON-RPC response is an error / missing
+  its `result`, so it can't silently report a 0 balance. `WalletSyncService.sync()` catches
+  it and wraps it in a friendly `SyncException`; `GlobalExceptionHandler` maps it to a generic
+  `422` as defense-in-depth. The business rule still holds — this is a technical, not a
+  business, exception. See [`docs/features/crypto-tracking.md`](../features/crypto-tracking.md).
 
 ## Frontend display
 

--- a/docs/features/crypto-tracking.md
+++ b/docs/features/crypto-tracking.md
@@ -46,6 +46,8 @@ The adapter scans each chain until `GAP_LIMIT` (20) consecutive unused addresses
 
 Both on-chain adapters validate the JSON-RPC envelope through `JsonRpcResponse.requireResult(response, context)` (`adapter/util/`) before reading a balance. A present `error` field, a missing `result`, or an empty response throws `WalletRpcException`, which `WalletSyncService` surfaces as a `422` sync failure. This is deliberate: reading `result` with `path(...)` returns a non-null `MissingNode`, so an error payload would otherwise default to a **silent 0 balance** — indistinguishable from a genuinely empty wallet. A real `0x0` / `value:0` result still returns 0. On Solana, an error on the SPL-token call fails the whole sync rather than silently dropping stablecoin holdings.
 
+`WalletSyncService.sync()` splits its catch: **expected** failures (`WalletRpcException`, `SyncException`) log at `WARN` and become the friendly `422`; **unexpected** ones (NPE, `ClassCastException`, …) log at `ERROR` with the full stacktrace so a real bug can't hide as a transient sync. `WalletRpcException` has no dedicated `@ExceptionHandler` — it stays wrapped in `SyncException`, which keeps the `422` mapping. Two per-item cases inside the Solana adapter are **not** fatal, to avoid one bad field hiding the rest of the wallet: a non-array token `value` and a malformed `uiAmountString` are logged (WARN / ERROR respectively) and that one entry is skipped, while SOL and every parseable token still come through. `resyncAll()` returns a `ResyncSummary(total, succeeded, failed)` so its callers (the daily scheduler and the `trigger_crypto_wallet_sync` MCP tool) can report per-wallet outcomes instead of a blanket "done".
+
 ### Key files
 
 - `backend/src/main/java/com/picsou/service/CryptoExchangeSyncService.java` -- Exchange connection management, holding sync
@@ -122,6 +124,8 @@ Upsert Account (type=CRYPTO, no ticker)
 - **Output descriptor parsing**: Descriptors are parsed by extracting the xpub between brackets. The checksum after `#` is ignored. Complex descriptors (multisig, P2SH-wrapped) are not supported.
 - **Exchange holdings use PriceService**: Holdings are converted to EUR at sync time using `PriceService.refreshPrices()`. If the price cache is stale (older than 15 min), prices are refreshed on demand.
 - **Wallet RPC errors must not read as 0**: When parsing a blockchain JSON-RPC response, always go through `JsonRpcResponse.requireResult(...)` — never `response.path("result")` directly. `path(...)` returns a `MissingNode` for an error payload, which silently becomes a 0 balance (this caused the July 2026 Ethereum outage). `requireResult` uses `get(...)` to reject a missing/error result while still allowing a legitimate `0x0` / `value:0`.
+- **Don't re-throw `WalletRpcException` raw from `sync()`**: it has no `@ExceptionHandler`, so a raw re-throw becomes a `500`, not the friendly `422`. Keep it wrapped in `SyncException`. The split catch is only about **log level** — unexpected errors log at ERROR with a stacktrace; the user-facing status/message is unchanged.
+- **Per-token Solana failures are logged, not fatal**: a malformed `uiAmountString` or a non-array token `value` is logged and skipped so the SOL balance and other tokens survive. Only an envelope-level RPC `error`/missing-`result` (via `requireResult`) fails the whole sync. Loud (logged) ≠ fatal (thrown) — pick per blast radius.
 
 ## Tests
 
@@ -129,8 +133,10 @@ Upsert Account (type=CRYPTO, no ticker)
 - `BitcoinKeyUtilsTest` -- unit tests for BIP32 derivation, address generation
 - `CryptoExchangeSyncServiceTest` -- unit tests for exchange management
 - `WalletSyncServiceTest` -- unit tests for wallet sync
-- `EthereumWalletAdapterTest` -- valid/zero/error/missing-result JSON-RPC parsing
-- `SolanaWalletAdapterTest` -- SOL + SPL parsing, unknown-mint drop, RPC-error fails sync
+- `JsonRpcResponseTest` -- envelope validation: valid/zero/empty-array results returned; null/error/missing/explicit-null throw
+- `WalletSyncServiceTest` -- RPC error wrapped as `SyncException` (wallet not marked synced), empty balances throw, `resyncAll` summary reports failed chains
+- `EthereumWalletAdapterTest` -- valid/zero/error/missing-result parsing, null body, malformed hex
+- `SolanaWalletAdapterTest` -- SOL + SPL parsing, unknown-mint drop, RPC-error fails sync, non-array/malformed token skipped (non-fatal)
 
 ## Links
 

--- a/docs/features/crypto-tracking.md
+++ b/docs/features/crypto-tracking.md
@@ -1,6 +1,6 @@
 # Feature: Crypto Tracking
 
-> Last updated: 2026-04-08
+> Last updated: 2026-07-16
 
 ## Context
 
@@ -36,7 +36,7 @@ The adapter scans each chain until `GAP_LIMIT` (20) consecutive unused addresses
 
 ### Ethereum wallet adapter
 
-`EthereumWalletAdapter` calls `eth_getBalance` on the Cloudflare Ethereum RPC (`cloudflare-eth.com`). Returns balance converted from wei to ETH (18 decimals).
+`EthereumWalletAdapter` calls `eth_getBalance` on a public Ethereum RPC (`ethereum-rpc.publicnode.com`). Returns balance converted from wei to ETH (18 decimals).
 
 ### Solana wallet adapter
 
@@ -49,7 +49,7 @@ The adapter scans each chain until `GAP_LIMIT` (20) consecutive unused addresses
 - `backend/src/main/java/com/picsou/config/CryptoEncryption.java` -- AES-256-GCM encrypt/decrypt for API secrets
 - `backend/src/main/java/com/picsou/adapter/BinanceAdapter.java` -- Binance REST API with HMAC-SHA256
 - `backend/src/main/java/com/picsou/adapter/BitcoinWalletAdapter.java` -- Blockstream Esplora, BIP32 key derivation
-- `backend/src/main/java/com/picsou/adapter/EthereumWalletAdapter.java` -- Cloudflare ETH RPC
+- `backend/src/main/java/com/picsou/adapter/EthereumWalletAdapter.java` -- PublicNode ETH RPC
 - `backend/src/main/java/com/picsou/adapter/SolanaWalletAdapter.java` -- Solana mainnet RPC
 - `backend/src/main/java/com/picsou/adapter/util/BitcoinKeyUtils.java` -- BIP32 derivation, Base58Check, Bech32
 - `backend/src/main/java/com/picsou/port/CryptoExchangePort.java` -- Exchange port interface

--- a/docs/features/crypto-tracking.md
+++ b/docs/features/crypto-tracking.md
@@ -40,7 +40,11 @@ The adapter scans each chain until `GAP_LIMIT` (20) consecutive unused addresses
 
 ### Solana wallet adapter
 
-`SolanaWalletAdapter` calls `getBalance` on the Solana mainnet RPC (`api.mainnet-beta.solana.com`). Returns balance converted from lamports to SOL (9 decimals).
+`SolanaWalletAdapter` calls `getBalance` on the Solana mainnet RPC (`api.mainnet-beta.solana.com`). Returns balance converted from lamports to SOL (9 decimals). It also calls `getTokenAccountsByOwner` to pick up known SPL stablecoins (USDC/EURC/USDT).
+
+### JSON-RPC error handling
+
+Both on-chain adapters validate the JSON-RPC envelope through `JsonRpcResponse.requireResult(response, context)` (`adapter/util/`) before reading a balance. A present `error` field, a missing `result`, or an empty response throws `WalletRpcException`, which `WalletSyncService` surfaces as a `422` sync failure. This is deliberate: reading `result` with `path(...)` returns a non-null `MissingNode`, so an error payload would otherwise default to a **silent 0 balance** — indistinguishable from a genuinely empty wallet. A real `0x0` / `value:0` result still returns 0. On Solana, an error on the SPL-token call fails the whole sync rather than silently dropping stablecoin holdings.
 
 ### Key files
 
@@ -51,6 +55,8 @@ The adapter scans each chain until `GAP_LIMIT` (20) consecutive unused addresses
 - `backend/src/main/java/com/picsou/adapter/BitcoinWalletAdapter.java` -- Blockstream Esplora, BIP32 key derivation
 - `backend/src/main/java/com/picsou/adapter/EthereumWalletAdapter.java` -- PublicNode ETH RPC
 - `backend/src/main/java/com/picsou/adapter/SolanaWalletAdapter.java` -- Solana mainnet RPC
+- `backend/src/main/java/com/picsou/adapter/util/JsonRpcResponse.java` -- JSON-RPC envelope validation shared by the wallet adapters
+- `backend/src/main/java/com/picsou/exception/WalletRpcException.java` -- thrown on a JSON-RPC error/missing result
 - `backend/src/main/java/com/picsou/adapter/util/BitcoinKeyUtils.java` -- BIP32 derivation, Base58Check, Bech32
 - `backend/src/main/java/com/picsou/port/CryptoExchangePort.java` -- Exchange port interface
 - `backend/src/main/java/com/picsou/port/WalletPort.java` -- Wallet port interface
@@ -115,6 +121,7 @@ Upsert Account (type=CRYPTO, no ticker)
 - **Bitcoin xpub vs zpub**: Both are supported. `BitcoinKeyUtils.normalizeToXpub()` converts zpub to xpub before derivation. The derivation always produces P2WPKH (native segwit) addresses.
 - **Output descriptor parsing**: Descriptors are parsed by extracting the xpub between brackets. The checksum after `#` is ignored. Complex descriptors (multisig, P2SH-wrapped) are not supported.
 - **Exchange holdings use PriceService**: Holdings are converted to EUR at sync time using `PriceService.refreshPrices()`. If the price cache is stale (older than 15 min), prices are refreshed on demand.
+- **Wallet RPC errors must not read as 0**: When parsing a blockchain JSON-RPC response, always go through `JsonRpcResponse.requireResult(...)` — never `response.path("result")` directly. `path(...)` returns a `MissingNode` for an error payload, which silently becomes a 0 balance (this caused the July 2026 Ethereum outage). `requireResult` uses `get(...)` to reject a missing/error result while still allowing a legitimate `0x0` / `value:0`.
 
 ## Tests
 
@@ -122,6 +129,8 @@ Upsert Account (type=CRYPTO, no ticker)
 - `BitcoinKeyUtilsTest` -- unit tests for BIP32 derivation, address generation
 - `CryptoExchangeSyncServiceTest` -- unit tests for exchange management
 - `WalletSyncServiceTest` -- unit tests for wallet sync
+- `EthereumWalletAdapterTest` -- valid/zero/error/missing-result JSON-RPC parsing
+- `SolanaWalletAdapterTest` -- SOL + SPL parsing, unknown-mint drop, RPC-error fails sync
 
 ## Links
 


### PR DESCRIPTION
## What

Ethereum wallet balances no longer sync : wallets appear to sync successfully, but the account shows a **0 € balance** with no error surfaced.

## Why

`EthereumWalletAdapter` hard-codes `https://cloudflare-eth.com`, a public gateway that Cloudflare has deprecated.

The endpoint still answers static methods (`eth_chainId`), but returns **HTTP 200** with a JSON-RPC error (`-32603 Internal error`) for `eth_getBalance`.

The adapter reads `response.path("result").asText("0x0")` without inspecting the `error` field, so the failure is silently interpreted as a 0 ETH balance: the `CRYPTO` account is written with a 0 € balance and no holding, and nothing surfaces to the user.

## Fix

Switch the RPC endpoint to `https://ethereum-rpc.publicnode.com`, a keyless public endpoint that returns correct balances.

## Verification

Tested against a mainnet address holding **0.96 ETH**:

| Endpoint | Result |
|---|---|
| `cloudflare-eth.com` | `-32603 Internal error` |
| `ethereum-rpc.publicnode.com` | Correct balance returned |

- Reproduced end-to-end in the Docker build : wallet resync now displays the balance.
- `mvn test` green (529 tests).

## Notes

- The deeper issue : the adapter swallowing JSON-RPC errors as `0` (the same pattern exists in `SolanaWalletAdapter`) is left for a follow-up to keep this PR focused.
- A configurable RPC URL (`ETH_RPC_URL`) would also help self-hosters.