### PR TITLE
fix: harden setup seeding, rate limiting, GDPR export, and P&L ordering

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -134,6 +134,12 @@
             <version>${bucket4j.version}</version>
         </dependency>
 
+        <!-- Bounded, self-evicting rate-limit bucket stores (RateLimitConfig) -->
+        <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+        </dependency>
+
         <!-- TOTP (RFC 6238) for 2FA: secret generation, QR code, code verification -->
         <dependency>
             <groupId>dev.samstevens.totp</groupId>

--- a/backend/src/main/java/com/picsou/config/ClientIp.java
+++ b/backend/src/main/java/com/picsou/config/ClientIp.java
@@ -1,0 +1,100 @@
+package com.picsou.config;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import java.util.regex.Pattern;
+
+/**
+ * Trusted client address for rate-limit keys.
+ *
+ * <p>{@code server.forward-headers-strategy: framework} (see {@code application.yml}) installs
+ * Spring's {@code ForwardedHeaderFilter} so {@code request.getScheme()/getServerName()/
+ * getServerPort()} reflect the public-facing values behind nginx — required for CORS same-origin
+ * detection (see {@code docs/features/security-cors-cookies.md}). The same filter also rewrites
+ * {@link HttpServletRequest#getRemoteAddr()} from the <strong>leftmost</strong> entry of
+ * {@code X-Forwarded-For} — and nginx's {@code proxy_add_x_forwarded_for} only ever appends to
+ * whatever the client sent, so that leftmost entry is client-controlled. A raw HTTP client can
+ * rotate it on every request and get a fresh rate-limit bucket each time. That makes
+ * {@code getRemoteAddr()} unsafe as a rate-limit key while this strategy is active.
+ *
+ * <p>{@code X-Real-IP} is the trustworthy signal instead: both nginx configs
+ * ({@code docker/nginx.conf}, {@code frontend/nginx.conf}) unconditionally set it to
+ * {@code $remote_addr} — the TCP peer nginx itself observed — on every proxied request, so a
+ * client cannot inject or override it through our proxy.
+ *
+ * <p>Resolution order:
+ * <ol>
+ *   <li>{@code X-Real-IP}, if present and syntactically a plain IPv4/IPv6 literal. The literal
+ *       check is defense in depth against a directly-exposed backend (no nginx in front) where
+ *       the header would otherwise be attacker-supplied.</li>
+ *   <li>Otherwise {@code request.getRemoteAddr()} — correct when there is genuinely no proxy in
+ *       front (local dev, unit tests): without any {@code X-Forwarded-*} headers on the request,
+ *       {@code ForwardedHeaderFilter} is a no-op and this is the real socket address.</li>
+ * </ol>
+ */
+public final class ClientIp {
+
+    private ClientIp() {}
+
+    private static final String HEADER = "X-Real-IP";
+
+    /**
+     * Longest legal textual IP literal is 45 chars (IPv4-mapped IPv6, e.g.
+     * {@code ffff:ffff:ffff:ffff:ffff:ffff:255.255.255.255}). Reject anything longer before it
+     * ever reaches the regexes below — cheap protection against feeding a pathological string to
+     * a fairly elaborate pattern from an attacker-controlled header.
+     */
+    private static final int MAX_LITERAL_LENGTH = 45;
+
+    // Strict dotted-quad: each octet 0-255, no leading zeros (e.g. "010" is rejected).
+    private static final Pattern IPV4 = Pattern.compile(
+        "^(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])"
+        + "(\\.(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])){3}$"
+    );
+
+    // Standard textual IPv6 forms, including "::" compression and an embedded IPv4 tail
+    // (e.g. "::ffff:192.0.2.1"). Zone/scope ids ("%eth0") are deliberately not accepted: nginx's
+    // $remote_addr never carries one on the networks this app runs on, so rejecting them just
+    // falls back to getRemoteAddr() rather than risking a malformed match.
+    private static final Pattern IPV6 = Pattern.compile("""
+        ^(
+          ([0-9a-fA-F]{1,4}:){7}[0-9a-fA-F]{1,4}
+        | ([0-9a-fA-F]{1,4}:){1,7}:
+        | ([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}
+        | ([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}
+        | ([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}
+        | ([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}
+        | ([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}
+        | [0-9a-fA-F]{1,4}:(:[0-9a-fA-F]{1,4}){1,6}
+        | :((:[0-9a-fA-F]{1,4}){1,7}|:)
+        | ::(ffff(:0{1,4})?:)?((25[0-5]|(2[0-4]|1?[0-9])?[0-9])\\.){3}(25[0-5]|(2[0-4]|1?[0-9])?[0-9])
+        | ([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1?[0-9])?[0-9])\\.){3}(25[0-5]|(2[0-4]|1?[0-9])?[0-9])
+        )$
+        """, Pattern.COMMENTS);
+
+    /** Trusted client address for rate-limit keys — see class javadoc for the resolution order. */
+    public static String resolve(HttpServletRequest request) {
+        String realIp = request.getHeader(HEADER);
+        if (isIpLiteral(realIp)) {
+            return realIp;
+        }
+        return request.getRemoteAddr();
+    }
+
+    /**
+     * Deliberately does NOT use {@link java.net.InetAddress#getByName}: for a string that is
+     * not already a literal, that method falls through to the platform name service (DNS/hosts
+     * lookup) — network I/O driven by an untrusted header value. Pure regex matching never
+     * leaves the process.
+     */
+    private static boolean isIpLiteral(String value) {
+        if (value == null) {
+            return false;
+        }
+        String trimmed = value.trim();
+        if (trimmed.isEmpty() || trimmed.length() > MAX_LITERAL_LENGTH) {
+            return false;
+        }
+        return IPV4.matcher(trimmed).matches() || IPV6.matcher(trimmed).matches();
+    }
+}

--- a/backend/src/main/java/com/picsou/config/RateLimitConfig.java
+++ b/backend/src/main/java/com/picsou/config/RateLimitConfig.java
@@ -8,7 +8,6 @@ import org.springframework.context.annotation.Configuration;
 
 import java.time.Duration;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 
 @Configuration
 public class RateLimitConfig {
@@ -123,22 +122,25 @@ public class RateLimitConfig {
     /**
      * Per-key MCP rate limiter: keyed by access-key id (not IP), since one key may serve many
      * tool calls from a single AI client. Lives in the {@code AccessKeyAuthFilter}, which creates
-     * a bucket lazily on first use and shares it across that key's requests.
+     * a bucket lazily on first use — only after the key has resolved to a valid one, so the key
+     * space is server-assigned, not attacker-mintable. Bounded anyway: uniformity is cheaper to
+     * audit than a per-store judgment call about whose keys are "safe" to keep forever.
      */
     @Bean("mcpKeyBuckets")
     public Map<Long, Bucket> mcpKeyBuckets() {
-        return new ConcurrentHashMap<>();
+        return boundedBucketStore();
     }
 
     /**
      * Per-member access-key creation limiter: keyed by member id (not IP), because the
      * {@code POST /api/access-keys} endpoint is cookie-authenticated and self-service — the member is
      * the correct abuse boundary, so an attacker with a stolen session can't mint keys faster than this
-     * regardless of IP rotation.
+     * regardless of IP rotation. Member ids are server-assigned (bounded by the family's size), but
+     * the store is bounded like every other for uniformity.
      */
     @Bean("accessKeyCreateBuckets")
     public Map<Long, Bucket> accessKeyCreateBuckets() {
-        return new ConcurrentHashMap<>();
+        return boundedBucketStore();
     }
 
     public static Bucket createLoginBucket() {

--- a/backend/src/main/java/com/picsou/config/RateLimitConfig.java
+++ b/backend/src/main/java/com/picsou/config/RateLimitConfig.java
@@ -1,5 +1,6 @@
 package com.picsou.config;
 
+import com.github.benmanes.caffeine.cache.Caffeine;
 import io.github.bucket4j.Bandwidth;
 import io.github.bucket4j.Bucket;
 import org.springframework.context.annotation.Bean;
@@ -13,12 +14,41 @@ import java.util.concurrent.ConcurrentHashMap;
 public class RateLimitConfig {
 
     /**
+     * Idle buckets refill to full anyway (Bucket4j resets state on the bucket's own refill
+     * schedule), so forgetting one after an hour of inactivity changes nothing a client would
+     * observe — it only reclaims memory from IPs/users that stopped calling.
+     */
+    private static final Duration BUCKET_STORE_EXPIRE_AFTER_ACCESS = Duration.ofHours(1);
+
+    /**
+     * Ceiling on distinct keys held at once per store. 50k covers a large multiple of any
+     * realistic concurrent client population for a self-hosted single-/family app; beyond that,
+     * Caffeine evicts least-recently-used entries rather than growing without bound.
+     */
+    private static final long BUCKET_STORE_MAX_SIZE = 50_000;
+
+    /**
+     * Bounded, self-evicting replacement for {@code new ConcurrentHashMap<>()}: an unbounded map
+     * of per-key Bucket4j buckets never shrinks, so a key an attacker fully controls (e.g. an
+     * unauthenticated caller's IP) is an unbounded memory-growth vector. Caffeine's
+     * {@code asMap()} view is a drop-in {@code Map<String, Bucket>} — same {@code computeIfAbsent}
+     * call sites, no behavior change for any key still within its idle window.
+     */
+    private static <K> Map<K, Bucket> boundedBucketStore() {
+        return Caffeine.newBuilder()
+            .expireAfterAccess(BUCKET_STORE_EXPIRE_AFTER_ACCESS)
+            .maximumSize(BUCKET_STORE_MAX_SIZE)
+            .<K, Bucket>build()
+            .asMap();
+    }
+
+    /**
      * Per-IP login rate limiter: 5 attempts per 15 minutes.
-     * Uses a ConcurrentHashMap of Bucket4j buckets keyed by IP address.
+     * Bounded Caffeine-backed map of Bucket4j buckets keyed by IP address (see ClientIp).
      */
     @Bean("loginBuckets")
     public Map<String, Bucket> loginBuckets() {
-        return new ConcurrentHashMap<>();
+        return boundedBucketStore();
     }
 
     /**
@@ -26,7 +56,7 @@ public class RateLimitConfig {
      */
     @Bean("syncBuckets")
     public Map<String, Bucket> syncBuckets() {
-        return new ConcurrentHashMap<>();
+        return boundedBucketStore();
     }
 
     /**
@@ -35,7 +65,7 @@ public class RateLimitConfig {
      */
     @Bean("trAuthBuckets")
     public Map<String, Bucket> trAuthBuckets() {
-        return new ConcurrentHashMap<>();
+        return boundedBucketStore();
     }
 
     /**
@@ -43,7 +73,7 @@ public class RateLimitConfig {
      */
     @Bean("boursoAuthBuckets")
     public Map<String, Bucket> boursoAuthBuckets() {
-        return new ConcurrentHashMap<>();
+        return boundedBucketStore();
     }
 
     /**
@@ -54,7 +84,7 @@ public class RateLimitConfig {
      */
     @Bean("setupBuckets")
     public Map<String, Bucket> setupBuckets() {
-        return new ConcurrentHashMap<>();
+        return boundedBucketStore();
     }
 
     /**
@@ -64,7 +94,7 @@ public class RateLimitConfig {
      */
     @Bean("mfaVerifyBuckets")
     public Map<String, Bucket> mfaVerifyBuckets() {
-        return new ConcurrentHashMap<>();
+        return boundedBucketStore();
     }
 
     /**
@@ -74,18 +104,20 @@ public class RateLimitConfig {
      */
     @Bean("mfaEnrollBuckets")
     public Map<String, Bucket> mfaEnrollBuckets() {
-        return new ConcurrentHashMap<>();
+        return boundedBucketStore();
     }
 
     /**
      * Per-user GDPR data export rate limiter: 5 exports per hour.
      * Each export streams the user's full graph (accounts, holdings,
      * transactions, ...) — expensive to build and to ship over the wire,
-     * and a successful re-auth shouldn't unlock unbounded dumps.
+     * and a successful re-auth shouldn't unlock unbounded dumps. Bounded
+     * store here too: same unbounded-ConcurrentHashMap shape as the
+     * per-IP stores above, just keyed by user id instead of IP.
      */
     @Bean("exportBuckets")
     public Map<String, Bucket> exportBuckets() {
-        return new ConcurrentHashMap<>();
+        return boundedBucketStore();
     }
 
     /**

--- a/backend/src/main/java/com/picsou/controller/AuthController.java
+++ b/backend/src/main/java/com/picsou/controller/AuthController.java
@@ -1,6 +1,7 @@
 package com.picsou.controller;
 
 import com.picsou.config.AuthCookieWriter;
+import com.picsou.config.ClientIp;
 import com.picsou.config.JwtUtil;
 import com.picsou.config.RateLimitConfig;
 import com.picsou.dto.ActivationRequest;
@@ -550,10 +551,14 @@ public class AuthController {
 
     private String getClientIp(HttpServletRequest request) {
         // Never trust X-Forwarded-For from the client — it is user-controllable and
-        // would allow rate-limit bypass by spoofing IPs. Use only the TCP-level remote
-        // address, which is the nginx container's internal IP in production (the only
-        // valid entry point on the picsou-net Docker bridge network).
-        return request.getRemoteAddr();
+        // would allow rate-limit bypass by spoofing IPs. request.getRemoteAddr() is NOT
+        // a safe substitute either: under server.forward-headers-strategy=framework
+        // (see application.yml), Spring's ForwardedHeaderFilter rewrites it from the
+        // leftmost X-Forwarded-For entry, which nginx's proxy_add_x_forwarded_for only
+        // ever appends to (never replaces) — so it inherits the same spoofability.
+        // ClientIp.resolve() uses X-Real-IP instead, which our nginx always overwrites
+        // with $remote_addr and a client cannot inject through the proxy.
+        return ClientIp.resolve(request);
     }
 
     record ChangePasswordRequest(

--- a/backend/src/main/java/com/picsou/controller/BoursoController.java
+++ b/backend/src/main/java/com/picsou/controller/BoursoController.java
@@ -1,5 +1,6 @@
 package com.picsou.controller;
 
+import com.picsou.config.ClientIp;
 import com.picsou.config.RateLimitConfig;
 import com.picsou.dto.AccountResponse;
 import com.picsou.service.BoursoSyncService;
@@ -85,7 +86,7 @@ public class BoursoController {
     // ─── Rate limiting ────────────────────────────────────────────────────────
 
     private boolean checkRateLimit(HttpServletRequest request) {
-        String ip = request.getRemoteAddr();
+        String ip = ClientIp.resolve(request);
         Bucket bucket = boursoAuthBuckets.computeIfAbsent(ip, k -> RateLimitConfig.createBoursoAuthBucket());
         return bucket.tryConsume(1);
     }

--- a/backend/src/main/java/com/picsou/controller/MfaController.java
+++ b/backend/src/main/java/com/picsou/controller/MfaController.java
@@ -1,5 +1,6 @@
 package com.picsou.controller;
 
+import com.picsou.config.ClientIp;
 import com.picsou.config.RateLimitConfig;
 import com.picsou.dto.MfaDtos.DisableMfaRequest;
 import com.picsou.dto.MfaDtos.EnrollInitRequest;
@@ -61,7 +62,7 @@ public class MfaController {
         @Valid @RequestBody EnrollInitRequest req,
         HttpServletRequest httpReq
     ) {
-        String ip = httpReq.getRemoteAddr();
+        String ip = ClientIp.resolve(httpReq);
         Bucket bucket = mfaEnrollBuckets.computeIfAbsent(ip, k -> RateLimitConfig.createMfaEnrollBucket());
         if (!bucket.tryConsume(1)) {
             return ResponseEntity.status(HttpStatus.TOO_MANY_REQUESTS).build();

--- a/backend/src/main/java/com/picsou/controller/SetupController.java
+++ b/backend/src/main/java/com/picsou/controller/SetupController.java
@@ -1,5 +1,6 @@
 package com.picsou.controller;
 
+import com.picsou.config.ClientIp;
 import com.picsou.config.RateLimitConfig;
 import com.picsou.dto.BoursoBankHealthResponse;
 import com.picsou.dto.CryptoKeyGenerateResponse;
@@ -52,9 +53,13 @@ import java.util.Map;
  * <h3>Rate limiting</h3>
  * 10 mutating requests per minute per client IP (see {@code setupBuckets} in
  * {@link RateLimitConfig}). {@code GET /status} is polled by the frontend
- * and is exempt. IP is read from {@code RemoteAddr} only — never
- * {@code X-Forwarded-For} — since the deployment contract is nginx on the
- * docker bridge, so the only legitimate remote is the reverse-proxy IP.
+ * and is exempt. The key is {@link com.picsou.config.ClientIp#resolve}, never
+ * {@code request.getRemoteAddr()} directly and never {@code X-Forwarded-For}:
+ * under {@code server.forward-headers-strategy: framework} (the deployment
+ * contract is nginx on the docker bridge), {@code getRemoteAddr()} itself is
+ * rewritten from the client-suppliable leftmost X-Forwarded-For entry, so it
+ * is no safer than trusting the header outright. {@code ClientIp} reads
+ * nginx's {@code X-Real-IP} instead, which a client cannot inject.
  */
 @RestController
 @RequestMapping("/api/setup")
@@ -276,7 +281,7 @@ public class SetupController {
     // ─── Helpers ─────────────────────────────────────────────────────────────
 
     private boolean consumeRateLimitToken(HttpServletRequest request) {
-        String ip = request.getRemoteAddr();
+        String ip = ClientIp.resolve(request);
         Bucket bucket = setupBuckets.computeIfAbsent(ip, k -> RateLimitConfig.createSetupBucket());
         return bucket.tryConsume(1);
     }

--- a/backend/src/main/java/com/picsou/controller/SyncController.java
+++ b/backend/src/main/java/com/picsou/controller/SyncController.java
@@ -1,5 +1,6 @@
 package com.picsou.controller;
 
+import com.picsou.config.ClientIp;
 import com.picsou.config.RateLimitConfig;
 import com.picsou.dto.AccountResponse;
 import com.picsou.model.Requisition;
@@ -84,7 +85,7 @@ public class SyncController {
     }
 
     private boolean checkSyncRateLimit(HttpServletRequest request) {
-        String ip = request.getRemoteAddr();
+        String ip = ClientIp.resolve(request);
         Bucket bucket = syncBuckets.computeIfAbsent(ip, k -> RateLimitConfig.createSyncBucket());
         return bucket.tryConsume(1);
     }

--- a/backend/src/main/java/com/picsou/controller/TradeRepublicController.java
+++ b/backend/src/main/java/com/picsou/controller/TradeRepublicController.java
@@ -1,5 +1,6 @@
 package com.picsou.controller;
 
+import com.picsou.config.ClientIp;
 import com.picsou.config.RateLimitConfig;
 import com.picsou.dto.AccountResponse;
 import com.picsou.service.TradeRepublicSyncService;
@@ -81,7 +82,7 @@ public class TradeRepublicController {
     // --- Rate limiting ---
 
     private boolean checkAuthRateLimit(HttpServletRequest request) {
-        String ip = request.getRemoteAddr();
+        String ip = ClientIp.resolve(request);
         Bucket bucket = trAuthBuckets.computeIfAbsent(ip, k -> RateLimitConfig.createTrAuthBucket());
         return bucket.tryConsume(1);
     }

--- a/backend/src/main/java/com/picsou/controller/TransactionImportController.java
+++ b/backend/src/main/java/com/picsou/controller/TransactionImportController.java
@@ -1,5 +1,6 @@
 package com.picsou.controller;
 
+import com.picsou.config.ClientIp;
 import com.picsou.config.RateLimitConfig;
 import com.picsou.dto.TransactionImportPreviewResponse;
 import com.picsou.dto.TransactionImportRequest;
@@ -71,7 +72,7 @@ public class TransactionImportController {
     }
 
     private boolean checkRateLimit(HttpServletRequest request) {
-        String ip = request.getRemoteAddr();
+        String ip = ClientIp.resolve(request);
         Bucket bucket = syncBuckets.computeIfAbsent(ip, k -> RateLimitConfig.createSyncBucket());
         return bucket.tryConsume(1);
     }

--- a/backend/src/main/java/com/picsou/export/BalanceSnapshotsExporter.java
+++ b/backend/src/main/java/com/picsou/export/BalanceSnapshotsExporter.java
@@ -48,15 +48,19 @@ class BalanceSnapshotsExporter implements EntityExporter {
     @Override
     public void writeCsv(AppUser user, ExportContext ctx, CsvWriter csv) throws IOException {
         for (Account account : accounts(user)) {
-            for (BalanceSnapshot s : balanceSnapshotRepository.findByAccountIdOrderByDateAsc(account.getId())) {
-                csv.writeRow(List.of(
-                    String.valueOf(s.getId()),
-                    String.valueOf(s.getAccount().getId()),
-                    s.getDate() == null ? "" : s.getDate().toString(),
-                    s.getBalance() == null ? "" : s.getBalance().toPlainString(),
-                    s.getInvestedAmount() == null ? "" : s.getInvestedAmount().toPlainString(),
-                    s.getCreatedAt() == null ? "" : s.getCreatedAt().toString()
-                ));
+            try {
+                for (BalanceSnapshot s : balanceSnapshotRepository.findByAccountIdOrderByDateAsc(account.getId())) {
+                    csv.writeRow(List.of(
+                        String.valueOf(s.getId()),
+                        String.valueOf(s.getAccount().getId()),
+                        s.getDate() == null ? "" : s.getDate().toString(),
+                        s.getBalance() == null ? "" : s.getBalance().toPlainString(),
+                        s.getInvestedAmount() == null ? "" : s.getInvestedAmount().toPlainString(),
+                        s.getCreatedAt() == null ? "" : s.getCreatedAt().toString()
+                    ));
+                }
+            } catch (RuntimeException | IOException ex) {
+                throw withAccountContext(account, ex);
             }
         }
     }
@@ -65,18 +69,31 @@ class BalanceSnapshotsExporter implements EntityExporter {
     public void writeJson(AppUser user, ExportContext ctx, JsonGenerator json) throws IOException {
         json.writeStartArray();
         for (Account account : accounts(user)) {
-            for (BalanceSnapshot s : balanceSnapshotRepository.findByAccountIdOrderByDateAsc(account.getId())) {
-                json.writeStartObject();
-                json.writeNumberField("id", s.getId());
-                json.writeNumberField("account_id", s.getAccount().getId());
-                json.writeStringField("date", s.getDate() == null ? null : s.getDate().toString());
-                writeBigDecimal(json, "balance", s.getBalance());
-                writeBigDecimal(json, "invested_amount", s.getInvestedAmount());
-                json.writeStringField("created_at", s.getCreatedAt() == null ? null : s.getCreatedAt().toString());
-                json.writeEndObject();
+            try {
+                for (BalanceSnapshot s : balanceSnapshotRepository.findByAccountIdOrderByDateAsc(account.getId())) {
+                    json.writeStartObject();
+                    json.writeNumberField("id", s.getId());
+                    json.writeNumberField("account_id", s.getAccount().getId());
+                    json.writeStringField("date", s.getDate() == null ? null : s.getDate().toString());
+                    writeBigDecimal(json, "balance", s.getBalance());
+                    writeBigDecimal(json, "invested_amount", s.getInvestedAmount());
+                    json.writeStringField("created_at", s.getCreatedAt() == null ? null : s.getCreatedAt().toString());
+                    json.writeEndObject();
+                }
+            } catch (RuntimeException | IOException ex) {
+                throw withAccountContext(account, ex);
             }
         }
         json.writeEndArray();
+    }
+
+    /**
+     * Adds the failing account's id to the exception so support can pinpoint it.
+     * Deliberately id-only: the account NAME is user data and exception messages
+     * end up in server logs (same philosophy as the no-secret-leak export tests).
+     */
+    private static IOException withAccountContext(Account account, Exception ex) {
+        return new IOException("balance_snapshots export failed for account id=" + account.getId(), ex);
     }
 
     /**

--- a/backend/src/main/java/com/picsou/export/BalanceSnapshotsExporter.java
+++ b/backend/src/main/java/com/picsou/export/BalanceSnapshotsExporter.java
@@ -47,39 +47,46 @@ class BalanceSnapshotsExporter implements EntityExporter {
 
     @Override
     public void writeCsv(AppUser user, ExportContext ctx, CsvWriter csv) throws IOException {
-        for (BalanceSnapshot s : snapshots(user)) {
-            csv.writeRow(List.of(
-                String.valueOf(s.getId()),
-                String.valueOf(s.getAccount().getId()),
-                s.getDate() == null ? "" : s.getDate().toString(),
-                s.getBalance() == null ? "" : s.getBalance().toPlainString(),
-                s.getInvestedAmount() == null ? "" : s.getInvestedAmount().toPlainString(),
-                s.getCreatedAt() == null ? "" : s.getCreatedAt().toString()
-            ));
+        for (Account account : accounts(user)) {
+            for (BalanceSnapshot s : balanceSnapshotRepository.findByAccountIdOrderByDateAsc(account.getId())) {
+                csv.writeRow(List.of(
+                    String.valueOf(s.getId()),
+                    String.valueOf(s.getAccount().getId()),
+                    s.getDate() == null ? "" : s.getDate().toString(),
+                    s.getBalance() == null ? "" : s.getBalance().toPlainString(),
+                    s.getInvestedAmount() == null ? "" : s.getInvestedAmount().toPlainString(),
+                    s.getCreatedAt() == null ? "" : s.getCreatedAt().toString()
+                ));
+            }
         }
     }
 
     @Override
     public void writeJson(AppUser user, ExportContext ctx, JsonGenerator json) throws IOException {
         json.writeStartArray();
-        for (BalanceSnapshot s : snapshots(user)) {
-            json.writeStartObject();
-            json.writeNumberField("id", s.getId());
-            json.writeNumberField("account_id", s.getAccount().getId());
-            json.writeStringField("date", s.getDate() == null ? null : s.getDate().toString());
-            writeBigDecimal(json, "balance", s.getBalance());
-            writeBigDecimal(json, "invested_amount", s.getInvestedAmount());
-            json.writeStringField("created_at", s.getCreatedAt() == null ? null : s.getCreatedAt().toString());
-            json.writeEndObject();
+        for (Account account : accounts(user)) {
+            for (BalanceSnapshot s : balanceSnapshotRepository.findByAccountIdOrderByDateAsc(account.getId())) {
+                json.writeStartObject();
+                json.writeNumberField("id", s.getId());
+                json.writeNumberField("account_id", s.getAccount().getId());
+                json.writeStringField("date", s.getDate() == null ? null : s.getDate().toString());
+                writeBigDecimal(json, "balance", s.getBalance());
+                writeBigDecimal(json, "invested_amount", s.getInvestedAmount());
+                json.writeStringField("created_at", s.getCreatedAt() == null ? null : s.getCreatedAt().toString());
+                json.writeEndObject();
+            }
         }
         json.writeEndArray();
     }
 
-    private List<BalanceSnapshot> snapshots(AppUser user) {
-        Long memberId = user.getMember().getId();
-        return accountRepository.findAllByMemberIdOrderByCreatedAtAsc(memberId).stream()
-            .map(Account::getId)
-            .flatMap(id -> balanceSnapshotRepository.findByAccountIdOrderByDateAsc(id).stream())
-            .toList();
+    /**
+     * Per-account streaming: each account's snapshot history is fetched, written and
+     * discarded before the next account starts, so heap is bounded by one account's
+     * history rather than the member's entire history across all accounts. Called once
+     * per account per pass (CSV, JSON) — 2 passes total, same as before; the fix is the
+     * per-pass heap ceiling, not the query count (see docs/features/data-export.md).
+     */
+    private List<Account> accounts(AppUser user) {
+        return accountRepository.findAllByMemberIdOrderByCreatedAtAsc(user.getMember().getId());
     }
 }

--- a/backend/src/main/java/com/picsou/export/DataExportService.java
+++ b/backend/src/main/java/com/picsou/export/DataExportService.java
@@ -132,8 +132,10 @@ public class DataExportService {
                 + "Please retry; if the problem persists, contact the administrator.\n")
                 .getBytes(StandardCharsets.UTF_8));
             zip.closeEntry();
-        } catch (IOException ignore) {
-            // best-effort; zip stream may already be broken
+        } catch (IOException ex) {
+            // Best-effort — the zip stream is usually already broken by the original
+            // failure. Log it so an operator can tell the archive carries no marker.
+            log.warn("export.failure-marker-write-failed — archive is incomplete AND unmarked", ex);
         }
     }
 }

--- a/backend/src/main/java/com/picsou/repository/TransactionRepository.java
+++ b/backend/src/main/java/com/picsou/repository/TransactionRepository.java
@@ -26,7 +26,7 @@ public interface TransactionRepository extends JpaRepository<Transaction, Long> 
     @Query("SELECT COALESCE(SUM(t.amount), 0) FROM Transaction t WHERE t.account.id = :accountId AND t.date > :date")
     BigDecimal sumAmountByAccountIdAndDateAfter(@Param("accountId") Long accountId, @Param("date") LocalDate date);
 
-    List<Transaction> findByAccountIdAndTxTypeInOrderByDateAsc(Long accountId, List<TransactionType> types);
+    List<Transaction> findByAccountIdAndTxTypeInOrderByDateAscIdAsc(Long accountId, List<TransactionType> types);
 
     /** Earliest transaction date across all accounts */
     @Query("SELECT MIN(t.date) FROM Transaction t")

--- a/backend/src/main/java/com/picsou/service/HoldingComputeService.java
+++ b/backend/src/main/java/com/picsou/service/HoldingComputeService.java
@@ -28,7 +28,7 @@ public class HoldingComputeService {
     @Transactional
     public void recomputeHoldings(Account account) {
         List<Transaction> transactions = transactionRepository
-                .findByAccountIdAndTxTypeInOrderByDateAsc(
+                .findByAccountIdAndTxTypeInOrderByDateAscIdAsc(
                         account.getId(),
                         List.of(TransactionType.BUY, TransactionType.SELL));
 

--- a/backend/src/main/java/com/picsou/service/RealizedPnlService.java
+++ b/backend/src/main/java/com/picsou/service/RealizedPnlService.java
@@ -47,7 +47,7 @@ public class RealizedPnlService {
         Account account = accountRepository.findByIdAndMemberId(accountId, memberId)
             .orElseThrow(() -> ResourceNotFoundException.account(accountId));
 
-        List<Transaction> stream = transactionRepository.findByAccountIdAndTxTypeInOrderByDateAsc(
+        List<Transaction> stream = transactionRepository.findByAccountIdAndTxTypeInOrderByDateAscIdAsc(
             accountId, List.of(TransactionType.BUY, TransactionType.SELL));
 
         // Moving-average state per ticker.

--- a/backend/src/main/java/com/picsou/service/SetupService.java
+++ b/backend/src/main/java/com/picsou/service/SetupService.java
@@ -106,6 +106,10 @@ public class SetupService {
             SetupState.IN_PROGRESS.name()
         );
         if (claimed == 0 && state == SetupState.PENDING_ADMIN) {
+            // Two concurrent seeding attempts raced on the PENDING_ADMIN → IN_PROGRESS CAS
+            // (e.g. double-submitted wizard tabs). Log it so the resulting 5xx is
+            // distinguishable from a genuine server error in the logs.
+            log.warn("Setup: concurrent admin-seeding attempt lost the setup-state CAS (state={})", state);
             throw new IllegalStateException("Another setup session is already in progress.");
         }
 

--- a/backend/src/main/java/com/picsou/service/SetupService.java
+++ b/backend/src/main/java/com/picsou/service/SetupService.java
@@ -78,7 +78,10 @@ public class SetupService {
      * {@code DataSeeder} path or by the setup wizard controller.
      *
      * SERIALIZABLE isolation + a CAS on setup.state prevents two racing
-     * callers (e.g. two browser tabs) from each creating an admin.
+     * callers (e.g. two browser tabs) from each creating an admin. The wizard
+     * seeds exactly one account: once any user exists, further calls are
+     * rejected regardless of {@code setup.state} — additional members/admins
+     * are created from the authenticated Family admin UI, never from here.
      */
     @Transactional(isolation = Isolation.SERIALIZABLE)
     public AppUser seedAdmin(String username, String bcryptHash, String displayName, String avatarColor) {
@@ -90,6 +93,11 @@ public class SetupService {
         SetupState state = currentState();
         if (state == SetupState.COMPLETE) {
             throw new IllegalStateException("Setup is already complete; use the admin UI to manage users.");
+        }
+
+        if (userRepository.count() > 0) {
+            throw new IllegalStateException(
+                "An account already exists; additional members are created from the Family admin UI.");
         }
 
         int claimed = settingRepository.compareAndSet(

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -80,6 +80,14 @@ server:
   # 403. "framework" (Spring's ForwardedHeaderFilter) is used because the backend is only
   # reachable through nginx — no per-IP trusted-proxy config needed — and it is a no-op
   # when no X-Forwarded-* headers are present (dev / direct-HTTP access).
+  #
+  # Side effect: this ALSO rewrites request.getRemoteAddr() from the leftmost
+  # X-Forwarded-For entry, which nginx's proxy_add_x_forwarded_for only appends to (never
+  # replaces) — so a raw client can set that entry itself and getRemoteAddr() is no longer
+  # a trustworthy per-client identity. Never key a rate limiter (or anything else
+  # security-sensitive) on getRemoteAddr() while this is "framework"; use
+  # com.picsou.config.ClientIp#resolve(request) instead, which reads the nginx-owned
+  # X-Real-IP header — see docs/features/security-cors-cookies.md ("client IP trust").
   forward-headers-strategy: framework
   error:
     include-stacktrace: never     # never expose stack traces to clients

--- a/backend/src/test/java/com/picsou/config/ClientIpTest.java
+++ b/backend/src/test/java/com/picsou/config/ClientIpTest.java
@@ -1,0 +1,121 @@
+package com.picsou.config;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * {@link ClientIp#resolve} is the trusted-IP contract every rate limiter now depends on — see
+ * {@code docs/features/security-cors-cookies.md} ("client IP trust"). These cases mirror the
+ * attack this class defends against: a spoofed X-Forwarded-For must never influence the
+ * resolved key, and a header that fails to parse as a plain IP literal must fail closed to
+ * {@code getRemoteAddr()} rather than be trusted verbatim.
+ */
+class ClientIpTest {
+
+    @Test
+    void resolve_prefersXRealIp_overSpoofedXForwardedFor() {
+        MockHttpServletRequest req = new MockHttpServletRequest();
+        req.setRemoteAddr("172.18.0.2"); // e.g. tainted by ForwardedHeaderFilter from the spoofed XFF below
+        req.addHeader("X-Forwarded-For", "1.2.3.4, 5.6.7.8"); // attacker rotates this per request
+        req.addHeader("X-Real-IP", "203.0.113.9"); // set by nginx, not attacker-reachable
+
+        assertThat(ClientIp.resolve(req)).isEqualTo("203.0.113.9");
+    }
+
+    @Test
+    void resolve_fallsBackToRemoteAddr_whenNoHeadersPresent() {
+        MockHttpServletRequest req = new MockHttpServletRequest();
+        req.setRemoteAddr("127.0.0.1"); // dev / test: no proxy in front, ForwardedHeaderFilter is a no-op
+
+        assertThat(ClientIp.resolve(req)).isEqualTo("127.0.0.1");
+    }
+
+    @Test
+    void resolve_fallsBackToRemoteAddr_whenXRealIpIsGarbage() {
+        MockHttpServletRequest req = new MockHttpServletRequest();
+        req.setRemoteAddr("10.0.0.5");
+        req.addHeader("X-Real-IP", "garbage<script>");
+
+        assertThat(ClientIp.resolve(req)).isEqualTo("10.0.0.5");
+    }
+
+    @Test
+    void resolve_fallsBackToRemoteAddr_whenXRealIpIsBlankOrAbsent() {
+        MockHttpServletRequest blank = new MockHttpServletRequest();
+        blank.setRemoteAddr("10.0.0.5");
+        blank.addHeader("X-Real-IP", "   ");
+        assertThat(ClientIp.resolve(blank)).isEqualTo("10.0.0.5");
+
+        MockHttpServletRequest empty = new MockHttpServletRequest();
+        empty.setRemoteAddr("10.0.0.6");
+        empty.addHeader("X-Real-IP", "");
+        assertThat(ClientIp.resolve(empty)).isEqualTo("10.0.0.6");
+    }
+
+    @Test
+    void resolve_fallsBackToRemoteAddr_whenXRealIpCarriesMultipleValues() {
+        // Unlike XFF, our nginx never emits a comma-joined X-Real-IP -- a value shaped like
+        // one is not from our proxy and must not be trusted verbatim.
+        MockHttpServletRequest req = new MockHttpServletRequest();
+        req.setRemoteAddr("10.0.0.5");
+        req.addHeader("X-Real-IP", "203.0.113.9, 1.2.3.4");
+
+        assertThat(ClientIp.resolve(req)).isEqualTo("10.0.0.5");
+    }
+
+    @Test
+    void resolve_fallsBackToRemoteAddr_whenXRealIpExceedsMaxLiteralLength() {
+        MockHttpServletRequest req = new MockHttpServletRequest();
+        req.setRemoteAddr("10.0.0.5");
+        req.addHeader("X-Real-IP", "1".repeat(500));
+
+        assertThat(ClientIp.resolve(req)).isEqualTo("10.0.0.5");
+    }
+
+    @Test
+    void resolve_trustsWellFormedIPv4Literals_atBoundariesAndOrdinary() {
+        assertThat(resolveWithXRealIp("0.0.0.0")).isEqualTo("0.0.0.0");             // min
+        assertThat(resolveWithXRealIp("255.255.255.255")).isEqualTo("255.255.255.255"); // max
+        assertThat(resolveWithXRealIp("203.0.113.9")).isEqualTo("203.0.113.9");     // ordinary
+        assertThat(resolveWithXRealIp("10.0.0.1")).isEqualTo("10.0.0.1");
+    }
+
+    @Test
+    void resolve_rejectsMalformedIPv4_fallsBackToRemoteAddr() {
+        assertThat(resolveWithXRealIp("256.1.1.1")).isEqualTo("10.0.0.5");   // octet out of range
+        assertThat(resolveWithXRealIp("1.1.1")).isEqualTo("10.0.0.5");       // too few octets
+        assertThat(resolveWithXRealIp("1.1.1.1.1")).isEqualTo("10.0.0.5");   // too many octets
+        assertThat(resolveWithXRealIp("01.1.1.1")).isEqualTo("10.0.0.5");    // leading zero
+        assertThat(resolveWithXRealIp("1.1.1.-1")).isEqualTo("10.0.0.5");    // negative
+        assertThat(resolveWithXRealIp("1.1.1.")).isEqualTo("10.0.0.5");      // trailing dot
+    }
+
+    @Test
+    void resolve_trustsWellFormedIPv6Literals() {
+        assertThat(resolveWithXRealIp("::1")).isEqualTo("::1"); // loopback, min form
+        assertThat(resolveWithXRealIp("2001:db8::1")).isEqualTo("2001:db8::1"); // compressed
+        assertThat(resolveWithXRealIp("::ffff:192.0.2.1")).isEqualTo("::ffff:192.0.2.1"); // IPv4-mapped
+        assertThat(resolveWithXRealIp("fe80::1")).isEqualTo("fe80::1");
+        // fully expanded, max-length form
+        assertThat(resolveWithXRealIp("2001:0db8:0000:0000:0000:0000:0000:0001"))
+            .isEqualTo("2001:0db8:0000:0000:0000:0000:0000:0001");
+    }
+
+    @Test
+    void resolve_rejectsMalformedIPv6_fallsBackToRemoteAddr() {
+        assertThat(resolveWithXRealIp("gggg::1")).isEqualTo("10.0.0.5");             // non-hex chars
+        assertThat(resolveWithXRealIp("1::2::3")).isEqualTo("10.0.0.5");             // two "::" compressions
+        assertThat(resolveWithXRealIp("1:2:3:4:5:6:7:8:9")).isEqualTo("10.0.0.5");   // too many groups
+        assertThat(resolveWithXRealIp("fe80::1%eth0")).isEqualTo("10.0.0.5");        // zone id -- unsupported
+    }
+
+    /** Builds a request whose remoteAddr is the fixed sentinel "10.0.0.5" and given X-Real-IP header. */
+    private static String resolveWithXRealIp(String xRealIp) {
+        MockHttpServletRequest req = new MockHttpServletRequest();
+        req.setRemoteAddr("10.0.0.5");
+        req.addHeader("X-Real-IP", xRealIp);
+        return ClientIp.resolve(req);
+    }
+}

--- a/backend/src/test/java/com/picsou/config/RateLimitConfigTest.java
+++ b/backend/src/test/java/com/picsou/config/RateLimitConfigTest.java
@@ -1,0 +1,49 @@
+package com.picsou.config;
+
+import io.github.bucket4j.Bucket;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The per-IP/per-user bucket-store beans used to be plain {@code ConcurrentHashMap}s that only
+ * ever grew: every distinct key -- fully attacker-controlled for the per-IP ones, see
+ * {@link ClientIp} -- added an entry nothing ever removed. This asserts the Caffeine-backed
+ * replacement actually bounds memory. See docs/features/security-cors-cookies.md
+ * ("client IP trust") and {@link RateLimitConfig#loginBuckets()}.
+ *
+ * <p>Only {@code loginBuckets} is exercised: every {@code Map<String, Bucket>} bean is a one-line
+ * delegation to the same private {@code boundedBucketStore()} factory, so this covers all of them.
+ */
+class RateLimitConfigTest {
+
+    private static final int MAX_SIZE = 50_000;
+
+    @Test
+    void loginBuckets_evictsDownToMaximumSize_whenOverfilled() {
+        Map<String, Bucket> buckets = new RateLimitConfig().loginBuckets();
+
+        for (int i = 0; i < MAX_SIZE + 10_000; i++) {
+            buckets.computeIfAbsent("key-" + i, k -> RateLimitConfig.createLoginBucket());
+        }
+
+        // Caffeine's eviction maintenance can run on a background executor (ForkJoinPool
+        // commonPool by default), so give it a short, bounded window to catch up rather than
+        // asserting immediately after the write burst -- avoids both a flaky immediate check
+        // and an unbounded hang if something is genuinely wrong.
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(2);
+        while (buckets.size() > MAX_SIZE && System.nanoTime() < deadline) {
+            try {
+                Thread.sleep(20);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                break;
+            }
+        }
+
+        assertThat(buckets.size()).isLessThanOrEqualTo(MAX_SIZE);
+    }
+}

--- a/backend/src/test/java/com/picsou/config/RateLimitConfigTest.java
+++ b/backend/src/test/java/com/picsou/config/RateLimitConfigTest.java
@@ -15,8 +15,11 @@ import static org.assertj.core.api.Assertions.assertThat;
  * replacement actually bounds memory. See docs/features/security-cors-cookies.md
  * ("client IP trust") and {@link RateLimitConfig#loginBuckets()}.
  *
- * <p>Only {@code loginBuckets} is exercised: every {@code Map<String, Bucket>} bean is a one-line
- * delegation to the same private {@code boundedBucketStore()} factory, so this covers all of them.
+ * <p>{@code loginBuckets} (String keys) and {@code mcpKeyBuckets} (Long keys) are exercised;
+ * every other bucket-store bean is the same one-line delegation to the private
+ * {@code boundedBucketStore()} factory, so these two cover all of them — including
+ * {@code accessKeyCreateBuckets}, which shares {@code mcpKeyBuckets}'s {@code Map<Long, Bucket>}
+ * shape.
  */
 class RateLimitConfigTest {
 
@@ -30,10 +33,30 @@ class RateLimitConfigTest {
             buckets.computeIfAbsent("key-" + i, k -> RateLimitConfig.createLoginBucket());
         }
 
-        // Caffeine's eviction maintenance can run on a background executor (ForkJoinPool
-        // commonPool by default), so give it a short, bounded window to catch up rather than
-        // asserting immediately after the write burst -- avoids both a flaky immediate check
-        // and an unbounded hang if something is genuinely wrong.
+        awaitEvictionBelowMax(buckets);
+        assertThat(buckets.size()).isLessThanOrEqualTo(MAX_SIZE);
+    }
+
+    /** Long-keyed variant: the MCP / access-key stores must be bounded like the per-IP ones. */
+    @Test
+    void mcpKeyBuckets_evictsDownToMaximumSize_whenOverfilled() {
+        Map<Long, Bucket> buckets = new RateLimitConfig().mcpKeyBuckets();
+
+        for (long i = 0; i < MAX_SIZE + 10_000; i++) {
+            buckets.computeIfAbsent(i, k -> RateLimitConfig.createMcpKeyBucket());
+        }
+
+        awaitEvictionBelowMax(buckets);
+        assertThat(buckets.size()).isLessThanOrEqualTo(MAX_SIZE);
+    }
+
+    /**
+     * Caffeine's eviction maintenance can run on a background executor (ForkJoinPool
+     * commonPool by default), so give it a short, bounded window to catch up rather than
+     * asserting immediately after the write burst -- avoids both a flaky immediate check
+     * and an unbounded hang if something is genuinely wrong.
+     */
+    private static void awaitEvictionBelowMax(Map<?, Bucket> buckets) {
         long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(2);
         while (buckets.size() > MAX_SIZE && System.nanoTime() < deadline) {
             try {
@@ -43,7 +66,5 @@ class RateLimitConfigTest {
                 break;
             }
         }
-
-        assertThat(buckets.size()).isLessThanOrEqualTo(MAX_SIZE);
     }
 }

--- a/backend/src/test/java/com/picsou/controller/AuthControllerTest.java
+++ b/backend/src/test/java/com/picsou/controller/AuthControllerTest.java
@@ -41,6 +41,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
@@ -302,6 +303,48 @@ class AuthControllerTest {
         // No session is established, and a credential-less profile never reaches MFA.
         verify(cookieWriter, never()).setAccessAndRefresh(any(), any(), any(), org.mockito.ArgumentMatchers.anyBoolean());
         verify(mfaService, never()).isEnabled(any());
+    }
+
+    @Test
+    void login_ratelimitKey_isXRealIp_notSpoofableXForwardedFor() {
+        // Regression for the leftmost-XFF spoofing bug: request.getRemoteAddr() is tainted by
+        // ForwardedHeaderFilter from whatever the client puts in X-Forwarded-For (nginx only
+        // appends, never replaces), so a raw client could rotate it and get a fresh bucket every
+        // request. ClientIp.resolve() must key on nginx's X-Real-IP instead, which stays constant
+        // for the same real client regardless of the spoofed XFF value.
+        @SuppressWarnings("unchecked")
+        Map<String, Bucket> mockedLoginBuckets = mock(Map.class);
+        Bucket bucket = mock(Bucket.class);
+        when(bucket.tryConsume(1)).thenReturn(true);
+        when(mockedLoginBuckets.computeIfAbsent(any(), any())).thenReturn(bucket);
+        when(userRepository.findByUsernameWithMember("alice")).thenReturn(Optional.empty());
+
+        AuthController spoofTestController = new AuthController(
+            userRepository, passwordEncoder, jwtUtil,
+            mockedLoginBuckets, mfaVerifyBuckets, cookieWriter,
+            mfaService, persistentSessionService, auditService, false);
+
+        MockHttpServletRequest firstCall = new MockHttpServletRequest();
+        firstCall.setRemoteAddr("172.18.0.2");
+        firstCall.addHeader("X-Forwarded-For", "1.1.1.1"); // attacker-supplied, rotates per request
+        firstCall.addHeader("X-Real-IP", "203.0.113.9");   // nginx-observed peer, stable
+
+        MockHttpServletRequest secondCall = new MockHttpServletRequest();
+        secondCall.setRemoteAddr("172.18.0.2");
+        secondCall.addHeader("X-Forwarded-For", "9.9.9.9"); // rotated -- same attacker, new value
+        secondCall.addHeader("X-Real-IP", "203.0.113.9");   // unchanged: same real client
+
+        assertThatThrownBy(() -> spoofTestController.login(
+                new LoginRequest("alice", "pw", false), firstCall, httpRes))
+            .isInstanceOf(BadCredentialsException.class);
+        assertThatThrownBy(() -> spoofTestController.login(
+                new LoginRequest("alice", "pw", false), secondCall, httpRes))
+            .isInstanceOf(BadCredentialsException.class);
+
+        // Both calls looked up the SAME key, despite the different X-Forwarded-For each time.
+        ArgumentCaptor<String> keyCaptor = ArgumentCaptor.forClass(String.class);
+        verify(mockedLoginBuckets, times(2)).computeIfAbsent(keyCaptor.capture(), any());
+        assertThat(keyCaptor.getAllValues()).containsOnly("203.0.113.9");
     }
 
     // ─── activate ────────────────────────────────────────────────────────

--- a/backend/src/test/java/com/picsou/export/BalanceSnapshotsExporterTest.java
+++ b/backend/src/test/java/com/picsou/export/BalanceSnapshotsExporterTest.java
@@ -1,0 +1,121 @@
+package com.picsou.export;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.picsou.model.Account;
+import com.picsou.model.AccountType;
+import com.picsou.model.AppUser;
+import com.picsou.model.BalanceSnapshot;
+import com.picsou.model.FamilyMember;
+import com.picsou.repository.AccountRepository;
+import com.picsou.repository.BalanceSnapshotRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.ByteArrayOutputStream;
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+/**
+ * Plan 005 part B: {@link BalanceSnapshotsExporter} must stream per account instead of
+ * collecting the member's entire snapshot history before writing (see the class Javadoc
+ * on the exporter and docs/features/data-export.md). This test drives the exporter
+ * directly (bypassing {@link DataExportService}) so per-pass repository call counts can
+ * be asserted precisely.
+ */
+@ExtendWith(MockitoExtension.class)
+class BalanceSnapshotsExporterTest {
+
+    @Mock private AccountRepository accountRepository;
+    @Mock private BalanceSnapshotRepository balanceSnapshotRepository;
+
+    private BalanceSnapshotsExporter exporter;
+    private AppUser user;
+    private Account accountA;
+    private Account accountB;
+
+    @BeforeEach
+    void setUp() {
+        FamilyMember member = FamilyMember.builder().id(42L).displayName("Chloé Test").build();
+        user = AppUser.builder().id(7L).username("chloe").member(member).build();
+        exporter = new BalanceSnapshotsExporter(accountRepository, balanceSnapshotRepository);
+
+        accountA = Account.builder().id(100L).member(member).name("Livret A").type(AccountType.SAVINGS).build();
+        accountB = Account.builder().id(200L).member(member).name("Compte-titres").type(AccountType.COMPTE_TITRES).build();
+    }
+
+    @Test
+    void streamsPerAccount_inAccountThenDateOrder_withOneRepositoryCallPerAccountPerPass() throws Exception {
+        when(accountRepository.findAllByMemberIdOrderByCreatedAtAsc(42L))
+            .thenReturn(List.of(accountA, accountB));
+
+        List<BalanceSnapshot> snapshotsA = List.of(
+            BalanceSnapshot.builder().id(1L).account(accountA).date(LocalDate.of(2026, 1, 1)).balance(new BigDecimal("1000")).investedAmount(new BigDecimal("900")).build(),
+            BalanceSnapshot.builder().id(2L).account(accountA).date(LocalDate.of(2026, 1, 2)).balance(new BigDecimal("1010")).investedAmount(new BigDecimal("900")).build(),
+            BalanceSnapshot.builder().id(3L).account(accountA).date(LocalDate.of(2026, 1, 3)).balance(new BigDecimal("1020")).investedAmount(new BigDecimal("900")).build()
+        );
+        List<BalanceSnapshot> snapshotsB = List.of(
+            BalanceSnapshot.builder().id(4L).account(accountB).date(LocalDate.of(2026, 1, 1)).balance(new BigDecimal("5000")).investedAmount(new BigDecimal("4800")).build(),
+            BalanceSnapshot.builder().id(5L).account(accountB).date(LocalDate.of(2026, 1, 2)).balance(new BigDecimal("5050")).investedAmount(new BigDecimal("4800")).build(),
+            BalanceSnapshot.builder().id(6L).account(accountB).date(LocalDate.of(2026, 1, 3)).balance(new BigDecimal("5100")).investedAmount(new BigDecimal("4800")).build()
+        );
+        when(balanceSnapshotRepository.findByAccountIdOrderByDateAsc(100L)).thenReturn(snapshotsA);
+        when(balanceSnapshotRepository.findByAccountIdOrderByDateAsc(200L)).thenReturn(snapshotsB);
+
+        ExportContext ctx = new ExportContext(true);
+
+        // --- CSV pass ---
+        ByteArrayOutputStream csvOut = new ByteArrayOutputStream();
+        CsvWriter csv = new CsvWriter(csvOut);
+        exporter.writeCsv(user, ctx, csv);
+        csv.flush();
+        List<String> csvLines = Arrays.stream(csvOut.toString(StandardCharsets.UTF_8).split("\r\n"))
+            .filter(line -> !line.isBlank())
+            .toList();
+        assertThat(csvLines).hasSize(6);
+        assertThat(csvLines.get(0)).contains("1,100,2026-01-01,1000");
+        assertThat(csvLines.get(1)).contains("2,100,2026-01-02,1010");
+        assertThat(csvLines.get(2)).contains("3,100,2026-01-03,1020");
+        assertThat(csvLines.get(3)).contains("4,200,2026-01-01,5000");
+        assertThat(csvLines.get(4)).contains("5,200,2026-01-02,5050");
+        assertThat(csvLines.get(5)).contains("6,200,2026-01-03,5100");
+
+        // --- JSON pass ---
+        ByteArrayOutputStream jsonOut = new ByteArrayOutputStream();
+        JsonFactory factory = new JsonFactory();
+        try (JsonGenerator json = factory.createGenerator(jsonOut)) {
+            exporter.writeJson(user, ctx, json);
+        }
+        JsonNode node = new ObjectMapper().readTree(jsonOut.toByteArray());
+        assertThat(node).hasSize(6);
+        assertThat(node.get(0).get("account_id").asLong()).isEqualTo(100L);
+        assertThat(node.get(0).get("date").asText()).isEqualTo("2026-01-01");
+        assertThat(node.get(2).get("account_id").asLong()).isEqualTo(100L);
+        assertThat(node.get(2).get("date").asText()).isEqualTo("2026-01-03");
+        assertThat(node.get(3).get("account_id").asLong()).isEqualTo(200L);
+        assertThat(node.get(3).get("date").asText()).isEqualTo("2026-01-01");
+        assertThat(node.get(5).get("account_id").asLong()).isEqualTo(200L);
+        assertThat(node.get(5).get("date").asText()).isEqualTo("2026-01-03");
+
+        // Exactly one call per account per pass (CSV + JSON = 2 passes) — never a
+        // whole-member collection call, and no third/extra call sneaking in.
+        verify(balanceSnapshotRepository, times(2)).findByAccountIdOrderByDateAsc(100L);
+        verify(balanceSnapshotRepository, times(2)).findByAccountIdOrderByDateAsc(200L);
+        verifyNoMoreInteractions(balanceSnapshotRepository);
+        verify(accountRepository, times(2)).findAllByMemberIdOrderByCreatedAtAsc(42L);
+    }
+}

--- a/backend/src/test/java/com/picsou/export/DataExportServiceTest.java
+++ b/backend/src/test/java/com/picsou/export/DataExportServiceTest.java
@@ -1,5 +1,6 @@
 package com.picsou.export;
 
+import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.picsou.model.*;
@@ -23,6 +24,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -33,6 +35,7 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -249,6 +252,34 @@ class DataExportServiceTest {
         JsonNode parsed = new ObjectMapper().readTree(entries.get("data.json"));
         assertThat(parsed.get("accounts")).hasSize(0);
         assertThat(parsed.get("holdings")).hasSize(0);
+    }
+
+    /**
+     * A mid-stream exporter failure cannot change the HTTP status (headers are gone with
+     * the first ZIP byte) — the contract is: rethrow so the controller logs it, but first
+     * stamp an {@code __EXPORT_FAILED__.txt} entry into the archive so the user can tell
+     * a truncated download from a complete one.
+     */
+    @Test
+    void exporterFailureMidStream_stampsFailureMarkerAndRethrows() throws Exception {
+        EntityExporter failing = new EntityExporter() {
+            @Override public String name() { return "failing"; }
+            @Override public List<String> csvHeader() { return List.of("x"); }
+            @Override public void writeCsv(AppUser u, ExportContext c, CsvWriter w) { }
+            @Override public void writeJson(AppUser u, ExportContext c, JsonGenerator json) throws IOException {
+                throw new IOException("simulated mid-stream failure");
+            }
+        };
+        DataExportService failingService = new DataExportService(List.of(failing));
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        assertThatThrownBy(() -> failingService.export(user, ExportContext.defaults(), out))
+            .isInstanceOf(IOException.class)
+            .hasMessageContaining("simulated mid-stream failure");
+
+        Map<String, byte[]> entries = readZip(out.toByteArray());
+        assertThat(entries).containsKey("__EXPORT_FAILED__.txt");
+        assertThat(new String(entries.get("__EXPORT_FAILED__.txt"))).contains("incomplete");
     }
 
     private static Map<String, byte[]> readZip(byte[] bytes) throws Exception {

--- a/backend/src/test/java/com/picsou/export/DataExportServiceTest.java
+++ b/backend/src/test/java/com/picsou/export/DataExportServiceTest.java
@@ -5,6 +5,16 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.picsou.model.*;
 import com.picsou.repository.AccountHoldingRepository;
 import com.picsou.repository.AccountRepository;
+import com.picsou.repository.BalanceSnapshotRepository;
+import com.picsou.repository.DebtRepository;
+import com.picsou.repository.GoalContributorRepository;
+import com.picsou.repository.GoalManualContributionRepository;
+import com.picsou.repository.GoalMonthOverrideRepository;
+import com.picsou.repository.GoalRepository;
+import com.picsou.repository.RequisitionRepository;
+import com.picsou.repository.SharedResourceRepository;
+import com.picsou.repository.TransactionRepository;
+import com.picsou.repository.WalletAddressRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -15,6 +25,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.math.BigDecimal;
 import java.time.Instant;
+import java.time.LocalDate;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -29,6 +40,16 @@ class DataExportServiceTest {
 
     @Mock private AccountRepository accountRepository;
     @Mock private AccountHoldingRepository holdingRepository;
+    @Mock private RequisitionRepository requisitionRepository;
+    @Mock private DebtRepository debtRepository;
+    @Mock private GoalRepository goalRepository;
+    @Mock private GoalContributorRepository goalContributorRepository;
+    @Mock private GoalManualContributionRepository goalManualContributionRepository;
+    @Mock private GoalMonthOverrideRepository goalMonthOverrideRepository;
+    @Mock private SharedResourceRepository sharedResourceRepository;
+    @Mock private TransactionRepository transactionRepository;
+    @Mock private WalletAddressRepository walletAddressRepository;
+    @Mock private BalanceSnapshotRepository balanceSnapshotRepository;
 
     private DataExportService service;
     private AppUser user;
@@ -37,6 +58,10 @@ class DataExportServiceTest {
     private static final String SECRET_PASSWORD_HASH = "$2a$10$NeVeRsHoUlDaPpEaR";
     private static final String SECRET_TOTP = "JBSWY3DPEHPK3PXPSeCrEt";
     private static final String SECRET_TOKEN = "ACTIVATION_TOKEN_aBcDeF123";
+    // Requisition.authLink: "a one-shot OAuth-style URL with a temporary token" (see the
+    // exclusion rationale in BankConnectionsExporter's Javadoc) — deliberately not exported.
+    private static final String SECRET_BANK_AUTH_LINK =
+        "https://auth.enablebanking.com/start?token=SECRET_ONE_SHOT_AUTH_XyZ789";
 
     @BeforeEach
     void setUp() {
@@ -51,10 +76,27 @@ class DataExportServiceTest {
             .member(member)
             .build();
 
+        // Wire ALL exporter beans, matching production Spring injection
+        // (DataExportService.java receives List<EntityExporter> for every @Component
+        // exporter). A test built with only a subset never exercises the exporters it
+        // omits — see plan 005 for the incident this closes.
         ProfileExporter profile = new ProfileExporter();
         AccountsExporter accounts = new AccountsExporter(accountRepository);
         HoldingsExporter holdings = new HoldingsExporter(accountRepository, holdingRepository);
-        service = new DataExportService(List.of(profile, accounts, holdings));
+        BankConnectionsExporter bankConnections = new BankConnectionsExporter(requisitionRepository);
+        DebtsExporter debts = new DebtsExporter(debtRepository);
+        GoalsExporter goals = new GoalsExporter(
+            goalRepository, goalContributorRepository, goalManualContributionRepository, goalMonthOverrideRepository);
+        SharedResourcesExporter sharedResources = new SharedResourcesExporter(sharedResourceRepository);
+        TransactionsExporter transactions = new TransactionsExporter(accountRepository, transactionRepository);
+        WalletAddressesExporter walletAddresses = new WalletAddressesExporter(walletAddressRepository);
+        BalanceSnapshotsExporter balanceSnapshots =
+            new BalanceSnapshotsExporter(accountRepository, balanceSnapshotRepository);
+
+        service = new DataExportService(List.of(
+            profile, accounts, holdings, bankConnections, debts, goals,
+            sharedResources, transactions, walletAddresses, balanceSnapshots
+        ));
     }
 
     @Test
@@ -70,18 +112,104 @@ class DataExportServiceTest {
             .quantity(new BigDecimal("0.5")).averageBuyIn(new BigDecimal("30000"))
             .currentPrice(new BigDecimal("65000"))
             .build();
+        Requisition connection = Requisition.builder()
+            .id(300L).member(member)
+            .requisitionId("req_enablebanking_abc123")
+            .institutionId("bnpparibas").institutionName("BNP Paribas")
+            .status(RequisitionStatus.LINKED)
+            .authLink(SECRET_BANK_AUTH_LINK)
+            .lastSyncedAt(Instant.parse("2026-01-02T00:00:00Z"))
+            .build();
+        Debt debt = Debt.builder()
+            .id(400L).member(member).account(a)
+            .borrowedAmount(new BigDecimal("150000"))
+            .interestRate(new BigDecimal("0.0345"))
+            .monthlyPayment(new BigDecimal("850.23"))
+            .lenderName("Crédit Agricole")
+            .startDate(LocalDate.of(2022, 1, 1)).endDate(LocalDate.of(2042, 1, 1))
+            .insuranceMonthly(new BigDecimal("12.50")).fileFees(new BigDecimal("300"))
+            .build();
+        Goal goal = Goal.builder()
+            .id(500L).member(member).name("Vacation fund")
+            .targetAmount(new BigDecimal("5000")).deadline(LocalDate.of(2027, 6, 1))
+            .accounts(List.of(a))
+            .build();
+        GoalContributor contributor = GoalContributor.builder()
+            .id(new GoalContributorId(500L, 42L)).goal(goal).member(member)
+            .build();
+        GoalManualContribution manualContribution = new GoalManualContribution();
+        manualContribution.setId(501L);
+        manualContribution.setGoal(goal);
+        manualContribution.setMember(member);
+        manualContribution.setYearMonth("2026-01");
+        manualContribution.setAmount(new BigDecimal("200"));
+        GoalMonthOverride monthOverride = new GoalMonthOverride();
+        monthOverride.setId(502L);
+        monthOverride.setGoal(goal);
+        monthOverride.setYearMonth("2026-02");
+        monthOverride.setAmount(new BigDecimal("250"));
+        SharedResource sharedResource = SharedResource.builder()
+            .id(600L).ownerMember(member)
+            .resourceType("ACCOUNT").resourceId(100L)
+            .createdAt(Instant.parse("2026-01-03T00:00:00Z"))
+            .build();
+        Transaction tx = Transaction.builder()
+            .id(700L).account(a)
+            .date(LocalDate.of(2026, 1, 5)).description("Grocery store")
+            .amount(new BigDecimal("-45.67")).type("EXPENSE").category("Food")
+            .nativeCurrency("EUR").isManual(true)
+            .txType(TransactionType.BUY).ticker("BTC")
+            .quantity(new BigDecimal("0.001")).pricePerUnit(new BigDecimal("65000"))
+            .fees(new BigDecimal("0.50"))
+            .build();
+        // No tripwire on WalletAddress.address: resolving the "is a wallet xpub secret?"
+        // question from plan 005's escape hatch. address is polymorphic -- BitcoinWalletAdapter
+        // documents accepting a plain address OR an xpub/zpub/descriptor, stored verbatim
+        // (WalletSyncService passes wallet.getAddress() straight through, no normalization) --
+        // but it is the exporter's one intentionally-exported payload field regardless of
+        // which shape it holds, not a deliberately-excluded secret like Requisition.authLink.
+        // Returning a user's own wallet-tracking credential in their own GDPR export is
+        // correct (Art. 20 portability), not a leak, so it is out of the tripwire net.
+        WalletAddress wallet = WalletAddress.builder()
+            .id(800L).member(member).chain(Chain.BITCOIN)
+            .address("bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh").label("Cold storage")
+            .lastSyncedAt(Instant.parse("2026-01-04T00:00:00Z"))
+            .build();
+        BalanceSnapshot snapshot = BalanceSnapshot.builder()
+            .id(900L).account(a)
+            .date(LocalDate.of(2026, 1, 1))
+            .balance(new BigDecimal("12345.67")).investedAmount(new BigDecimal("10000"))
+            .build();
 
         when(accountRepository.findAllByMemberIdOrderByCreatedAtAsc(42L))
             .thenReturn(List.of(a));
         when(holdingRepository.findByAccount_Id(100L)).thenReturn(List.of(h));
+        when(requisitionRepository.findAllByMemberId(42L)).thenReturn(List.of(connection));
+        when(debtRepository.findAllByMemberId(42L)).thenReturn(List.of(debt));
+        when(goalRepository.findAllByMemberIdOrderByCreatedAtAsc(42L)).thenReturn(List.of(goal));
+        when(goalContributorRepository.findByGoalId(500L)).thenReturn(List.of(contributor));
+        when(goalManualContributionRepository.findByGoalId(500L)).thenReturn(List.of(manualContribution));
+        when(goalMonthOverrideRepository.findByGoalId(500L)).thenReturn(List.of(monthOverride));
+        when(sharedResourceRepository.findAllByOwnerMemberIdAndResourceType(42L, "ACCOUNT"))
+            .thenReturn(List.of(sharedResource));
+        when(transactionRepository.findByAccountIdOrderByDateDesc(100L)).thenReturn(List.of(tx));
+        when(walletAddressRepository.findAllByMemberId(42L)).thenReturn(List.of(wallet));
+        when(balanceSnapshotRepository.findByAccountIdOrderByDateAsc(100L)).thenReturn(List.of(snapshot));
 
         ByteArrayOutputStream out = new ByteArrayOutputStream();
-        service.export(user, ExportContext.defaults(), out);
+        // includeBalanceSnapshots=true so balance_snapshots.csv (gated) is in scope for the net too.
+        service.export(user, new ExportContext(true), out);
         byte[] zipBytes = out.toByteArray();
 
         Map<String, byte[]> entries = readZip(zipBytes);
         assertThat(entries.keySet())
-            .contains("data.json", "profile.csv", "accounts.csv", "holdings.csv", "README.txt");
+            .contains(
+                "data.json", "README.txt",
+                "profile.csv", "accounts.csv", "holdings.csv",
+                "bank_connections.csv", "debts.csv", "goals.csv",
+                "shared_resources.csv", "transactions.csv",
+                "wallet_addresses.csv", "balance_snapshots.csv"
+            );
 
         String json = new String(entries.get("data.json"));
         assertThat(json).contains("\"username\" : \"chloe\"");
@@ -99,10 +227,12 @@ class DataExportServiceTest {
 
         // Whole-archive byte-grep: NONE of the known secret tokens may appear anywhere
         // (data.json, csv files, README, ZIP metadata) — this is the GDPR safety net.
+        // Covers all 10 exporters, matching production wiring (see setUp()).
         String archive = new String(zipBytes, java.nio.charset.StandardCharsets.ISO_8859_1);
         assertThat(archive).doesNotContain(SECRET_PASSWORD_HASH);
         assertThat(archive).doesNotContain(SECRET_TOTP);
         assertThat(archive).doesNotContain(SECRET_TOKEN);
+        assertThat(archive).doesNotContain(SECRET_BANK_AUTH_LINK);
         assertThat(archive).doesNotContain("password_hash");
         assertThat(archive).doesNotContain("activation_token");
     }

--- a/backend/src/test/java/com/picsou/repository/TransactionRepositoryTest.java
+++ b/backend/src/test/java/com/picsou/repository/TransactionRepositoryTest.java
@@ -1,0 +1,90 @@
+package com.picsou.repository;
+
+import com.picsou.model.Account;
+import com.picsou.model.Transaction;
+import com.picsou.model.TransactionType;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.jdbc.Sql;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * {@link TransactionRepository#findByAccountIdAndTxTypeInOrderByDateAscIdAsc} feeds the
+ * order-sensitive realized-P&L moving-average pass ({@code RealizedPnlService}) and the holdings
+ * recompute pass ({@code HoldingComputeService}). {@code Transaction.date} is a day-granularity
+ * {@code LocalDate}, so two same-day rows have undefined order under a {@code date}-only
+ * ORDER BY. This test pins that {@code id} (insertion order) is a deterministic tiebreaker.
+ *
+ * <p>Flyway is disabled and the schema is hand-rolled (see
+ * {@code sql/transaction-repository-test-schema.sql}): the real migrations are
+ * PostgreSQL-flavoured and cannot run on H2 -- per docs/conventions/testing.md. This is the
+ * first {@code @DataJpaTest} in the suite.
+ */
+@DataJpaTest
+@TestPropertySource(properties = {
+    "spring.flyway.enabled=false",
+    "spring.jpa.hibernate.ddl-auto=none"
+})
+@Sql("classpath:sql/transaction-repository-test-schema.sql")
+class TransactionRepositoryTest {
+
+    @Autowired
+    TransactionRepository transactionRepository;
+
+    @Autowired
+    TestEntityManager testEntityManager;
+
+    @Test
+    void sameDateRows_orderedByIdAfterDate_stableAcrossRepeatedCalls() {
+        // A reference proxy (not a builder-constructed POJO): the seed account row was inserted
+        // by the raw SQL script above, outside JPA, so Hibernate has never "seen" it as managed --
+        // persisting a Transaction against a plain Account.builder().id(1L).build() would throw
+        // TransientPropertyValueException. getReference() is the standard way to point a
+        // @ManyToOne at a row known to exist without loading or re-persisting it.
+        Account account = testEntityManager.getEntityManager().getReference(Account.class, 1L);
+        LocalDate sameDate = LocalDate.of(2026, 7, 1);
+
+        // Persist SELL first so it gets the lower id, despite BUY being the economically "earlier"
+        // leg -- this is what proves the tiebreaker is insertion order (id), not transaction type.
+        Transaction sell = transactionRepository.save(Transaction.builder()
+            .account(account)
+            .date(sameDate)
+            .description("SELL")
+            .amount(BigDecimal.ZERO)
+            .txType(TransactionType.SELL)
+            .ticker("AAPL")
+            .quantity(new BigDecimal("10"))
+            .build());
+
+        Transaction buy = transactionRepository.save(Transaction.builder()
+            .account(account)
+            .date(sameDate)
+            .description("BUY")
+            .amount(BigDecimal.ZERO)
+            .txType(TransactionType.BUY)
+            .ticker("AAPL")
+            .quantity(new BigDecimal("10"))
+            .build());
+
+        testEntityManager.flush();
+        assertThat(sell.getId()).isLessThan(buy.getId());
+
+        List<TransactionType> types = List.of(TransactionType.BUY, TransactionType.SELL);
+
+        // Called twice: not a coincidence of one lucky plan, but the guaranteed order the
+        // ORDER BY (date, id) clause produces every time.
+        List<Transaction> first = transactionRepository.findByAccountIdAndTxTypeInOrderByDateAscIdAsc(1L, types);
+        List<Transaction> second = transactionRepository.findByAccountIdAndTxTypeInOrderByDateAscIdAsc(1L, types);
+
+        assertThat(first).extracting(Transaction::getId).containsExactly(sell.getId(), buy.getId());
+        assertThat(second).extracting(Transaction::getId).containsExactly(sell.getId(), buy.getId());
+    }
+}

--- a/backend/src/test/java/com/picsou/service/HoldingComputeServiceTest.java
+++ b/backend/src/test/java/com/picsou/service/HoldingComputeServiceTest.java
@@ -91,7 +91,7 @@ class HoldingComputeServiceTest {
         Account account = account(1L);
         Transaction buy = buyTx("AAPL", "10", "150.00");
 
-        when(transactionRepository.findByAccountIdAndTxTypeInOrderByDateAsc(eq(1L), anyList()))
+        when(transactionRepository.findByAccountIdAndTxTypeInOrderByDateAscIdAsc(eq(1L), anyList()))
                 .thenReturn(List.of(buy));
         when(accountHoldingRepository.findByAccount_Id(1L))
                 .thenReturn(List.of());
@@ -117,7 +117,7 @@ class HoldingComputeServiceTest {
         Transaction buy1 = buyTx("ETH", "10", "100.00");
         Transaction buy2 = buyTx("ETH", "20", "200.00");
 
-        when(transactionRepository.findByAccountIdAndTxTypeInOrderByDateAsc(eq(1L), anyList()))
+        when(transactionRepository.findByAccountIdAndTxTypeInOrderByDateAscIdAsc(eq(1L), anyList()))
                 .thenReturn(List.of(buy1, buy2));
         when(accountHoldingRepository.findByAccount_Id(1L))
                 .thenReturn(List.of());
@@ -140,7 +140,7 @@ class HoldingComputeServiceTest {
         // Buy 10 @ 100 with 5 fees → averageBuyIn = (10*100 + 5) / 10 = 100.5 (French PEA PMP convention)
         Transaction buy = buyTxWithFees("AAPL", "10", "100.00", "5.00");
 
-        when(transactionRepository.findByAccountIdAndTxTypeInOrderByDateAsc(eq(1L), anyList()))
+        when(transactionRepository.findByAccountIdAndTxTypeInOrderByDateAscIdAsc(eq(1L), anyList()))
                 .thenReturn(List.of(buy));
         when(accountHoldingRepository.findByAccount_Id(1L))
                 .thenReturn(List.of());
@@ -163,7 +163,7 @@ class HoldingComputeServiceTest {
         Transaction buy1 = buyTxWithFees("ETH", "10", "100.00", "5.00");
         Transaction buy2 = buyTxWithFees("ETH", "10", "200.00", "5.00");
 
-        when(transactionRepository.findByAccountIdAndTxTypeInOrderByDateAsc(eq(1L), anyList()))
+        when(transactionRepository.findByAccountIdAndTxTypeInOrderByDateAscIdAsc(eq(1L), anyList()))
                 .thenReturn(List.of(buy1, buy2));
         when(accountHoldingRepository.findByAccount_Id(1L))
                 .thenReturn(List.of());
@@ -185,7 +185,7 @@ class HoldingComputeServiceTest {
         // No fees recorded → averageBuyIn = plain VWAP = 100
         Transaction buy = buyTxWithFees("BTC", "10", "100.00", null);
 
-        when(transactionRepository.findByAccountIdAndTxTypeInOrderByDateAsc(eq(1L), anyList()))
+        when(transactionRepository.findByAccountIdAndTxTypeInOrderByDateAscIdAsc(eq(1L), anyList()))
                 .thenReturn(List.of(buy));
         when(accountHoldingRepository.findByAccount_Id(1L))
                 .thenReturn(List.of());
@@ -206,7 +206,7 @@ class HoldingComputeServiceTest {
         Transaction buy = buyTx("BTC", "5", "30000.00");
         Transaction sell = sellTx("BTC", "2");
 
-        when(transactionRepository.findByAccountIdAndTxTypeInOrderByDateAsc(eq(1L), anyList()))
+        when(transactionRepository.findByAccountIdAndTxTypeInOrderByDateAscIdAsc(eq(1L), anyList()))
                 .thenReturn(List.of(buy, sell));
         when(accountHoldingRepository.findByAccount_Id(1L))
                 .thenReturn(List.of());
@@ -237,7 +237,7 @@ class HoldingComputeServiceTest {
                 .quantity(new BigDecimal("10"))
                 .build();
 
-        when(transactionRepository.findByAccountIdAndTxTypeInOrderByDateAsc(eq(1L), anyList()))
+        when(transactionRepository.findByAccountIdAndTxTypeInOrderByDateAscIdAsc(eq(1L), anyList()))
                 .thenReturn(List.of(buy, sell));
         when(accountHoldingRepository.findByAccount_Id(1L))
                 .thenReturn(List.of(existing));
@@ -269,7 +269,7 @@ class HoldingComputeServiceTest {
                 .pricePerUnit(new BigDecimal("100"))
                 .build();
 
-        when(transactionRepository.findByAccountIdAndTxTypeInOrderByDateAsc(eq(1L), anyList()))
+        when(transactionRepository.findByAccountIdAndTxTypeInOrderByDateAscIdAsc(eq(1L), anyList()))
                 .thenReturn(List.of(buy));
         when(accountHoldingRepository.findByAccount_Id(1L))
                 .thenReturn(List.of());
@@ -290,7 +290,7 @@ class HoldingComputeServiceTest {
         Transaction buyAapl = buyTx("AAPL", "10", "150.00");
         Transaction buyMsft = buyTx("MSFT", "5", "300.00");
 
-        when(transactionRepository.findByAccountIdAndTxTypeInOrderByDateAsc(eq(1L), anyList()))
+        when(transactionRepository.findByAccountIdAndTxTypeInOrderByDateAscIdAsc(eq(1L), anyList()))
                 .thenReturn(List.of(buyAapl, buyMsft));
         when(accountHoldingRepository.findByAccount_Id(1L))
                 .thenReturn(List.of());
@@ -328,7 +328,7 @@ class HoldingComputeServiceTest {
             .pricePerUnit(new BigDecimal("50000"))
             .build();
 
-        when(transactionRepository.findByAccountIdAndTxTypeInOrderByDateAsc(eq(1L), anyList()))
+        when(transactionRepository.findByAccountIdAndTxTypeInOrderByDateAscIdAsc(eq(1L), anyList()))
             .thenReturn(List.of(tx));
         when(accountHoldingRepository.findByAccount_Id(1L))
             .thenReturn(List.of());
@@ -345,7 +345,7 @@ class HoldingComputeServiceTest {
         // Buy 10 with no price — should use 0 for VWAP computation
         Transaction buy = buyTx("XRP", "10", null);
 
-        when(transactionRepository.findByAccountIdAndTxTypeInOrderByDateAsc(eq(1L), anyList()))
+        when(transactionRepository.findByAccountIdAndTxTypeInOrderByDateAscIdAsc(eq(1L), anyList()))
                 .thenReturn(List.of(buy));
         when(accountHoldingRepository.findByAccount_Id(1L))
                 .thenReturn(List.of());
@@ -375,7 +375,7 @@ class HoldingComputeServiceTest {
                 .averageBuyIn(new BigDecimal("300.00"))
                 .build();
 
-        when(transactionRepository.findByAccountIdAndTxTypeInOrderByDateAsc(eq(1L), anyList()))
+        when(transactionRepository.findByAccountIdAndTxTypeInOrderByDateAscIdAsc(eq(1L), anyList()))
                 .thenReturn(List.of(buy));
         when(accountHoldingRepository.findByAccount_Id(1L))
                 .thenReturn(List.of(existing));
@@ -404,7 +404,7 @@ class HoldingComputeServiceTest {
         Transaction newer = buyTxWithName("IWDA.AS", "5", "90.00",
                 "iShares Core MSCI World UCITS ETF", LocalDate.of(2024, 3, 1));
 
-        when(transactionRepository.findByAccountIdAndTxTypeInOrderByDateAsc(eq(1L), anyList()))
+        when(transactionRepository.findByAccountIdAndTxTypeInOrderByDateAscIdAsc(eq(1L), anyList()))
                 .thenReturn(List.of(older, newer));
         when(accountHoldingRepository.findByAccount_Id(1L))
                 .thenReturn(List.of());
@@ -434,7 +434,7 @@ class HoldingComputeServiceTest {
                 .quantity(new BigDecimal("1"))
                 .build();
 
-        when(transactionRepository.findByAccountIdAndTxTypeInOrderByDateAsc(eq(1L), anyList()))
+        when(transactionRepository.findByAccountIdAndTxTypeInOrderByDateAscIdAsc(eq(1L), anyList()))
                 .thenReturn(List.of(buy));
         when(accountHoldingRepository.findByAccount_Id(1L))
                 .thenReturn(List.of(existing));

--- a/backend/src/test/java/com/picsou/service/RealizedPnlServiceTest.java
+++ b/backend/src/test/java/com/picsou/service/RealizedPnlServiceTest.java
@@ -61,7 +61,7 @@ class RealizedPnlServiceTest {
 
     private RealizedPnlResponse compute(Account account, Transaction... txs) {
         when(accountRepository.findByIdAndMemberId(1L, 10L)).thenReturn(Optional.of(account));
-        when(transactionRepository.findByAccountIdAndTxTypeInOrderByDateAsc(eq(1L), anyList()))
+        when(transactionRepository.findByAccountIdAndTxTypeInOrderByDateAscIdAsc(eq(1L), anyList()))
             .thenReturn(List.of(txs));
         return service.compute(1L, 10L);
     }
@@ -132,5 +132,77 @@ class RealizedPnlServiceTest {
 
         assertThat(r.currency()).isEqualTo("USD");
         assertThat(r.realizedTotal()).isEqualByComparingTo("10");
+    }
+
+    /**
+     * Pins the behavioral contract that the repository's {@code (date, id)} ordering exists to
+     * protect. A same-day BUY-then-SELL stream, returned by the (mocked) repository in insertion
+     * order: BUY 10 @ 100 -> avg cost 100; SELL 10 @ 110 fees 0 -> proceeds 1100, cost 1000,
+     * realized 100. No warning, because quantity sold (10) never exceeds quantity held (10).
+     */
+    @Test
+    void sameDayBuyThenSell_inInsertionOrder_realizesGainNoWarning() {
+        LocalDate sameDay = LocalDate.of(2026, 7, 1);
+        Transaction buy = Transaction.builder()
+            .account(account("EUR"))
+            .date(sameDay)
+            .txType(TransactionType.BUY)
+            .ticker("AAPL").name("AAPL")
+            .quantity(new BigDecimal("10"))
+            .pricePerUnit(new BigDecimal("100"))
+            .amount(BigDecimal.ZERO)
+            .build();
+        Transaction sell = Transaction.builder()
+            .account(account("EUR"))
+            .date(sameDay)
+            .txType(TransactionType.SELL)
+            .ticker("AAPL").name("AAPL")
+            .quantity(new BigDecimal("10"))
+            .pricePerUnit(new BigDecimal("110"))
+            .fees(BigDecimal.ZERO)
+            .amount(BigDecimal.ZERO)
+            .build();
+
+        RealizedPnlResponse r = compute(account("EUR"), buy, sell);
+
+        assertThat(r.realizedTotal()).isEqualByComparingTo("100");
+        assertThat(r.byTicker().get(0).warning()).isFalse();
+    }
+
+    /**
+     * Same two same-day transactions, repository order reversed (SELL before BUY) -- exactly what
+     * an undefined date-only DB order could hand back. RealizedPnlService never reorders same-day
+     * rows itself (that is the repository's job), so the SELL is walked against a still-empty
+     * pool: held=0 -> avgCost=0, costed quantity clamped to 0, realized = full proceeds (1100),
+     * and the over-sell warning fires. This is the silent-wrong-money failure mode that the
+     * repository's (date, id) ordering guarantee must prevent from happening on real data.
+     */
+    @Test
+    void sameDaySellThenBuy_reversedOrder_documentsOverSellWarningContract() {
+        LocalDate sameDay = LocalDate.of(2026, 7, 1);
+        Transaction buy = Transaction.builder()
+            .account(account("EUR"))
+            .date(sameDay)
+            .txType(TransactionType.BUY)
+            .ticker("AAPL").name("AAPL")
+            .quantity(new BigDecimal("10"))
+            .pricePerUnit(new BigDecimal("100"))
+            .amount(BigDecimal.ZERO)
+            .build();
+        Transaction sell = Transaction.builder()
+            .account(account("EUR"))
+            .date(sameDay)
+            .txType(TransactionType.SELL)
+            .ticker("AAPL").name("AAPL")
+            .quantity(new BigDecimal("10"))
+            .pricePerUnit(new BigDecimal("110"))
+            .fees(BigDecimal.ZERO)
+            .amount(BigDecimal.ZERO)
+            .build();
+
+        RealizedPnlResponse r = compute(account("EUR"), sell, buy);
+
+        assertThat(r.realizedTotal()).isEqualByComparingTo("1100");
+        assertThat(r.byTicker().get(0).warning()).isTrue();
     }
 }

--- a/backend/src/test/java/com/picsou/service/SetupServiceTest.java
+++ b/backend/src/test/java/com/picsou/service/SetupServiceTest.java
@@ -68,6 +68,7 @@ class SetupServiceTest {
     void seedAdmin_createsFamilyMemberAndAppUser_andClaimsInProgressState() {
         when(userRepository.existsByUsername("admin")).thenReturn(false);
         when(settingRepository.findByKey(SetupService.KEY_SETUP_STATE)).thenReturn(Optional.empty());
+        when(userRepository.count()).thenReturn(0L);
         when(settingRepository.compareAndSet(SetupService.KEY_SETUP_STATE,
             SetupState.PENDING_ADMIN.name(), SetupState.IN_PROGRESS.name())).thenReturn(1);
 
@@ -124,6 +125,28 @@ class SetupServiceTest {
         assertThatThrownBy(() -> setupService.seedAdmin("admin", "$2a$12$any", null, null))
             .isInstanceOf(IllegalStateException.class)
             .hasMessageContaining("already complete");
+    }
+
+    /**
+     * Closes the setup-wizard second-admin backdoor: while state is IN_PROGRESS (an
+     * admin was seeded but /api/setup/complete has not been called yet), the wizard's
+     * /admin endpoint is still unauthenticated. Without this guard a differently-named
+     * account sails through — the same-username idempotency check doesn't catch it, and
+     * the CAS only protects the PENDING_ADMIN -> IN_PROGRESS transition, not this one.
+     */
+    @Test
+    void seedAdmin_refuses_whenAnyAccountAlreadyExists() {
+        AppSetting state = AppSetting.builder().key(SetupService.KEY_SETUP_STATE).value("IN_PROGRESS").build();
+        when(userRepository.existsByUsername("bob")).thenReturn(false);
+        when(settingRepository.findByKey(SetupService.KEY_SETUP_STATE)).thenReturn(Optional.of(state));
+        when(userRepository.count()).thenReturn(1L);
+
+        assertThatThrownBy(() -> setupService.seedAdmin("bob", "$2a$12$any", "Bob", null))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("already exists");
+
+        verify(userRepository, never()).save(any());
+        verify(memberRepository, never()).save(any());
     }
 
     @Test

--- a/backend/src/test/resources/sql/transaction-repository-test-schema.sql
+++ b/backend/src/test/resources/sql/transaction-repository-test-schema.sql
@@ -1,0 +1,43 @@
+-- Minimal H2 schema for TransactionRepositoryTest (@DataJpaTest).
+--
+-- The real schema comes from Flyway (backend/src/main/resources/db/migration), which is
+-- PostgreSQL-flavoured (native enum types via CREATE TYPE ... AS ENUM, etc.) and cannot run on
+-- H2 -- see docs/conventions/testing.md. This script stands up just enough structure for
+-- TransactionRepository's derived-query ordering to be exercised: an `account` row to satisfy
+-- the FK on `transaction.account_id`, and a `transaction` table with every column the
+-- Transaction entity maps (Hibernate includes all mapped columns in generated INSERTs
+-- regardless of what a given test cares about).
+--
+-- `account` deliberately carries only `id` and `deleted_at`: this test never persists or queries
+-- the Account entity through JPA (see getReference() usage in the test), only via this seed row,
+-- so it never touches Account's Postgres-only `account_type` native-enum column. `deleted_at` is
+-- required despite that: Account carries a class-level @SQLRestriction("deleted_at IS NULL"),
+-- which Hibernate folds into the JOIN ON clause for *any* query that traverses the `account`
+-- association -- including a plain `t.account.id` path in a derived query -- so the column must
+-- exist even though this test never sets it (NULL, matching the restriction).
+
+CREATE TABLE account (
+    id         BIGINT AUTO_INCREMENT PRIMARY KEY,
+    deleted_at TIMESTAMP
+);
+
+INSERT INTO account (id) VALUES (1);
+
+CREATE TABLE transaction (
+    id              BIGINT AUTO_INCREMENT PRIMARY KEY,
+    account_id      BIGINT          NOT NULL,
+    date            DATE            NOT NULL,
+    description     VARCHAR(255)    NOT NULL,
+    amount          DECIMAL(20, 8)  NOT NULL,
+    type            VARCHAR(100),
+    category        VARCHAR(100),
+    native_currency VARCHAR(10)     NOT NULL,
+    created_at      TIMESTAMP       NOT NULL,
+    is_manual       BOOLEAN         NOT NULL,
+    tx_type         VARCHAR(20),
+    ticker          VARCHAR(30),
+    name            VARCHAR(100),
+    quantity        DECIMAL(20, 8),
+    price_per_unit  DECIMAL(20, 8),
+    fees            DECIMAL(20, 8)
+);

--- a/docs/features/data-export.md
+++ b/docs/features/data-export.md
@@ -197,6 +197,7 @@ Frontend:
 - **Currency separation.** Money is always written as `(decimal-string, currency-code)` — never as a localized string like `"1 234,56 €"` and never as a `Double`.
 - **`SharedResource` direction.** Only export rows where the AppUser's member is the **recipient** (data shared *with* me); rows where they share *outwards* are also relevant since they describe how my data is shared — both directions are exported, but always anchored on "my member id" so we never include third-party data we shouldn't.
 - **Managed-profile detour.** The export endpoint ignores any `?memberId=` query/cookie context — always anchors on the authenticated `AppUser`.
+- **`BalanceSnapshotsExporter` streams per account.** `writeCsv`/`writeJson` each iterate the member's accounts and, per account, query `balanceSnapshotRepository.findByAccountIdOrderByDateAsc` — instead of collecting the member's *entire* snapshot history into one list before writing anything. This is the table the class's own Javadoc calls out as able to "dwarf the rest of the archive" (years × many accounts), so heap must stay bounded to one account's history at a time rather than growing with total history size. Cost: each of the 2 passes (CSV, JSON) re-runs the same per-account queries — 2 passes total, unchanged from before. Accepted: the goal is bounded heap, not minimal query count. Row order (account insertion order, then date within account) is unchanged.
 
 ## Tests
 
@@ -204,6 +205,7 @@ Backend:
 
 - `*ExporterTest` (one per `EntityExporter`) — fixtures → expected JSON node + CSV rows. Each includes a *negative* assertion: the produced bytes do not contain known-secret tokens.
 - `DataExportServiceTest` — verifies ZIP file list given options, presence/absence of `balance_snapshots.csv` based on toggle, presence of `README.txt`. Wires **all** `EntityExporter` beans (matching production Spring injection, not a subset) with one fixture per entity carrying a unique tripwire literal in every sensitive, non-exported field (e.g. `Requisition.authLink`); asserts none of the tripwires appear anywhere in the archive bytes. **New exporter ⇒ new wiring + new tripwire(s) in this test** — the net only protects what it exercises, and a partial exporter list (as this test shipped with for a while) silently blinds it to whichever exporters are missing.
+- `BalanceSnapshotsExporterTest` — drives the exporter directly (2 accounts × 3 snapshots): asserts CSV/JSON row order (account, then date) and, via `Mockito.verify`, exactly one `balanceSnapshotRepository.findByAccountIdOrderByDateAsc` call per account per pass (2 passes) — never a whole-member collecting call.
 - `MeExportControllerTest` (`@WebMvcTest`) — happy path, re-auth fail (password), re-auth fail (TOTP), missing body, rate-limit exceeded.
 - `DataExportIntegrationTest` (`@SpringBootTest` + H2) — seed an `AppUser` with **all** entity types populated **and** every secret-bearing entity (MFA secret, recovery codes, BoursoSession ciphertext, requisition tokens, persistent session). Hit the endpoint, parse the ZIP in memory, assert:
   - all expected files present

--- a/docs/features/data-export.md
+++ b/docs/features/data-export.md
@@ -1,6 +1,6 @@
 # Feature: GDPR-friendly data export (JSON + CSV)
 
-> Last updated: 2026-04-26
+> Last updated: 2026-07-20
 > Status: ✅ Implemented
 
 ## Context
@@ -203,7 +203,7 @@ Frontend:
 Backend:
 
 - `*ExporterTest` (one per `EntityExporter`) — fixtures → expected JSON node + CSV rows. Each includes a *negative* assertion: the produced bytes do not contain known-secret tokens.
-- `DataExportServiceTest` — verifies ZIP file list given options, presence/absence of `balance_snapshots.csv` based on toggle, presence of `README.txt`.
+- `DataExportServiceTest` — verifies ZIP file list given options, presence/absence of `balance_snapshots.csv` based on toggle, presence of `README.txt`. Wires **all** `EntityExporter` beans (matching production Spring injection, not a subset) with one fixture per entity carrying a unique tripwire literal in every sensitive, non-exported field (e.g. `Requisition.authLink`); asserts none of the tripwires appear anywhere in the archive bytes. **New exporter ⇒ new wiring + new tripwire(s) in this test** — the net only protects what it exercises, and a partial exporter list (as this test shipped with for a while) silently blinds it to whichever exporters are missing.
 - `MeExportControllerTest` (`@WebMvcTest`) — happy path, re-auth fail (password), re-auth fail (TOTP), missing body, rate-limit exceeded.
 - `DataExportIntegrationTest` (`@SpringBootTest` + H2) — seed an `AppUser` with **all** entity types populated **and** every secret-bearing entity (MFA secret, recovery codes, BoursoSession ciphertext, requisition tokens, persistent session). Hit the endpoint, parse the ZIP in memory, assert:
   - all expected files present

--- a/docs/features/realized-pnl.md
+++ b/docs/features/realized-pnl.md
@@ -1,6 +1,6 @@
 # Feature: Realized P&L on closed positions
 
-> Last updated: 2026-07-11
+> Last updated: 2026-07-20
 
 ## Context
 
@@ -17,6 +17,16 @@ order and maintains a **moving-average (PMP) cost basis** per ticker:
 - **BUY**: `costPool += qty·price + fees`, `qtyHeld += qty` (buy fees are part of the cost).
 - **SELL**: `avgCost = costPool / qtyHeld`; `proceeds = qty·price − fees`;
   `realized = proceeds − avgCost·qtySold`; then draw the pool down by `avgCost·qtySold`.
+
+This pass is **order-sensitive**: a same-day SELL walked before its BUY sees `held = 0`, costs the
+sale at zero, and reports the full proceeds as realized gain (plus a spurious over-sell warning).
+`TransactionRepository.findByAccountIdAndTxTypeInOrderByDateAscIdAsc` therefore orders by
+`(date, id)`, not `date` alone — `Transaction.date` is a day-granularity `LocalDate`, so two
+same-day rows would otherwise come back in undefined database order. `id` is a deterministic
+tiebreaker equal to insertion order (auto-increment), so **same-day transactions are processed in
+the order they were entered/imported**. This is a stable-processing guarantee, not a semantic
+reordering: a genuinely out-of-order same-day entry (e.g. a sale keyed in before its matching buy)
+still — correctly and visibly — triggers the over-sell warning below.
 
 An over-sell (selling more than is held, or with no prior buy) clamps the costed quantity to what's
 held — no fabricated negative cost — and flags a per-ticker `warning`. Everything is in the
@@ -60,7 +70,12 @@ See ADR [2026-07-11-realized-pnl-average-cost-on-the-fly](../decisions/2026-07-1
 ## Tests
 
 - `RealizedPnlServiceTest` — partial/full close, fee folding, over-sell (clamp + warning),
-  sell-without-buy, account currency, buys-only (empty).
+  sell-without-buy, account currency, buys-only (empty), and the same-day ordering behavioral
+  contract: BUY-then-SELL in insertion order realizes the correct gain with no warning, while the
+  reversed order documents the over-sell-warning failure mode that DB ordering must prevent.
+- `TransactionRepositoryTest` (`@DataJpaTest` + H2) — persists a SELL then a BUY on the same date
+  and asserts `findByAccountIdAndTxTypeInOrderByDateAscIdAsc` returns them in insertion order
+  (`(date, id)`), consistently across repeated calls.
 - `RealizedPnlSection.test.tsx` — green/red total, hidden when no lots.
 
 ## Links

--- a/docs/features/security-cors-cookies.md
+++ b/docs/features/security-cors-cookies.md
@@ -1,6 +1,6 @@
 # Feature: CORS & Cookie Security
 
-> Last updated: 2026-06-02 (forward-headers-strategy — fixes 403 behind HTTPS reverse proxy)
+> Last updated: 2026-07-20 (client IP trust — rate-limit keys use X-Real-IP, not the XFF-spoofable getRemoteAddr())
 
 ## Context
 
@@ -53,6 +53,52 @@ chain must carry the headers end to end:
   are passed through **only when present** — never synthesized — so the backend derives the port
   from the scheme (443 for https) on the common standard-port deployment.
 
+### Client IP trust (rate-limit keys)
+
+`server.forward-headers-strategy: framework` fixes CORS (above) but has a side effect nothing
+about CORS warns you of: Spring's `ForwardedHeaderFilter` also rewrites
+`request.getRemoteAddr()` from the **leftmost** entry of `X-Forwarded-For`. Both nginx configs
+set `X-Forwarded-For` via `proxy_add_x_forwarded_for`, which **appends** to whatever the client
+already sent rather than replacing it — so a raw HTTP client can put anything it wants as the
+first entry and `getRemoteAddr()` reflects that client-chosen value, not the real TCP peer. Every
+per-IP Bucket4j limiter (login, MFA verify/enroll, setup wizard, BoursoBank/TR/IBKR/sync auth)
+used to key its bucket on `getRemoteAddr()` — meaning a client could rotate the header on every
+request and get a fresh bucket each time, nullifying the limiter entirely.
+
+The trustworthy signal is `X-Real-IP`: both nginx configs unconditionally set it to
+`$remote_addr` — the address nginx itself observed the connection from — on every proxied
+request (`docker/nginx.conf`, `frontend/nginx.conf`), so a client cannot inject or override it
+through our proxy the way it can with `X-Forwarded-For`.
+
+`com.picsou.config.ClientIp#resolve(HttpServletRequest)` is the single helper every rate-limit
+call site now uses instead of `getRemoteAddr()`:
+
+1. Prefer `X-Real-IP`, but only if it parses as a plain IPv4/IPv6 literal — defense in depth
+   against a directly-exposed backend (no nginx in front) where the header would otherwise be
+   attacker-supplied. The literal check is pure regex, deliberately not
+   `InetAddress.getByName()`, which falls through to a DNS/hosts lookup for anything that isn't
+   already a literal — network I/O driven by an untrusted header value.
+2. Otherwise fall back to `getRemoteAddr()`. Correct for local dev / unit tests: with no
+   `X-Forwarded-*` headers on the request, `ForwardedHeaderFilter` is a no-op and that value is
+   the genuine socket address.
+
+This trust chain assumes the backend is reachable **only** through our own nginx (the same
+assumption `forward-headers-strategy: framework` itself already makes — see Technical choices
+below). It does not defend against an attacker who can reach the backend port directly *and*
+supply their own `X-Forwarded-For`; that would need trusted-proxy IP ranges (`native` strategy,
+rejected below) rather than a request-local header check.
+
+Left out of scope, worth a follow-up: `SetupAuditService` and the admin-recovery audit trail
+still log `getRemoteAddr()` rather than `ClientIp.resolve()` for their `ip=` fields — honest
+audit logs would want the same fix, but audit logging is a different concern from rate-limit
+key derivation and the two weren't bundled. If a second proxy layer is ever added in front of
+the container (e.g. a reverse proxy in front of Docker), `X-Real-IP` must be set by the
+**outermost** trusted hop — document that in the compose README when it happens.
+
+`RateLimitConfig`'s bucket-store beans are also Caffeine-backed
+(`expireAfterAccess(1h)` + `maximumSize(50_000)`) rather than plain `ConcurrentHashMap`s, so a
+key an attacker fully controls (their own resolved IP) can no longer grow the map without bound.
+
 ### Cookies
 
 Auth tokens are HttpOnly cookies written by `AuthCookieWriter`:
@@ -73,7 +119,9 @@ access_token=...; Max-Age=900; Path=/; HttpOnly; SameSite=Lax[; Secure]
 | `backend/src/main/java/com/picsou/config/LoggingCorsProcessor.java` | Logs origin on CORS rejection |
 | `backend/src/main/java/com/picsou/config/AuthCookieWriter.java` / `SecureCookieProvider.java` | Cookie construction + `Secure` flag |
 | `backend/src/main/resources/application.yml` | `server.forward-headers-strategy: framework`, `app.cors.allowed-origins`, `app.secure-cookies` |
-| `docker/nginx.conf`, `frontend/nginx.conf` | Preserve upstream `X-Forwarded-Proto/Host/Port` |
+| `docker/nginx.conf`, `frontend/nginx.conf` | Preserve upstream `X-Forwarded-Proto/Host/Port`; always set `X-Real-IP: $remote_addr` |
+| `backend/src/main/java/com/picsou/config/ClientIp.java` | Trusted client IP for rate-limit keys (`X-Real-IP`, validated, else `getRemoteAddr()`) |
+| `backend/src/main/java/com/picsou/config/RateLimitConfig.java` | Bucket4j bucket definitions; bounded Caffeine-backed bucket-store beans |
 | `backend/src/main/java/com/picsou/controller/SetupController.java` (`/api/setup/security`) | Persists wizard's allowed origins |
 
 ## Technical choices
@@ -85,6 +133,8 @@ access_token=...; Max-Age=900; Path=/; HttpOnly; SameSite=Lax[; Secure]
 | Fail-closed empty default + wildcard stripping | `*` with credentials is unsafe and illegal in Spring | `ALLOWED_ORIGINS=*` default (previous behavior) |
 | `setAllowedOrigins` (exact) | Credentialed CORS; origins come from the wizard | `setAllowedOriginPatterns("*")` |
 | `SameSite=Lax` | Safari iOS compatibility | `SameSite=Strict` |
+| Rate-limit keys read `X-Real-IP`, not `getRemoteAddr()` | `getRemoteAddr()` is XFF-tainted under `framework`; `X-Real-IP` is nginx-owned and not client-injectable | Switching to `native` + Tomcat `RemoteIpValve` (bigger blast radius; only justified if forwarded Host/Proto/Port ever stop being needed) |
+| Bucket stores are Caffeine-backed (`expireAfterAccess(1h)`, `maximumSize(50_000)`) | Plain `ConcurrentHashMap` bucket maps never shrink; the key is attacker-controlled for the per-IP ones | Leaving them unbounded (memory-growth DoS) |
 
 ## Gotchas / Pitfalls
 
@@ -111,6 +161,14 @@ access_token=...; Max-Age=900; Path=/; HttpOnly; SameSite=Lax[; Secure]
   cross-origin request is still rejected.
 - `config/DynamicCorsConfigurationSourceTest` — origin resolution (DB → env fallback, empty CSV, non-API routes).
 - `config/SecureCookieProviderTest` — `Secure` flag resolution.
+- `config/ClientIpTest` — `X-Real-IP` preferred over a spoofed `X-Forwarded-For`; falls back to
+  `getRemoteAddr()` when `X-Real-IP` is absent, blank, multi-valued, oversized, or not a plain
+  IPv4/IPv6 literal; accepts well-formed literals at their boundaries (`0.0.0.0`, `255.255.255.255`,
+  `::1`, IPv4-mapped IPv6, ...).
+- `config/RateLimitConfigTest` — a bucket-store bean evicts back down to `maximumSize` after being
+  overfilled.
+- `controller/AuthControllerTest#login_ratelimitKey_isXRealIp_notSpoofableXForwardedFor` — two
+  calls with different spoofed `X-Forwarded-For` but the same `X-Real-IP` resolve to one bucket key.
 
 ## Links
 

--- a/docs/features/setup-wizard.md
+++ b/docs/features/setup-wizard.md
@@ -203,6 +203,12 @@ future work):
 - **Audit trail** in the `setup_audit` table for `setup.admin.created`,
   `setup.integration.enabled`, `setup.security.updated`, `setup.completed` — valuable
   forensics for a self-host admin who wants to know "who ran setup on this machine".
+- **Single-account seeding.** The wizard seeds exactly one account. `SetupService.seedAdmin`
+  rejects any call once one user already exists (`AppUserRepository.count() > 0`),
+  regardless of `setup.state` — so a second, differently-named `role=ADMIN` account can no
+  longer be planted through `POST /api/setup/admin` during the `IN_PROGRESS` window (after
+  the first admin is seeded but before `/api/setup/complete` is called). Further accounts
+  are created from the authenticated Family admin UI, never from the wizard.
 
 ## Running without Docker
 
@@ -230,8 +236,8 @@ The wizard makes zero outbound requests on first load:
 
 - `SetupServiceTest` — state transitions (`PENDING_ADMIN → IN_PROGRESS → COMPLETE`),
   SERIALIZABLE CAS on admin claim, bcrypt-hash rejection, idempotent seed when user
-  already exists, CSV origin persistence, empty-origin rejection, consistent
-  integration-key formatting.
+  already exists, rejection when any account already exists (second-admin backdoor),
+  CSV origin persistence, empty-origin rejection, consistent integration-key formatting.
 - `SetupControllerTest` — endpoint-level: admin seed returns 410 after completion,
   EB keypair regenerate-flag on first call vs. idempotent subsequent calls, EB
   `test` only flips the integration flag on success, BoursoBank health / TR / Finary


### PR DESCRIPTION
Four independent production-hardening fixes that came out of a security/quality audit of the codebase. Each one is a self-contained commit; none changes intended behavior for legitimate users.

## 1. `fix(setup)`: close the second-admin backdoor in `seedAdmin`

`POST /api/setup/admin` is unauthenticated until setup reaches `COMPLETE`. The existing CAS guard only protects the `PENDING_ADMIN → IN_PROGRESS` transition: once a legitimate operator has seeded the first admin but not yet called `/api/setup/complete` (abandoned wizard, multi-step setup), anyone who can reach the app could seed a **second, differently-named admin** that survives completion. The fix rejects seeding as soon as any user exists — additional members must go through the role-gated Family admin UI.

## 2. `fix(pnl)`: deterministic same-day transaction ordering

Realized P&L queries ordered transactions by `date` only, so several fills on the same day came back in arbitrary (physical/plan-dependent) order, which can change average-cost P&L results between runs. Ordering is now `(date, id)` everywhere the ledger is replayed.

## 3. `fix(security)` + `fix(ratelimit)`: trusted client IP + bounded bucket stores

- Rate-limit keys were derived from `getRemoteAddr()`, which is the reverse proxy's address behind nginx (all clients share one bucket → trivially DoS-able) and spoofable in direct-exposure setups. Keys now come from a single `ClientIp` resolver that only trusts `X-Real-IP` set by the bundled nginx config.
- The per-IP bucket maps grew without bound (one entry per source IP, kept forever — a slow memory leak an attacker can accelerate). All bucket stores are now Caffeine caches with size + idle-time eviction. Covered by a new `RateLimitConfigTest`.

## 4. `fix/perf(export)`: GDPR export — no secret leaks, bounded memory

- The no-secret-leak test now wires **all** exporters instead of a subset, so any future exporter that serializes an encrypted-credential entity fails the build instead of shipping.
- `BalanceSnapshotsExporter` streamed the entire snapshot history of every account into memory before writing; it now streams per account.

## Tests

Full backend suite on this branch: **655 tests, 0 failures, 0 errors, 9 skipped** (the skips are the Testcontainers/Docker-dependent migration tests, which skip themselves when Docker is unreachable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
