### PR TITLE
feat(sync): Interactive Brokers connector via the Flex Web Service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   end-of-day and maps them to accounts + holdings (one account per IBKR account id),
   valued live in EUR through the existing ticker/price path. Cost basis is converted
   to the account base currency via `fxRateToBase`; per-tax-lot rows are de-duplicated.
-  Daily auto-sync runs alongside the other connectors. Backend only for now — the
-  settings connection card is a follow-up. See
+  Daily auto-sync runs alongside the other connectors. A connection tab on the Sync
+  page (paste token + query id, then sync/disconnect) drives it, in all four locales. See
   [ADR](docs/decisions/2026-07-19-ibkr-flex-web-service.md) and
   [feature note](docs/features/ibkr-sync.md).
 - **BNB Chain support and EVM multichain wallets.** On-chain wallets gained an

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Interactive Brokers (IBKR) sync via the Flex Web Service.** Connect once with a
+  read-only Flex token + an "Open Positions" query id; Picsou pulls open positions
+  end-of-day and maps them to accounts + holdings (one account per IBKR account id),
+  valued live in EUR through the existing ticker/price path. Cost basis is converted
+  to the account base currency via `fxRateToBase`; per-tax-lot rows are de-duplicated.
+  Daily auto-sync runs alongside the other connectors. Backend only for now — the
+  settings connection card is a follow-up. See
+  [ADR](docs/decisions/2026-07-19-ibkr-flex-web-service.md) and
+  [feature note](docs/features/ibkr-sync.md).
 - **BNB Chain support and EVM multichain wallets.** On-chain wallets gained an
   `EVM` chain that tracks a single `0x` address across every enabled EVM network
   — Ethereum, BNB Chain, Polygon, Arbitrum, Optimism, Base and Avalanche —

--- a/backend/src/main/java/com/picsou/config/RateLimitConfig.java
+++ b/backend/src/main/java/com/picsou/config/RateLimitConfig.java
@@ -77,9 +77,10 @@ public class RateLimitConfig {
 
     /**
      * Per-IP IBKR Flex sync rate limiter: 6 requests per minute.
-     * IBKR itself rate-limits the Flex Web Service to roughly one request per second
-     * per token and a sync fans out into SendRequest + several GetStatement polls, so a
-     * handful of manual syncs per minute is the sane ceiling.
+     * IBKR itself enforces a separate per-token limit (~1 request/sec) on the Flex Web
+     * Service; this application-level per-IP cap is additive and defensive — it keeps one
+     * caller from burning the shared token's budget, while leaving room for the
+     * SendRequest + several GetStatement polls a single sync fans out into.
      */
     @Bean("ibkrSyncBuckets")
     public Map<String, Bucket> ibkrSyncBuckets() {

--- a/backend/src/main/java/com/picsou/config/RateLimitConfig.java
+++ b/backend/src/main/java/com/picsou/config/RateLimitConfig.java
@@ -83,7 +83,7 @@ public class RateLimitConfig {
      */
     @Bean("ibkrSyncBuckets")
     public Map<String, Bucket> ibkrSyncBuckets() {
-        return new ConcurrentHashMap<>();
+        return boundedBucketStore();
     }
 
     /**

--- a/backend/src/main/java/com/picsou/config/RateLimitConfig.java
+++ b/backend/src/main/java/com/picsou/config/RateLimitConfig.java
@@ -76,6 +76,17 @@ public class RateLimitConfig {
     }
 
     /**
+     * Per-IP IBKR Flex sync rate limiter: 6 requests per minute.
+     * IBKR itself rate-limits the Flex Web Service to roughly one request per second
+     * per token and a sync fans out into SendRequest + several GetStatement polls, so a
+     * handful of manual syncs per minute is the sane ceiling.
+     */
+    @Bean("ibkrSyncBuckets")
+    public Map<String, Bucket> ibkrSyncBuckets() {
+        return new ConcurrentHashMap<>();
+    }
+
+    /**
      * Per-IP setup wizard rate limiter: 10 mutating requests per minute.
      * Tight because the endpoints are unauthenticated until setup completes
      * — without this, a fresh install is exposed to admin-seeding floods
@@ -175,6 +186,15 @@ public class RateLimitConfig {
             .addLimit(Bandwidth.builder()
                 .capacity(5)
                 .refillIntervally(5, Duration.ofMinutes(15))
+                .build())
+            .build();
+    }
+
+    public static Bucket createIbkrSyncBucket() {
+        return Bucket.builder()
+            .addLimit(Bandwidth.builder()
+                .capacity(6)
+                .refillIntervally(6, Duration.ofMinutes(1))
                 .build())
             .build();
     }

--- a/backend/src/main/java/com/picsou/controller/IbkrController.java
+++ b/backend/src/main/java/com/picsou/controller/IbkrController.java
@@ -4,7 +4,7 @@ import com.picsou.config.RateLimitConfig;
 import com.picsou.dto.AccountResponse;
 import com.picsou.dto.IbkrConnectRequest;
 import com.picsou.dto.IbkrConnectionStatusResponse;
-import com.picsou.ibkr.IbkrSyncService;
+import com.picsou.service.IbkrSyncService;
 import com.picsou.service.UserContext;
 import io.github.bucket4j.Bucket;
 import jakarta.servlet.http.HttpServletRequest;

--- a/backend/src/main/java/com/picsou/controller/IbkrController.java
+++ b/backend/src/main/java/com/picsou/controller/IbkrController.java
@@ -9,6 +9,7 @@ import com.picsou.service.IbkrSyncService;
 import com.picsou.service.UserContext;
 import io.github.bucket4j.Bucket;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
@@ -45,7 +46,7 @@ public class IbkrController {
 
     /** Store (or replace) the Flex token + query id. Credentials are encrypted at rest. */
     @PostMapping("/connect")
-    public ResponseEntity<Void> connect(@RequestBody IbkrConnectRequest req) {
+    public ResponseEntity<Void> connect(@Valid @RequestBody IbkrConnectRequest req) {
         ibkrService.connect(req.token(), req.queryId(), userContext.currentMemberId());
         return ResponseEntity.noContent().build();
     }

--- a/backend/src/main/java/com/picsou/controller/IbkrController.java
+++ b/backend/src/main/java/com/picsou/controller/IbkrController.java
@@ -1,0 +1,82 @@
+package com.picsou.controller;
+
+import com.picsou.config.RateLimitConfig;
+import com.picsou.dto.AccountResponse;
+import com.picsou.dto.IbkrConnectRequest;
+import com.picsou.dto.IbkrConnectionStatusResponse;
+import com.picsou.ibkr.IbkrSyncService;
+import com.picsou.service.UserContext;
+import io.github.bucket4j.Bucket;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Interactive Brokers Flex Web Service endpoints (Open Positions sync).
+ *
+ * <p>Connect once with a read-only Flex token + query id; sync pulls the current
+ * open positions (end-of-day) into accounts + holdings. Mirrors
+ * {@link TradeRepublicController}'s shape: connect / status / sync / clear.
+ */
+@RestController
+@RequestMapping("/api/ibkr")
+public class IbkrController {
+
+    private final IbkrSyncService ibkrService;
+    private final UserContext userContext;
+    private final Map<String, Bucket> ibkrSyncBuckets;
+
+    public IbkrController(
+        IbkrSyncService ibkrService,
+        UserContext userContext,
+        @Qualifier("ibkrSyncBuckets") Map<String, Bucket> ibkrSyncBuckets
+    ) {
+        this.ibkrService = ibkrService;
+        this.userContext = userContext;
+        this.ibkrSyncBuckets = ibkrSyncBuckets;
+    }
+
+    /** Store (or replace) the Flex token + query id. Credentials are encrypted at rest. */
+    @PostMapping("/connect")
+    public ResponseEntity<Void> connect(@RequestBody IbkrConnectRequest req) {
+        ibkrService.connect(req.token(), req.queryId(), userContext.currentMemberId());
+        return ResponseEntity.noContent().build();
+    }
+
+    /** Connection status: connected?, last sync, masked token. */
+    @GetMapping("/status")
+    public IbkrConnectionStatusResponse getStatus() {
+        return ibkrService.getConnectionStatus(userContext.currentMemberId());
+    }
+
+    /** Manual sync using the stored connection. Rate-limited per IP. */
+    @PostMapping("/sync")
+    public ResponseEntity<?> sync(HttpServletRequest request) {
+        if (!checkSyncRateLimit(request)) {
+            ProblemDetail detail = ProblemDetail.forStatus(HttpStatus.TOO_MANY_REQUESTS);
+            detail.setDetail("Too many sync requests. Please wait a moment before trying again.");
+            return ResponseEntity.status(HttpStatus.TOO_MANY_REQUESTS).body(detail);
+        }
+        List<AccountResponse> accounts = ibkrService.sync(userContext.currentMemberId());
+        return ResponseEntity.ok(accounts);
+    }
+
+    /** Clear the stored connection (forces reconnect). */
+    @DeleteMapping("/connection")
+    public ResponseEntity<Void> clearConnection() {
+        ibkrService.deleteConnection(userContext.currentMemberId());
+        return ResponseEntity.noContent().build();
+    }
+
+    private boolean checkSyncRateLimit(HttpServletRequest request) {
+        String ip = request.getRemoteAddr();
+        Bucket bucket = ibkrSyncBuckets.computeIfAbsent(ip, k -> RateLimitConfig.createIbkrSyncBucket());
+        return bucket.tryConsume(1);
+    }
+}

--- a/backend/src/main/java/com/picsou/controller/IbkrController.java
+++ b/backend/src/main/java/com/picsou/controller/IbkrController.java
@@ -1,5 +1,6 @@
 package com.picsou.controller;
 
+import com.picsou.config.ClientIp;
 import com.picsou.config.RateLimitConfig;
 import com.picsou.dto.AccountResponse;
 import com.picsou.dto.IbkrConnectRequest;
@@ -75,7 +76,7 @@ public class IbkrController {
     }
 
     private boolean checkSyncRateLimit(HttpServletRequest request) {
-        String ip = request.getRemoteAddr();
+        String ip = ClientIp.resolve(request);
         Bucket bucket = ibkrSyncBuckets.computeIfAbsent(ip, k -> RateLimitConfig.createIbkrSyncBucket());
         return bucket.tryConsume(1);
     }

--- a/backend/src/main/java/com/picsou/dto/IbkrConnectRequest.java
+++ b/backend/src/main/java/com/picsou/dto/IbkrConnectRequest.java
@@ -1,9 +1,11 @@
 package com.picsou.dto;
 
+import jakarta.validation.constraints.NotBlank;
+
 /**
  * Request body for storing Interactive Brokers Flex Web Service credentials.
  *
  * @param token   Flex Web Service token generated in Client Portal (read-only, 6h–1y)
  * @param queryId id of the pre-built "Open Positions" Flex Query
  */
-public record IbkrConnectRequest(String token, String queryId) {}
+public record IbkrConnectRequest(@NotBlank String token, @NotBlank String queryId) {}

--- a/backend/src/main/java/com/picsou/dto/IbkrConnectRequest.java
+++ b/backend/src/main/java/com/picsou/dto/IbkrConnectRequest.java
@@ -1,0 +1,9 @@
+package com.picsou.dto;
+
+/**
+ * Request body for storing Interactive Brokers Flex Web Service credentials.
+ *
+ * @param token   Flex Web Service token generated in Client Portal (read-only, 6h–1y)
+ * @param queryId id of the pre-built "Open Positions" Flex Query
+ */
+public record IbkrConnectRequest(String token, String queryId) {}

--- a/backend/src/main/java/com/picsou/dto/IbkrConnectionStatusResponse.java
+++ b/backend/src/main/java/com/picsou/dto/IbkrConnectionStatusResponse.java
@@ -1,0 +1,20 @@
+package com.picsou.dto;
+
+import java.time.Instant;
+
+/**
+ * Interactive Brokers connection status for the settings UI.
+ *
+ * @param connected     whether a connection is stored for the member
+ * @param connectionId  row id (null when not connected)
+ * @param status        "CONNECTED" or "ERROR" (last sync outcome)
+ * @param lastSyncedAt  last successful sync, null if never
+ * @param maskedToken   token with only the last 4 chars visible, null when not connected
+ */
+public record IbkrConnectionStatusResponse(
+    boolean connected,
+    Long connectionId,
+    String status,
+    Instant lastSyncedAt,
+    String maskedToken
+) {}

--- a/backend/src/main/java/com/picsou/ibkr/IbkrSyncService.java
+++ b/backend/src/main/java/com/picsou/ibkr/IbkrSyncService.java
@@ -1,0 +1,302 @@
+package com.picsou.ibkr;
+
+import com.picsou.adapter.OpenFigiIsinConverter;
+import com.picsou.adapter.OpenFigiIsinConverter.TickerResult;
+import com.picsou.config.CryptoEncryption;
+import com.picsou.dto.AccountResponse;
+import com.picsou.dto.IbkrConnectionStatusResponse;
+import com.picsou.exception.ResourceNotFoundException;
+import com.picsou.exception.SyncException;
+import com.picsou.model.Account;
+import com.picsou.model.AccountHolding;
+import com.picsou.model.AccountType;
+import com.picsou.model.FamilyMember;
+import com.picsou.model.IbkrConnection;
+import com.picsou.port.IbkrFlexPort;
+import com.picsou.port.IbkrFlexPort.IbkrAccountData;
+import com.picsou.port.IbkrFlexPort.IbkrPosition;
+import com.picsou.repository.AccountHoldingRepository;
+import com.picsou.repository.AccountRepository;
+import com.picsou.repository.FamilyMemberRepository;
+import com.picsou.repository.IbkrConnectionRepository;
+import com.picsou.service.AccountService;
+import com.picsou.service.HoldingDedup;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Orchestrates Interactive Brokers sync: stores the encrypted Flex credentials,
+ * pulls Open Positions once a day and maps them onto Picsou accounts + holdings.
+ *
+ * <p>Mirrors {@code TradeRepublicSyncService}'s broker→holdings pattern (delete +
+ * recompute, VWAP de-dup, ISIN→ticker via {@link OpenFigiIsinConverter}). The one
+ * IBKR-specific twist is currency: IBKR reports cost basis in each security's native
+ * currency, so {@code averageBuyIn} is converted to the account's base currency via
+ * {@code fxRateToBase}. Net worth itself never depends on that conversion — it is
+ * recomputed live in EUR from tickers by {@code AccountService.liveBalanceEur}
+ * (Yahoo/CoinGecko, FX-converted), exactly like every other holdings account.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@Transactional
+public class IbkrSyncService {
+
+    private final IbkrFlexPort ibkrFlexPort;
+    private final IbkrConnectionRepository connectionRepository;
+    private final AccountRepository accountRepository;
+    private final AccountHoldingRepository holdingRepository;
+    private final FamilyMemberRepository familyMemberRepository;
+    private final AccountService accountService;
+    private final OpenFigiIsinConverter isinConverter;
+    private final CryptoEncryption encryption;
+
+    // ---------------------------------------------------------------------------
+    // Connection management
+    // ---------------------------------------------------------------------------
+
+    /** Stores (or replaces) the encrypted Flex token + query id for a member. */
+    public void connect(String token, String queryId, Long memberId) {
+        if (token == null || token.isBlank() || queryId == null || queryId.isBlank()) {
+            throw new IllegalArgumentException("Both the Flex token and the query id are required.");
+        }
+        FamilyMember member = familyMemberRepository.findById(memberId)
+            .orElseThrow(() -> new ResourceNotFoundException("Family member not found"));
+
+        IbkrConnection connection = connectionRepository.findByMemberId(memberId)
+            .orElseGet(() -> IbkrConnection.builder().member(member).build());
+        connection.setToken(encryption.encrypt(token.trim()));
+        connection.setQueryId(encryption.encrypt(queryId.trim()));
+        connection.setStatus("CONNECTED");
+        connectionRepository.save(connection);
+        log.info("IBKR Flex credentials stored for member {}", memberId);
+    }
+
+    @Transactional(readOnly = true)
+    public IbkrConnectionStatusResponse getConnectionStatus(Long memberId) {
+        Optional<IbkrConnection> connection = connectionRepository.findByMemberId(memberId);
+        if (connection.isEmpty()) {
+            return new IbkrConnectionStatusResponse(false, null, null, null, null);
+        }
+        IbkrConnection c = connection.get();
+        String maskedToken = maskToken(encryption.decrypt(c.getToken()));
+        return new IbkrConnectionStatusResponse(true, c.getId(), c.getStatus(), c.getLastSyncedAt(), maskedToken);
+    }
+
+    public void deleteConnection(Long memberId) {
+        connectionRepository.findByMemberId(memberId).ifPresent(connectionRepository::delete);
+        log.info("IBKR connection cleared for member {}", memberId);
+    }
+
+    // ---------------------------------------------------------------------------
+    // Sync
+    // ---------------------------------------------------------------------------
+
+    /** Manual or scheduled sync using the stored connection. */
+    public List<AccountResponse> sync(Long memberId) {
+        IbkrConnection connection = connectionRepository.findByMemberId(memberId)
+            .orElseThrow(() -> new SyncException(
+                "No Interactive Brokers connection. Please connect from the Interactive Brokers page."));
+        return syncWithConnection(connection, memberId);
+    }
+
+    /** Scheduler entry point — no-op if the member has no connection. */
+    public void resyncIfConnected(Long memberId) {
+        Optional<IbkrConnection> connection = connectionRepository.findByMemberId(memberId);
+        if (connection.isEmpty()) {
+            return;
+        }
+        try {
+            syncWithConnection(connection.get(), memberId);
+        } catch (Exception ex) {
+            log.warn("IBKR auto-sync failed for member {}: {}", memberId, ex.getMessage());
+        }
+    }
+
+    private List<AccountResponse> syncWithConnection(IbkrConnection connection, Long memberId) {
+        String token = encryption.decrypt(connection.getToken());
+        String queryId = encryption.decrypt(connection.getQueryId());
+
+        List<IbkrAccountData> accounts;
+        try {
+            accounts = ibkrFlexPort.fetchOpenPositions(token, queryId);
+        } catch (RuntimeException ex) {
+            connection.setStatus("ERROR");
+            connectionRepository.save(connection);
+            throw ex;
+        }
+
+        List<AccountResponse> responses = accounts.stream()
+            .map(data -> upsertAccount(data, memberId))
+            .flatMap(Optional::stream)
+            .toList();
+
+        connection.setStatus("CONNECTED");
+        connection.setLastSyncedAt(Instant.now());
+        connectionRepository.save(connection);
+
+        log.info("IBKR sync complete for member {}: {} account(s) updated", memberId, responses.size());
+        return responses;
+    }
+
+    // ---------------------------------------------------------------------------
+    // Mapping
+    // ---------------------------------------------------------------------------
+
+    private Optional<AccountResponse> upsertAccount(IbkrAccountData data, Long memberId) {
+        String externalId = "ibkr_" + data.accountId();
+
+        Optional<Account> existing = accountRepository.findByExternalAccountIdAndMemberId(externalId, memberId);
+        if (existing.isEmpty()
+            && accountRepository.existsSoftDeletedByExternalAccountIdAndMemberId(externalId, memberId)) {
+            log.info("IBKR: skipping resurrection of soft-deleted account {} for member {}", externalId, memberId);
+            return Optional.empty();
+        }
+
+        Account account;
+        if (existing.isPresent()) {
+            account = existing.get();
+            account.setLastSyncedAt(Instant.now());
+        } else {
+            FamilyMember member = familyMemberRepository.findById(memberId)
+                .orElseThrow(() -> new ResourceNotFoundException("Family member not found"));
+            account = Account.builder()
+                .member(member)
+                .name("IBKR " + data.accountId())
+                .type(AccountType.COMPTE_TITRES)
+                .provider("Interactive Brokers")
+                .currency("EUR")
+                .currentBalance(BigDecimal.ZERO)
+                .lastSyncedAt(Instant.now())
+                .externalAccountId(externalId)
+                .isManual(false)
+                .color("#d81222") // IBKR red
+                .build();
+        }
+        account = accountRepository.save(account);
+
+        // Replace holdings wholesale — the statement is the full current picture.
+        holdingRepository.deleteByAccountId(account.getId());
+        holdingRepository.flush();
+
+        // De-dup by resolved ticker (VWAP) exactly like Trade Republic: several IBKR
+        // positions (or lot rows across accounts) can map to one ticker.
+        Map<String, HoldingDedup.HoldingAgg> deduped = new HashMap<>();
+        for (IbkrPosition p : data.positions()) {
+            if (!isReportable(p)) {
+                continue;
+            }
+            TickerResult resolved = resolveTicker(p);
+            if (resolved.ticker() == null || resolved.ticker().isBlank()) {
+                continue;
+            }
+            deduped.merge(
+                resolved.ticker(),
+                new HoldingDedup.HoldingAgg(p.position(), eurCostBasis(p), eurMark(p), resolved.name()),
+                HoldingDedup::vwapMerge);
+        }
+        for (Map.Entry<String, HoldingDedup.HoldingAgg> entry : deduped.entrySet()) {
+            HoldingDedup.HoldingAgg agg = entry.getValue();
+            holdingRepository.save(AccountHolding.builder()
+                .account(account)
+                .ticker(entry.getKey())
+                .name(agg.name())
+                .quantity(agg.quantity())
+                .averageBuyIn(agg.averageBuyIn())
+                .currentPrice(agg.currentPrice())
+                .lastSyncedAt(Instant.now())
+                .build());
+        }
+        holdingRepository.flush();
+
+        // Net-worth-critical figures use the trusted live-EUR path (Yahoo/CoinGecko,
+        // FX-converted), never IBKR's base currency — so net worth is right even if the
+        // user's IBKR base currency is not EUR.
+        BigDecimal liveEur = accountService.liveBalanceEur(account);
+        account.setCurrentBalance(liveEur);
+        account = accountRepository.save(account);
+        accountService.upsertSnapshot(account, liveEur, LocalDate.now());
+
+        return Optional.of(accountService.toResponse(account));
+    }
+
+    /**
+     * Whether a position should become a holding: non-zero quantity, summary-level
+     * (not a per-lot duplicate) and not a cash line. A ticker source (ISIN or symbol)
+     * is required so we never persist a nameless holding.
+     */
+    private boolean isReportable(IbkrPosition p) {
+        if (p.position() == null || p.position().signum() == 0) {
+            return false;
+        }
+        // Flex can emit both a SUMMARY row and per-tax-lot ("LOT") rows when lots are
+        // enabled on the query. Keep summary/absent, drop LOT, to avoid double counting.
+        if (p.levelOfDetail() != null && "LOT".equalsIgnoreCase(p.levelOfDetail())) {
+            return false;
+        }
+        if (p.assetCategory() != null && "CASH".equalsIgnoreCase(p.assetCategory())) {
+            return false;
+        }
+        return (p.isin() != null && !p.isin().isBlank()) || (p.symbol() != null && !p.symbol().isBlank());
+    }
+
+    /**
+     * Resolves an IBKR position to a price-able ticker + display name. Prefers the
+     * ISIN (via OpenFIGI) so the holding prices through Yahoo/CoinGecko; falls back to
+     * the IBKR symbol + description when there is no usable ISIN (e.g. some derivatives).
+     */
+    private TickerResult resolveTicker(IbkrPosition p) {
+        if (p.isin() != null && OpenFigiIsinConverter.isIsin(p.isin())) {
+            TickerResult result = isinConverter.resolve(p.isin());
+            // OpenFIGI may return the ISIN unchanged (miss) and a null name — fall back
+            // to the IBKR symbol/description, which at least price-resolves for US tickers.
+            if (result.ticker() != null && !OpenFigiIsinConverter.isIsin(result.ticker())) {
+                return result;
+            }
+            String ticker = p.symbol() != null ? p.symbol() : result.ticker();
+            String name = result.name() != null ? result.name() : p.description();
+            return new TickerResult(ticker, name);
+        }
+        return new TickerResult(p.symbol(), p.description());
+    }
+
+    /** Cost basis per unit in the account base currency (≈EUR). Null when unknown. */
+    private BigDecimal eurCostBasis(IbkrPosition p) {
+        if (p.costBasisPrice() == null) {
+            return null;
+        }
+        BigDecimal rate = p.fxRateToBase() != null ? p.fxRateToBase() : BigDecimal.ONE;
+        return p.costBasisPrice().multiply(rate);
+    }
+
+    /**
+     * Mark price per unit in the account base currency (≈EUR). Informational only:
+     * the stored {@code currentPrice} is never trusted for EUR valuation — the
+     * dashboard recomputes live from the ticker (see {@code AccountService}).
+     */
+    private BigDecimal eurMark(IbkrPosition p) {
+        if (p.markPrice() == null) {
+            return null;
+        }
+        BigDecimal rate = p.fxRateToBase() != null ? p.fxRateToBase() : BigDecimal.ONE;
+        return p.markPrice().multiply(rate);
+    }
+
+    /** Shows only the last 4 characters of the token, e.g. "••••••3F29". */
+    private String maskToken(String token) {
+        if (token == null || token.length() <= 4) {
+            return "••••";
+        }
+        return "••••••" + token.substring(token.length() - 4);
+    }
+}

--- a/backend/src/main/java/com/picsou/ibkr/client/IbkrFlexClient.java
+++ b/backend/src/main/java/com/picsou/ibkr/client/IbkrFlexClient.java
@@ -140,6 +140,8 @@ public class IbkrFlexClient implements IbkrFlexPort {
         if (message == null) {
             return false;
         }
+        // Deliberately broad substring matching ("generat" covers "generating"/"generation"):
+        // forward compatibility with rewordings of the transient not-ready message.
         String lower = message.toLowerCase();
         return lower.contains("in progress") || lower.contains("try again") || lower.contains("generat");
     }

--- a/backend/src/main/java/com/picsou/ibkr/client/IbkrFlexClient.java
+++ b/backend/src/main/java/com/picsou/ibkr/client/IbkrFlexClient.java
@@ -22,6 +22,7 @@ import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -168,6 +169,11 @@ public class IbkrFlexClient implements IbkrFlexPort {
         Document doc = parse(xml);
         NodeList positions = doc.getElementsByTagName("OpenPosition");
 
+        // Account base currency, keyed by accountId -- from the optional
+        // AccountInformation section (enabled per Flex Query, sibling of OpenPositions
+        // under FlexStatement). Absent entirely on statements that don't enable it.
+        Map<String, String> baseCurrencyByAccount = parseAccountInformation(doc);
+
         // LinkedHashMap: stable account ordering for deterministic downstream upserts.
         Map<String, List<IbkrPosition>> byAccount = new LinkedHashMap<>();
         for (int i = 0; i < positions.getLength(); i++) {
@@ -196,10 +202,36 @@ public class IbkrFlexClient implements IbkrFlexPort {
 
         List<IbkrAccountData> result = new ArrayList<>();
         for (Map.Entry<String, List<IbkrPosition>> entry : byAccount.entrySet()) {
-            result.add(new IbkrAccountData(entry.getKey(), entry.getValue()));
+            String accountId = entry.getKey();
+            result.add(new IbkrAccountData(accountId, entry.getValue(), baseCurrencyByAccount.get(accountId)));
         }
         log.info("IBKR Flex parsed {} open positions across {} account(s)",
             positions.getLength(), result.size());
+        return result;
+    }
+
+    /**
+     * Parses the optional {@code <AccountInformation accountId="..." currency="..." />}
+     * element(s) into an accountId → base-currency map. This section only appears when
+     * "Account Information" is enabled on the Flex Query; a statement without it (or
+     * without a usable {@code accountId}/{@code currency} pair) yields an empty map, and
+     * callers fall back to their pre-base-currency-detection behavior.
+     */
+    private Map<String, String> parseAccountInformation(Document doc) {
+        Map<String, String> result = new HashMap<>();
+        NodeList infos = doc.getElementsByTagName("AccountInformation");
+        for (int i = 0; i < infos.getLength(); i++) {
+            Node node = infos.item(i);
+            if (node.getNodeType() != Node.ELEMENT_NODE) {
+                continue;
+            }
+            Element el = (Element) node;
+            String accountId = blankToNull(attr(el, "accountId"));
+            String currency = blankToNull(attr(el, "currency"));
+            if (accountId != null && currency != null) {
+                result.put(accountId, currency);
+            }
+        }
         return result;
     }
 

--- a/backend/src/main/java/com/picsou/ibkr/client/IbkrFlexClient.java
+++ b/backend/src/main/java/com/picsou/ibkr/client/IbkrFlexClient.java
@@ -194,9 +194,19 @@ public class IbkrFlexClient implements IbkrFlexPort {
                 continue;
             }
             String stmtAccount = blankToNull(attr((Element) node, "accountId"));
-            if (stmtAccount != null) {
-                byAccount.computeIfAbsent(stmtAccount, k -> new ArrayList<>());
+            if (stmtAccount == null) {
+                continue;
             }
+            if (byAccount.containsKey(stmtAccount)) {
+                // Several FlexStatement sections for the SAME account = a multi-day query
+                // ("Breakout by Day" / date-ranged period): each day carries a full
+                // positions snapshot, and merging them would silently multiply every
+                // quantity by the number of days. Fail with the remedy instead.
+                throw new SyncException("The Flex statement contains several sections for account "
+                    + stmtAccount + " — set the Flex Query period to 'Last Business Day' "
+                    + "(and disable any day-by-day breakout) so positions are a single snapshot.");
+            }
+            byAccount.put(stmtAccount, new ArrayList<>());
         }
 
         for (int i = 0; i < positions.getLength(); i++) {

--- a/backend/src/main/java/com/picsou/ibkr/client/IbkrFlexClient.java
+++ b/backend/src/main/java/com/picsou/ibkr/client/IbkrFlexClient.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 /**
@@ -142,7 +143,7 @@ public class IbkrFlexClient implements IbkrFlexPort {
         }
         // Deliberately broad substring matching ("generat" covers "generating"/"generation"):
         // forward compatibility with rewordings of the transient not-ready message.
-        String lower = message.toLowerCase();
+        String lower = message.toLowerCase(Locale.ROOT);
         return lower.contains("in progress") || lower.contains("try again") || lower.contains("generat");
     }
 
@@ -254,7 +255,13 @@ public class IbkrFlexClient implements IbkrFlexPort {
                 throw new SyncException("Interactive Brokers returned HTTP " + response.statusCode()
                     + ". Please check your token and try again.");
             }
-            return response.body();
+            String body = response.body();
+            // BodyHandlers.ofString() never yields null, but an empty 200 body would only
+            // fail later in parse() with a misleading "non-XML response" — fail clearly here.
+            if (body == null || body.isBlank()) {
+                throw new SyncException("Interactive Brokers returned an empty response. Please try again.");
+            }
+            return body;
         } catch (SyncException e) {
             throw e;
         } catch (java.io.IOException e) {
@@ -281,7 +288,10 @@ public class IbkrFlexClient implements IbkrFlexPort {
             return doc;
         } catch (Exception e) {
             // A non-XML body usually means an HTML error page or a network interception.
-            log.error("Failed to parse IBKR Flex response as XML: {}",
+            // Deliberately truncated: a real statement carries the user's positions, and
+            // full payloads do not belong in server logs — the length tells the rest.
+            log.error("Failed to parse IBKR Flex response as XML ({} chars, first 300 shown): {}",
+                xml == null ? 0 : xml.length(),
                 xml == null ? "null" : xml.substring(0, Math.min(300, xml.length())));
             throw new SyncException("Interactive Brokers returned an unexpected (non-XML) response.", e);
         }

--- a/backend/src/main/java/com/picsou/ibkr/client/IbkrFlexClient.java
+++ b/backend/src/main/java/com/picsou/ibkr/client/IbkrFlexClient.java
@@ -9,9 +9,12 @@ import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
+import org.xml.sax.SAXException;
+
 import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
 import java.io.ByteArrayInputStream;
 import java.math.BigDecimal;
 import java.net.URI;
@@ -178,7 +181,24 @@ public class IbkrFlexClient implements IbkrFlexPort {
         Map<String, String> baseCurrencyByAccount = parseAccountInformation(doc);
 
         // LinkedHashMap: stable account ordering for deterministic downstream upserts.
+        // Accounts are seeded from the <FlexStatement accountId="..."> elements, which are
+        // present even when the account holds no open position (fully liquidated
+        // portfolio). Deriving accounts from <OpenPosition> rows alone made an emptied
+        // account vanish from the result, so its stale holdings were never purged and the
+        // dashboard kept valuing positions the user no longer owns.
         Map<String, List<IbkrPosition>> byAccount = new LinkedHashMap<>();
+        NodeList statements = doc.getElementsByTagName("FlexStatement");
+        for (int i = 0; i < statements.getLength(); i++) {
+            Node node = statements.item(i);
+            if (node.getNodeType() != Node.ELEMENT_NODE) {
+                continue;
+            }
+            String stmtAccount = blankToNull(attr((Element) node, "accountId"));
+            if (stmtAccount != null) {
+                byAccount.computeIfAbsent(stmtAccount, k -> new ArrayList<>());
+            }
+        }
+
         for (int i = 0; i < positions.getLength(); i++) {
             Node node = positions.item(i);
             if (node.getNodeType() != Node.ELEMENT_NODE) {
@@ -286,7 +306,10 @@ public class IbkrFlexClient implements IbkrFlexPort {
             Document doc = builder.parse(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)));
             doc.getDocumentElement().normalize();
             return doc;
-        } catch (Exception e) {
+        } catch (ParserConfigurationException | SAXException | java.io.IOException e) {
+            // Narrow on purpose: only genuine parse/IO failures become the user-facing
+            // "unexpected response" — a programming error (NPE, class cast) must surface
+            // as itself, not masquerade as an IBKR API change.
             // A non-XML body usually means an HTML error page or a network interception.
             // Deliberately truncated: a real statement carries the user's positions, and
             // full payloads do not belong in server logs — the length tells the rest.

--- a/backend/src/main/java/com/picsou/ibkr/client/IbkrFlexClient.java
+++ b/backend/src/main/java/com/picsou/ibkr/client/IbkrFlexClient.java
@@ -1,0 +1,300 @@
+package com.picsou.ibkr.client;
+
+import com.picsou.exception.SyncException;
+import com.picsou.port.IbkrFlexPort;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import java.io.ByteArrayInputStream;
+import java.math.BigDecimal;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Interactive Brokers Flex Web Service client (Open Positions).
+ *
+ * <p>Implements the two-step Flex flow with the JDK's own {@link HttpClient} and DOM
+ * parser — no new dependency, mirroring {@code FinaryApiClient}'s use of raw
+ * {@code HttpClient}:
+ * <ol>
+ *   <li>{@code GET /SendRequest?t=<token>&q=<queryId>&v=3} → {@code <FlexStatementResponse>}
+ *       with {@code <Status>Success</Status>} and a {@code <ReferenceCode>};</li>
+ *   <li>{@code GET /GetStatement?t=<token>&q=<referenceCode>&v=3} → either the
+ *       {@code <FlexQueryResponse>} payload, or a {@code <FlexStatementResponse>} whose
+ *       status says generation is still in progress (poll again), or an error.</li>
+ * </ol>
+ *
+ * <p>IBKR rate-limits Flex requests to roughly one per second per token and only
+ * refreshes Activity-statement data once a day, so bounded polling with backoff is
+ * sufficient and deliberate.
+ */
+@Component
+@Slf4j
+public class IbkrFlexClient implements IbkrFlexPort {
+
+    private static final String BASE_URL =
+        "https://ndcdyn.interactivebrokers.com/AccountManagement/FlexWebService";
+    private static final String VERSION = "3";
+    private static final Duration TIMEOUT = Duration.ofSeconds(30);
+
+    /** How many times to poll GetStatement while IBKR is still generating the report. */
+    private static final int MAX_POLLS = 8;
+    /** Base wait between polls; IBKR needs a few seconds and rate-limits to ~1 req/s. */
+    private static final Duration POLL_INTERVAL = Duration.ofSeconds(3);
+
+    private final HttpClient httpClient = HttpClient.newBuilder()
+        .connectTimeout(TIMEOUT)
+        .build();
+
+    @Override
+    public List<IbkrAccountData> fetchOpenPositions(String token, String queryId) {
+        String referenceCode = sendRequest(token, queryId);
+        String statementXml = pollStatement(token, referenceCode);
+        return parseOpenPositions(statementXml);
+    }
+
+    // ---------------------------------------------------------------------------
+    // Step 1: SendRequest → reference code
+    // ---------------------------------------------------------------------------
+
+    private String sendRequest(String token, String queryId) {
+        String url = BASE_URL + "/SendRequest?t=" + enc(token) + "&q=" + enc(queryId) + "&v=" + VERSION;
+        Document doc = parse(get(url));
+        String root = doc.getDocumentElement().getNodeName();
+
+        // A well-formed SendRequest reply is always a FlexStatementResponse.
+        String status = childText(doc.getDocumentElement(), "Status");
+        if ("Success".equalsIgnoreCase(status)) {
+            String referenceCode = childText(doc.getDocumentElement(), "ReferenceCode");
+            if (referenceCode == null || referenceCode.isBlank()) {
+                throw new SyncException("IBKR did not return a reference code. Check your token and query id.");
+            }
+            log.info("IBKR Flex SendRequest OK, reference code {}", referenceCode);
+            return referenceCode;
+        }
+        throw failFromError(doc.getDocumentElement(),
+            "IBKR rejected the Flex request (root=" + root + ", status=" + status + ")");
+    }
+
+    // ---------------------------------------------------------------------------
+    // Step 2: GetStatement (poll until ready) → statement XML
+    // ---------------------------------------------------------------------------
+
+    private String pollStatement(String token, String referenceCode) {
+        String url = BASE_URL + "/GetStatement?t=" + enc(token) + "&q=" + enc(referenceCode) + "&v=" + VERSION;
+
+        for (int attempt = 0; attempt < MAX_POLLS; attempt++) {
+            String body = get(url);
+            Document doc = parse(body);
+            String root = doc.getDocumentElement().getNodeName();
+
+            // Ready: the payload is a FlexQueryResponse.
+            if ("FlexQueryResponse".equals(root)) {
+                return body;
+            }
+
+            // Otherwise it is a FlexStatementResponse — either "still generating" (poll again)
+            // or a hard error (token expired, invalid query, ...).
+            String status = childText(doc.getDocumentElement(), "Status");
+            if (isGenerationInProgress(doc.getDocumentElement())) {
+                log.info("IBKR statement not ready yet (attempt {}/{}), waiting {}s",
+                    attempt + 1, MAX_POLLS, POLL_INTERVAL.toSeconds());
+                sleep(POLL_INTERVAL.multipliedBy(1L + attempt / 2)); // gentle backoff
+                continue;
+            }
+            throw failFromError(doc.getDocumentElement(),
+                "IBKR could not deliver the statement (root=" + root + ", status=" + status + ")");
+        }
+        throw new SyncException("IBKR statement was still generating after "
+            + MAX_POLLS + " attempts. Please try again in a minute.");
+    }
+
+    /**
+     * True when a FlexStatementResponse says the report is still being generated.
+     * IBKR signals this with error code 1019, but we also match the message text so a
+     * change in the numeric code does not turn a transient "not ready" into a hard failure.
+     */
+    private boolean isGenerationInProgress(Element root) {
+        String code = childText(root, "ErrorCode");
+        if ("1019".equals(code)) {
+            return true;
+        }
+        String message = childText(root, "ErrorMessage");
+        if (message == null) {
+            return false;
+        }
+        String lower = message.toLowerCase();
+        return lower.contains("in progress") || lower.contains("try again") || lower.contains("generat");
+    }
+
+    private SyncException failFromError(Element root, String context) {
+        String code = childText(root, "ErrorCode");
+        String message = childText(root, "ErrorMessage");
+        String detail = message != null ? message : context;
+        log.error("IBKR Flex error (code={}, message={})", code, message);
+        // Surface IBKR's own message — it is descriptive (expired token, invalid query id, ...).
+        return new SyncException("Interactive Brokers: " + detail
+            + (code != null ? " (code " + code + ")" : ""));
+    }
+
+    // ---------------------------------------------------------------------------
+    // Parsing
+    // ---------------------------------------------------------------------------
+
+    /**
+     * Parses {@code <OpenPosition>} rows out of a FlexQueryResponse, grouped by
+     * IBKR account id, preserving document order within each account.
+     */
+    // Package-private so IbkrFlexClientTest can exercise the parser directly against a
+    // fixture, without any HTTP. This is the single riskiest part (exact IBKR attribute
+    // names), so it is the part most worth a fixture test.
+    List<IbkrAccountData> parseOpenPositions(String xml) {
+        Document doc = parse(xml);
+        NodeList positions = doc.getElementsByTagName("OpenPosition");
+
+        // LinkedHashMap: stable account ordering for deterministic downstream upserts.
+        Map<String, List<IbkrPosition>> byAccount = new LinkedHashMap<>();
+        for (int i = 0; i < positions.getLength(); i++) {
+            Node node = positions.item(i);
+            if (node.getNodeType() != Node.ELEMENT_NODE) {
+                continue;
+            }
+            Element el = (Element) node;
+            String accountId = attr(el, "accountId");
+            IbkrPosition position = new IbkrPosition(
+                accountId,
+                blankToNull(attr(el, "isin")),
+                blankToNull(attr(el, "symbol")),
+                blankToNull(attr(el, "description")),
+                blankToNull(attr(el, "currency")),
+                blankToNull(attr(el, "assetCategory")),
+                blankToNull(attr(el, "levelOfDetail")),
+                decimal(el, "position"),
+                decimal(el, "markPrice"),
+                decimal(el, "costBasisPrice"),
+                decimal(el, "fxRateToBase")
+            );
+            byAccount.computeIfAbsent(accountId == null ? "" : accountId, k -> new ArrayList<>())
+                .add(position);
+        }
+
+        List<IbkrAccountData> result = new ArrayList<>();
+        for (Map.Entry<String, List<IbkrPosition>> entry : byAccount.entrySet()) {
+            result.add(new IbkrAccountData(entry.getKey(), entry.getValue()));
+        }
+        log.info("IBKR Flex parsed {} open positions across {} account(s)",
+            positions.getLength(), result.size());
+        return result;
+    }
+
+    // ---------------------------------------------------------------------------
+    // HTTP + XML helpers
+    // ---------------------------------------------------------------------------
+
+    private String get(String url) {
+        try {
+            HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(url))
+                .timeout(TIMEOUT)
+                .header("User-Agent", "picsou-finance")
+                .GET()
+                .build();
+            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+            if (response.statusCode() >= 400) {
+                throw new SyncException("Interactive Brokers returned HTTP " + response.statusCode()
+                    + ". Please check your token and try again.");
+            }
+            return response.body();
+        } catch (SyncException e) {
+            throw e;
+        } catch (java.io.IOException e) {
+            throw new SyncException("Unable to reach Interactive Brokers: " + e.getMessage(), e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new SyncException("IBKR request interrupted", e);
+        }
+    }
+
+    /** Parses XML with external entities disabled (XXE-safe), since the payload is remote. */
+    private Document parse(String xml) {
+        try {
+            DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+            factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+            factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+            factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+            factory.setXIncludeAware(false);
+            factory.setExpandEntityReferences(false);
+            DocumentBuilder builder = factory.newDocumentBuilder();
+            Document doc = builder.parse(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)));
+            doc.getDocumentElement().normalize();
+            return doc;
+        } catch (Exception e) {
+            // A non-XML body usually means an HTML error page or a network interception.
+            log.error("Failed to parse IBKR Flex response as XML: {}",
+                xml == null ? "null" : xml.substring(0, Math.min(300, xml.length())));
+            throw new SyncException("Interactive Brokers returned an unexpected (non-XML) response.", e);
+        }
+    }
+
+    /** First direct/descendant child element text with the given tag, or null. */
+    private String childText(Element parent, String tag) {
+        NodeList list = parent.getElementsByTagName(tag);
+        if (list.getLength() == 0) {
+            return null;
+        }
+        String text = list.item(0).getTextContent();
+        return text == null ? null : text.trim();
+    }
+
+    private String attr(Element el, String name) {
+        return el.hasAttribute(name) ? el.getAttribute(name).trim() : null;
+    }
+
+    /** Parses a numeric attribute; null/blank/unparseable → null (never throws). */
+    private BigDecimal decimal(Element el, String name) {
+        String raw = attr(el, name);
+        if (raw == null || raw.isBlank()) {
+            return null;
+        }
+        try {
+            return new BigDecimal(raw);
+        } catch (NumberFormatException e) {
+            log.warn("IBKR position: non-numeric {}='{}', treating as null", name, raw);
+            return null;
+        }
+    }
+
+    private static String blankToNull(String s) {
+        return (s == null || s.isBlank()) ? null : s;
+    }
+
+    private static String enc(String s) {
+        return URLEncoder.encode(s == null ? "" : s, StandardCharsets.UTF_8);
+    }
+
+    private void sleep(Duration duration) {
+        try {
+            Thread.sleep(duration.toMillis());
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new SyncException("IBKR polling interrupted", e);
+        }
+    }
+}

--- a/backend/src/main/java/com/picsou/model/IbkrConnection.java
+++ b/backend/src/main/java/com/picsou/model/IbkrConnection.java
@@ -1,0 +1,50 @@
+package com.picsou.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.Instant;
+
+/**
+ * Per-member Interactive Brokers Flex Web Service connection.
+ *
+ * <p>Holds the encrypted Flex token and query id used to pull Open Positions once
+ * a day. Structurally identical to {@link FinarySession} / {@link BoursoSession}:
+ * a single row per {@link FamilyMember}, credentials encrypted at rest by
+ * {@code CryptoEncryption}. No account balances live here — those become
+ * {@link Account} + {@link AccountHolding} rows at sync time.
+ */
+@Entity
+@Table(name = "ibkr_connection")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class IbkrConnection extends AuditableEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @JsonIgnore
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "member_id", nullable = false)
+    private FamilyMember member;
+
+    /** Flex Web Service token, AES-256-GCM encrypted. */
+    @Column(nullable = false, length = 500)
+    private String token;
+
+    /** Flex Query id, AES-256-GCM encrypted. */
+    @Column(name = "query_id", nullable = false, length = 500)
+    private String queryId;
+
+    @Column(nullable = false, length = 20)
+    @Builder.Default
+    private String status = "CONNECTED";
+
+    @Column(name = "last_synced_at")
+    private Instant lastSyncedAt;
+}

--- a/backend/src/main/java/com/picsou/port/IbkrFlexPort.java
+++ b/backend/src/main/java/com/picsou/port/IbkrFlexPort.java
@@ -1,0 +1,65 @@
+package com.picsou.port;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+/**
+ * Abstraction over Interactive Brokers' Flex Web Service.
+ *
+ * <p>The Flex Web Service is a two-step HTTP API: a {@code SendRequest} generates a
+ * report instance from a pre-built Flex Query and returns a reference code, then
+ * {@code GetStatement} retrieves the XML once generation completes. The concrete
+ * adapter ({@code IbkrFlexClient}) hides the polling, XML parsing and error codes;
+ * callers see only the parsed open positions.
+ *
+ * <p>Open Positions Flex Queries carry once-daily (end-of-day) data, which matches
+ * Picsou's daily snapshot cadence.
+ */
+public interface IbkrFlexPort {
+
+    /**
+     * Runs the Open Positions Flex Query and returns the current positions grouped
+     * by IBKR account. Blocks while IBKR generates the statement (bounded polling).
+     *
+     * @param token   Flex Web Service token (plaintext; the caller decrypts it)
+     * @param queryId Flex Query id for the Open Positions query
+     * @return one {@link IbkrAccountData} per IBKR account id found in the statement
+     */
+    List<IbkrAccountData> fetchOpenPositions(String token, String queryId);
+
+    /**
+     * A single open position as reported by IBKR. Amounts are in the security's
+     * native {@code currency}; {@code fxRateToBase} converts that currency to the
+     * account's IBKR base currency.
+     *
+     * @param accountId      IBKR account id (e.g. "U1234567")
+     * @param isin           ISIN, may be null for instruments without one (some derivatives)
+     * @param symbol         IBKR symbol (fallback ticker when there is no ISIN)
+     * @param description    human-readable instrument name
+     * @param currency       native quote currency (e.g. "USD", "EUR")
+     * @param assetCategory  IBKR asset class ("STK", "ETF", "OPT", "FUT", "CASH", ...)
+     * @param levelOfDetail  "SUMMARY" (aggregate) or "LOT" (per tax lot); used to de-dupe
+     * @param position       signed quantity held
+     * @param markPrice      current mark price per unit, native currency
+     * @param costBasisPrice cost basis per unit, native currency (may be null)
+     * @param fxRateToBase   native-currency → IBKR-base-currency rate (may be null)
+     */
+    record IbkrPosition(
+        String accountId,
+        String isin,
+        String symbol,
+        String description,
+        String currency,
+        String assetCategory,
+        String levelOfDetail,
+        BigDecimal position,
+        BigDecimal markPrice,
+        BigDecimal costBasisPrice,
+        BigDecimal fxRateToBase
+    ) {}
+
+    record IbkrAccountData(
+        String accountId,
+        List<IbkrPosition> positions
+    ) {}
+}

--- a/backend/src/main/java/com/picsou/port/IbkrFlexPort.java
+++ b/backend/src/main/java/com/picsou/port/IbkrFlexPort.java
@@ -58,8 +58,22 @@ public interface IbkrFlexPort {
         BigDecimal fxRateToBase
     ) {}
 
+    /**
+     * @param accountId    IBKR account id
+     * @param positions    open positions for this account
+     * @param baseCurrency the account's IBKR base currency (e.g. "EUR", "USD"), from the
+     *                     optional {@code AccountInformation} section of the Flex Query;
+     *                     null when that section is not enabled on the query, or absent
+     *                     from the statement
+     */
     record IbkrAccountData(
         String accountId,
-        List<IbkrPosition> positions
-    ) {}
+        List<IbkrPosition> positions,
+        String baseCurrency
+    ) {
+        /** Convenience constructor for callers/tests that predate the base-currency field. */
+        public IbkrAccountData(String accountId, List<IbkrPosition> positions) {
+            this(accountId, positions, null);
+        }
+    }
 }

--- a/backend/src/main/java/com/picsou/repository/IbkrConnectionRepository.java
+++ b/backend/src/main/java/com/picsou/repository/IbkrConnectionRepository.java
@@ -1,0 +1,12 @@
+package com.picsou.repository;
+
+import com.picsou.model.IbkrConnection;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface IbkrConnectionRepository extends JpaRepository<IbkrConnection, Long> {
+
+    // memberId-scoped query — every access is scoped by member, like the other connectors.
+    Optional<IbkrConnection> findByMemberId(Long memberId);
+}

--- a/backend/src/main/java/com/picsou/service/AccountService.java
+++ b/backend/src/main/java/com/picsou/service/AccountService.java
@@ -292,7 +292,10 @@ public class AccountService {
                 // guess -- but it is not free: during a price-provider outage the balance (and
                 // any snapshot taken from it) silently shrinks by whatever those holdings were
                 // worth. Log it so the dip is explicable rather than mysterious.
-                if (qty != null && qty.signum() > 0) {
+                // signum() != 0 (not > 0): omitting an unpriced SHORT overstates the
+                // balance — a liability valued at 0 — which deserves the trace at least
+                // as much as the understated long.
+                if (qty != null && qty.signum() != 0) {
                     log.warn("No EUR price for holding {} (account {}) -- excluding it from the live balance",
                         h.getTicker(), account.getId());
                 }
@@ -439,8 +442,11 @@ public class AccountService {
         BigDecimal pnlEur = currentValueEur != null
             ? currentValueEur.subtract(costBasis)
             : null;
+        // abs(): a short position has a negative cost basis, and dividing by it would
+        // flip the sign — a winning short would display as a loss. The percentage must
+        // carry the sign of the P&L itself, the denominator is only a magnitude.
         BigDecimal pnlPercent = (pnlEur != null && costBasis.signum() != 0)
-            ? pnlEur.divide(costBasis, 4, RoundingMode.HALF_UP).multiply(BigDecimal.valueOf(100))
+            ? pnlEur.divide(costBasis.abs(), 4, RoundingMode.HALF_UP).multiply(BigDecimal.valueOf(100))
             : null;
 
         return new HoldingResponse(

--- a/backend/src/main/java/com/picsou/service/BoursoSyncService.java
+++ b/backend/src/main/java/com/picsou/service/BoursoSyncService.java
@@ -265,6 +265,14 @@ public class BoursoSyncService {
 
             for (Map.Entry<String, HoldingDedup.HoldingAgg> entry : deduped.entrySet()) {
                 HoldingDedup.HoldingAgg agg = entry.getValue();
+                if (agg.quantity().signum() == 0) {
+                    // vwapMerge is sign-aware and can net two positions to exactly zero
+                    // (shared with IBKR, which can carry short quantities) -- a flat
+                    // position, not a holding to persist. Bourso only ever feeds positive
+                    // quantities today, so this is unreachable here but keeps the
+                    // invariant true regardless.
+                    continue;
+                }
                 holdingRepository.save(AccountHolding.builder()
                     .account(account)
                     .ticker(entry.getKey())

--- a/backend/src/main/java/com/picsou/service/HoldingDedup.java
+++ b/backend/src/main/java/com/picsou/service/HoldingDedup.java
@@ -1,17 +1,23 @@
 package com.picsou.service;
 
+import lombok.extern.slf4j.Slf4j;
+
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 
 /**
- * Shared deduplication helper for sync services (TR, Bourso) when multiple
- * external positions (e.g. several ISINs) resolve to the same ticker.
+ * Shared deduplication helper for sync services (IBKR, TR, Bourso) when multiple
+ * external positions (e.g. several ISINs, or long/short legs) resolve to the same
+ * ticker.
  *
  * <p>The merge uses a VWAP (Volume Weighted Average Price) formula so the
  * resulting {@code averageBuyIn} is the quantity-weighted mean of the inputs,
  * rather than the non-deterministic "first-seen" value that {@code HashMap}
- * iteration order would yield.
+ * iteration order would yield. TR and Bourso only ever feed positive quantities
+ * today; IBKR can carry short positions (negative {@code quantity}), so the merge
+ * is sign-aware -- see {@link #vwapMerge}.
  */
+@Slf4j
 public final class HoldingDedup {
 
     private HoldingDedup() {}
@@ -24,29 +30,53 @@ public final class HoldingDedup {
     ) {}
 
     /**
-     * Merges two aggregates of the same ticker. The resulting average buy-in is:
-     * <pre>
-     *   weightedAvg = (q1 * a1 + q2 * a2) / (q1 + q2)
-     * </pre>
-     * Scale 8, {@link RoundingMode#HALF_UP} -- matches the project-wide
-     * convention used by {@code HoldingComputeService}.
+     * Merges two aggregates of the same ticker.
      *
-     * <p>Null averages are treated as zero; if total quantity is zero, the
-     * previous aggregate is returned unchanged (cannot divide).
+     * <ul>
+     *   <li><b>Zero net quantity</b> (e.g. a short fully covered by an equal-and-opposite
+     *       long lot): returns a sentinel {@code HoldingAgg} with {@code quantity = 0}
+     *       and {@code averageBuyIn = null} -- a flat position, not "nothing to merge".
+     *       <b>Callers must skip a zero-quantity aggregate before persisting it</b> (a
+     *       stale non-zero holding must not survive when the net position is flat).</li>
+     *   <li><b>Opposite signs, non-zero net</b> (a long and a short leg that do not fully
+     *       cancel): a quantity-weighted average across the two is not meaningful -- it
+     *       can land anywhere, including negative -- so the quantity is netted
+     *       arithmetically and {@code averageBuyIn} is taken from the
+     *       <b>larger-{@code |quantity|}</b> side, i.e. the cost basis of the residual
+     *       exposure that remains after netting. Logged at WARN (mixed-sign positions
+     *       are unusual and worth surfacing).</li>
+     *   <li><b>Same signs</b> (or one side is already flat, e.g. from a prior netting
+     *       merge in the same reduction): the original formula, unchanged --
+     *       <pre>weightedAvg = (q1 * a1 + q2 * a2) / (q1 + q2)</pre>
+     *       Scale 8, {@link RoundingMode#HALF_UP} -- matches the project-wide convention
+     *       used by {@code HoldingComputeService}. Null averages are treated as zero.</li>
+     * </ul>
      */
     public static HoldingAgg vwapMerge(HoldingAgg prev, HoldingAgg next) {
         BigDecimal totalQty = prev.quantity().add(next.quantity());
+        BigDecimal currentPrice = prev.currentPrice() != null ? prev.currentPrice() : next.currentPrice();
+        String name = prev.name() != null ? prev.name() : next.name();
+
         if (totalQty.signum() == 0) {
-            return prev;
+            return new HoldingAgg(BigDecimal.ZERO, null, currentPrice, name);
         }
+
+        boolean mixedSigns = prev.quantity().signum() != 0
+            && next.quantity().signum() != 0
+            && prev.quantity().signum() != next.quantity().signum();
+
+        if (mixedSigns) {
+            log.warn("IBKR: netting mixed-sign positions for '{}': {} @ {} vs {} @ {} -> net {}",
+                name, prev.quantity(), prev.averageBuyIn(), next.quantity(), next.averageBuyIn(), totalQty);
+            HoldingAgg larger = prev.quantity().abs().compareTo(next.quantity().abs()) >= 0 ? prev : next;
+            return new HoldingAgg(totalQty, larger.averageBuyIn(), currentPrice, name);
+        }
+
         BigDecimal prevAvg = prev.averageBuyIn() != null ? prev.averageBuyIn() : BigDecimal.ZERO;
         BigDecimal nextAvg = next.averageBuyIn() != null ? next.averageBuyIn() : BigDecimal.ZERO;
         BigDecimal weightedAvg = prev.quantity().multiply(prevAvg)
             .add(next.quantity().multiply(nextAvg))
             .divide(totalQty, 8, RoundingMode.HALF_UP);
-
-        BigDecimal currentPrice = prev.currentPrice() != null ? prev.currentPrice() : next.currentPrice();
-        String name = prev.name() != null ? prev.name() : next.name();
 
         return new HoldingAgg(totalQty, weightedAvg, currentPrice, name);
     }

--- a/backend/src/main/java/com/picsou/service/IbkrStatusWriter.java
+++ b/backend/src/main/java/com/picsou/service/IbkrStatusWriter.java
@@ -1,0 +1,35 @@
+package com.picsou.service;
+
+import com.picsou.repository.IbkrConnectionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Persists an IBKR connection's {@code ERROR} status in its own transaction.
+ *
+ * <p>{@link IbkrSyncService} is {@code @Transactional}; when a manual sync fails, the
+ * rethrown exception marks that transaction rollback-only, so a plain save of the
+ * {@code ERROR} status made inside {@code syncWithConnection} is silently discarded on
+ * the manual path (the scheduled path happens to survive because it catches the
+ * exception before it crosses the proxy — the two paths must not disagree). This bean's
+ * {@code REQUIRES_NEW} method commits independently of the caller's transaction, so the
+ * status write survives regardless of how the caller handles the exception. Must be a
+ * separate Spring bean: a {@code REQUIRES_NEW} method invoked via {@code this} inside
+ * {@code IbkrSyncService} would not cross the proxy and would have no effect.
+ */
+@Service
+@RequiredArgsConstructor
+public class IbkrStatusWriter {
+
+    private final IbkrConnectionRepository connectionRepository;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void markError(Long connectionId) {
+        connectionRepository.findById(connectionId).ifPresent(c -> {
+            c.setStatus("ERROR");
+            connectionRepository.save(c);
+        });
+    }
+}

--- a/backend/src/main/java/com/picsou/service/IbkrStatusWriter.java
+++ b/backend/src/main/java/com/picsou/service/IbkrStatusWriter.java
@@ -2,6 +2,7 @@ package com.picsou.service;
 
 import com.picsou.repository.IbkrConnectionRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -21,15 +22,18 @@ import org.springframework.transaction.annotation.Transactional;
  */
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class IbkrStatusWriter {
 
     private final IbkrConnectionRepository connectionRepository;
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void markError(Long connectionId) {
-        connectionRepository.findById(connectionId).ifPresent(c -> {
+        connectionRepository.findById(connectionId).ifPresentOrElse(c -> {
             c.setStatus("ERROR");
             connectionRepository.save(c);
-        });
+        }, () -> log.error("Cannot mark IBKR connection {} as ERROR: row not found "
+            + "(connection deleted mid-sync?) — the user will not see an error status",
+            connectionId));
     }
 }

--- a/backend/src/main/java/com/picsou/service/IbkrSyncService.java
+++ b/backend/src/main/java/com/picsou/service/IbkrSyncService.java
@@ -105,7 +105,15 @@ public class IbkrSyncService {
             return new IbkrConnectionStatusResponse(false, null, null, null, null);
         }
         IbkrConnection c = connection.get();
-        String maskedToken = maskToken(encryption.decrypt(c.getToken()));
+        String maskedToken;
+        try {
+            maskedToken = maskToken(encryption.decrypt(c.getToken()));
+        } catch (RuntimeException ex) {
+            // A rotated encryption key / corrupted row must degrade into a visible ERROR
+            // status, not a 500 on the read-only endpoint the Sync page always calls.
+            log.error("IBKR: cannot decrypt stored token for connection {}", c.getId(), ex);
+            return new IbkrConnectionStatusResponse(true, c.getId(), "ERROR", c.getLastSyncedAt(), "••••");
+        }
         return new IbkrConnectionStatusResponse(true, c.getId(), c.getStatus(), c.getLastSyncedAt(), maskedToken);
     }
 
@@ -140,19 +148,32 @@ public class IbkrSyncService {
     }
 
     private List<AccountResponse> syncWithConnection(IbkrConnection connection, Long memberId) {
-        String token = encryption.decrypt(connection.getToken());
-        String queryId = encryption.decrypt(connection.getQueryId());
-
-        List<IbkrAccountData> accounts;
         try {
-            accounts = ibkrFlexPort.fetchOpenPositions(token, queryId);
+            return doSync(connection, memberId);
         } catch (RuntimeException ex) {
-            // A plain save here would be lost on the manual path: the rethrow marks this
-            // @Transactional method rollback-only, so the ERROR status never commits.
-            // statusWriter runs in its own REQUIRES_NEW transaction, which survives.
+            // Any failure — decryption, the Flex fetch, the non-EUR base-currency guard,
+            // a DB error while mapping — must leave a visible ERROR status, on both the
+            // manual and the scheduled path. A plain save here would be lost on the
+            // manual path: the rethrow marks this @Transactional method rollback-only,
+            // so the status write never commits. statusWriter runs in its own
+            // REQUIRES_NEW transaction, which survives the rollback.
             statusWriter.markError(connection.getId());
             throw ex;
         }
+    }
+
+    private List<AccountResponse> doSync(IbkrConnection connection, Long memberId) {
+        String token;
+        String queryId;
+        try {
+            token = encryption.decrypt(connection.getToken());
+            queryId = encryption.decrypt(connection.getQueryId());
+        } catch (RuntimeException ex) {
+            throw new SyncException("Could not decrypt the stored IBKR credentials — the encryption "
+                + "key may have changed. Please reconnect with a fresh token.", ex);
+        }
+
+        List<IbkrAccountData> accounts = ibkrFlexPort.fetchOpenPositions(token, queryId);
 
         List<AccountResponse> responses = accounts.stream()
             .map(data -> upsertAccount(data, memberId))

--- a/backend/src/main/java/com/picsou/service/IbkrSyncService.java
+++ b/backend/src/main/java/com/picsou/service/IbkrSyncService.java
@@ -66,7 +66,7 @@ public class IbkrSyncService {
     private final IbkrStatusWriter statusWriter;
 
     /** Column limits of {@code account_holding} (see V11): ticker VARCHAR(30), name VARCHAR(100). */
-    private static final int MAX_TICKER_LEN = 30;
+    private static final int MAX_TICKER_LEN = 100000; // JUDGE-TEMP: guard disabled to prove no test covers it
     private static final int MAX_NAME_LEN = 100;
 
     /**
@@ -239,6 +239,7 @@ public class IbkrSyncService {
 
         // Replace holdings wholesale — the statement is the full current picture.
         holdingRepository.deleteByAccountId(account.getId());
+        holdingRepository.flush();
 
         // De-dup by resolved ticker (VWAP) exactly like Trade Republic: several IBKR
         // positions (or lot rows across accounts) can map to one ticker.

--- a/backend/src/main/java/com/picsou/service/IbkrSyncService.java
+++ b/backend/src/main/java/com/picsou/service/IbkrSyncService.java
@@ -1,4 +1,4 @@
-package com.picsou.ibkr;
+package com.picsou.service;
 
 import com.picsou.adapter.OpenFigiIsinConverter;
 import com.picsou.adapter.OpenFigiIsinConverter.TickerResult;
@@ -19,8 +19,6 @@ import com.picsou.repository.AccountHoldingRepository;
 import com.picsou.repository.AccountRepository;
 import com.picsou.repository.FamilyMemberRepository;
 import com.picsou.repository.IbkrConnectionRepository;
-import com.picsou.service.AccountService;
-import com.picsou.service.HoldingDedup;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -38,12 +36,15 @@ import java.util.Optional;
  * Orchestrates Interactive Brokers sync: stores the encrypted Flex credentials,
  * pulls Open Positions once a day and maps them onto Picsou accounts + holdings.
  *
- * <p>Mirrors {@code TradeRepublicSyncService}'s broker→holdings pattern (delete +
- * recompute, VWAP de-dup, ISIN→ticker via {@link OpenFigiIsinConverter}). The one
- * IBKR-specific twist is currency: IBKR reports cost basis in each security's native
- * currency, so {@code averageBuyIn} is converted to the account's base currency via
+ * <p>Lives in {@code com.picsou.service} alongside the other broker sync services
+ * (Trade Republic, Bourso) so it can reuse {@link AccountService}'s package-private
+ * {@code upsertSnapshot} / {@code toResponse} helpers. Mirrors
+ * {@code TradeRepublicSyncService}'s broker→holdings pattern (delete + recompute,
+ * VWAP de-dup, ISIN→ticker via {@link OpenFigiIsinConverter}). The one IBKR-specific
+ * twist is currency: IBKR reports cost basis in each security's native currency, so
+ * {@code averageBuyIn} is converted to the account's base currency via
  * {@code fxRateToBase}. Net worth itself never depends on that conversion — it is
- * recomputed live in EUR from tickers by {@code AccountService.liveBalanceEur}
+ * recomputed live in EUR from tickers by {@link AccountService#liveBalanceEur}
  * (Yahoo/CoinGecko, FX-converted), exactly like every other holdings account.
  */
 @Service
@@ -282,7 +283,7 @@ public class IbkrSyncService {
     /**
      * Mark price per unit in the account base currency (≈EUR). Informational only:
      * the stored {@code currentPrice} is never trusted for EUR valuation — the
-     * dashboard recomputes live from the ticker (see {@code AccountService}).
+     * dashboard recomputes live from the ticker (see {@link AccountService}).
      */
     private BigDecimal eurMark(IbkrPosition p) {
         if (p.markPrice() == null) {

--- a/backend/src/main/java/com/picsou/service/IbkrSyncService.java
+++ b/backend/src/main/java/com/picsou/service/IbkrSyncService.java
@@ -62,6 +62,10 @@ public class IbkrSyncService {
     private final OpenFigiIsinConverter isinConverter;
     private final CryptoEncryption encryption;
 
+    /** Column limits of {@code account_holding} (see V11): ticker VARCHAR(30), name VARCHAR(100). */
+    private static final int MAX_TICKER_LEN = 30;
+    private static final int MAX_NAME_LEN = 100;
+
     // ---------------------------------------------------------------------------
     // Connection management
     // ---------------------------------------------------------------------------
@@ -198,11 +202,19 @@ public class IbkrSyncService {
                 continue;
             }
             TickerResult resolved = resolveTicker(p);
-            if (resolved.ticker() == null || resolved.ticker().isBlank()) {
+            String ticker = resolved.ticker();
+            if (ticker == null || ticker.isBlank()) {
+                continue;
+            }
+            if (ticker.length() > MAX_TICKER_LEN) {
+                // Options / futures carry long symbols (e.g. "SPY 240119C00470000") that
+                // overflow account_holding.ticker (VARCHAR 30) and never price through Yahoo
+                // anyway — skip the position rather than fail the whole account's sync.
+                log.warn("IBKR: skipping position with over-long ticker '{}' ({} chars)", ticker, ticker.length());
                 continue;
             }
             deduped.merge(
-                resolved.ticker(),
+                ticker,
                 new HoldingDedup.HoldingAgg(p.position(), eurCostBasis(p), eurMark(p), resolved.name()),
                 HoldingDedup::vwapMerge);
         }
@@ -211,7 +223,7 @@ public class IbkrSyncService {
             holdingRepository.save(AccountHolding.builder()
                 .account(account)
                 .ticker(entry.getKey())
-                .name(agg.name())
+                .name(clip(agg.name(), MAX_NAME_LEN))
                 .quantity(agg.quantity())
                 .averageBuyIn(agg.averageBuyIn())
                 .currentPrice(agg.currentPrice())
@@ -291,6 +303,14 @@ public class IbkrSyncService {
         }
         BigDecimal rate = p.fxRateToBase() != null ? p.fxRateToBase() : BigDecimal.ONE;
         return p.markPrice().multiply(rate);
+    }
+
+    /** Truncates {@code s} to {@code max} chars so it fits its DB column; null-safe. */
+    private static String clip(String s, int max) {
+        if (s == null) {
+            return null;
+        }
+        return s.length() <= max ? s : s.substring(0, max);
     }
 
     /** Shows only the last 4 characters of the token, e.g. "••••••3F29". */

--- a/backend/src/main/java/com/picsou/service/IbkrSyncService.java
+++ b/backend/src/main/java/com/picsou/service/IbkrSyncService.java
@@ -134,13 +134,18 @@ public class IbkrSyncService {
         return syncWithConnection(connection, memberId);
     }
 
-    /** Scheduler entry point — no-op if the member has no connection. */
+    /**
+     * Scheduler entry point — no-op if the member has no connection. NEVER throws:
+     * {@code SchedulerService.dailyBankSync} calls it unwrapped (like the TR/Bourso
+     * siblings), so an escaping exception — including a DB error on the connection
+     * lookup itself — would halt the loop and skip every remaining member's sync.
+     */
     public void resyncIfConnected(Long memberId) {
-        Optional<IbkrConnection> connection = connectionRepository.findByMemberId(memberId);
-        if (connection.isEmpty()) {
-            return;
-        }
         try {
+            Optional<IbkrConnection> connection = connectionRepository.findByMemberId(memberId);
+            if (connection.isEmpty()) {
+                return;
+            }
             syncWithConnection(connection.get(), memberId);
         } catch (SyncException ex) {
             // Expected operational failures (expired token, IBKR down, non-EUR guard):
@@ -234,7 +239,6 @@ public class IbkrSyncService {
 
         // Replace holdings wholesale — the statement is the full current picture.
         holdingRepository.deleteByAccountId(account.getId());
-        holdingRepository.flush();
 
         // De-dup by resolved ticker (VWAP) exactly like Trade Republic: several IBKR
         // positions (or lot rows across accounts) can map to one ticker.
@@ -260,6 +264,7 @@ public class IbkrSyncService {
                 new HoldingDedup.HoldingAgg(p.position(), eurCostBasis(p), eurMark(p), resolved.name()),
                 HoldingDedup::vwapMerge);
         }
+        int persisted = 0;
         for (Map.Entry<String, HoldingDedup.HoldingAgg> entry : deduped.entrySet()) {
             HoldingDedup.HoldingAgg agg = entry.getValue();
             if (agg.quantity().signum() == 0) {
@@ -277,13 +282,18 @@ public class IbkrSyncService {
                 .currentPrice(agg.currentPrice())
                 .lastSyncedAt(Instant.now())
                 .build());
+            persisted++;
         }
         holdingRepository.flush();
 
         // Net-worth-critical figures use the trusted live-EUR path (Yahoo/CoinGecko,
         // FX-converted), never IBKR's base currency — so net worth is right even if the
-        // user's IBKR base currency is not EUR.
-        BigDecimal liveEur = accountService.liveBalanceEur(account);
+        // user's IBKR base currency is not EUR. With ZERO holdings the live path would
+        // fall back to the account's stored currentBalance (see liveBalanceEur), which
+        // for a fully liquidated statement account is exactly the stale value we must
+        // NOT keep — a holdings-driven COMPTE_TITRES with nothing held is worth 0 here
+        // (cash is not modeled: CASH lines are skipped by isReportable).
+        BigDecimal liveEur = persisted == 0 ? BigDecimal.ZERO : accountService.liveBalanceEur(account);
         account.setCurrentBalance(liveEur);
         account = accountRepository.save(account);
         accountService.upsertSnapshot(account, liveEur, LocalDate.now());

--- a/backend/src/main/java/com/picsou/service/IbkrSyncService.java
+++ b/backend/src/main/java/com/picsou/service/IbkrSyncService.java
@@ -29,8 +29,10 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * Orchestrates Interactive Brokers sync: stores the encrypted Flex credentials,
@@ -66,6 +68,14 @@ public class IbkrSyncService {
     /** Column limits of {@code account_holding} (see V11): ticker VARCHAR(30), name VARCHAR(100). */
     private static final int MAX_TICKER_LEN = 30;
     private static final int MAX_NAME_LEN = 100;
+
+    /**
+     * Asset categories we price and cost-basis correctly (stocks/ETFs, mutual funds,
+     * bonds, crypto). Everything else (options, futures, CFDs, warrants, ...) is a
+     * derivative whose per-share cost basis ignores the contract multiplier and whose
+     * mark rarely resolves through Yahoo/CoinGecko — see {@link #isReportable}.
+     */
+    private static final Set<String> REPORTABLE_ASSET_CATEGORIES = Set.of("STK", "FUND", "BOND", "CRYPTO");
 
     // ---------------------------------------------------------------------------
     // Connection management
@@ -248,8 +258,9 @@ public class IbkrSyncService {
 
     /**
      * Whether a position should become a holding: non-zero quantity, summary-level
-     * (not a per-lot duplicate) and not a cash line. A ticker source (ISIN or symbol)
-     * is required so we never persist a nameless holding.
+     * (not a per-lot duplicate), not a cash line, and an asset category we can price
+     * and cost-basis correctly ({@link #REPORTABLE_ASSET_CATEGORIES}, or absent). A
+     * ticker source (ISIN or symbol) is required so we never persist a nameless holding.
      */
     private boolean isReportable(IbkrPosition p) {
         if (p.position() == null || p.position().signum() == 0) {
@@ -261,6 +272,17 @@ public class IbkrSyncService {
             return false;
         }
         if (p.assetCategory() != null && "CASH".equalsIgnoreCase(p.assetCategory())) {
+            return false;
+        }
+        // Allowlist rather than the old over-long-ticker guard alone: standard OCC
+        // option symbols (e.g. "SPY 240119C00470000", 19 chars) are well under the
+        // 30-char column limit and used to pass straight through as a stock holding.
+        // Skip (and warn) anything outside the categories we handle correctly so
+        // day-1 real data reveals any category we got wrong.
+        if (p.assetCategory() != null
+            && !REPORTABLE_ASSET_CATEGORIES.contains(p.assetCategory().toUpperCase(Locale.ROOT))) {
+            log.warn("IBKR: skipping unsupported assetCategory '{}' for symbol '{}'",
+                p.assetCategory(), p.symbol());
             return false;
         }
         return (p.isin() != null && !p.isin().isBlank()) || (p.symbol() != null && !p.symbol().isBlank());

--- a/backend/src/main/java/com/picsou/service/IbkrSyncService.java
+++ b/backend/src/main/java/com/picsou/service/IbkrSyncService.java
@@ -142,8 +142,13 @@ public class IbkrSyncService {
         }
         try {
             syncWithConnection(connection.get(), memberId);
-        } catch (Exception ex) {
+        } catch (SyncException ex) {
+            // Expected operational failures (expired token, IBKR down, non-EUR guard):
+            // the message is the whole story, status is already ERROR.
             log.warn("IBKR auto-sync failed for member {}: {}", memberId, ex.getMessage());
+        } catch (RuntimeException ex) {
+            // Anything else is a bug or infrastructure problem — keep the stack trace.
+            log.error("IBKR auto-sync hit an unexpected error for member {}", memberId, ex);
         }
     }
 
@@ -157,6 +162,7 @@ public class IbkrSyncService {
             // manual path: the rethrow marks this @Transactional method rollback-only,
             // so the status write never commits. statusWriter runs in its own
             // REQUIRES_NEW transaction, which survives the rollback.
+            log.error("IBKR sync failed for connection {} — marking ERROR status", connection.getId(), ex);
             statusWriter.markError(connection.getId());
             throw ex;
         }

--- a/backend/src/main/java/com/picsou/service/IbkrSyncService.java
+++ b/backend/src/main/java/com/picsou/service/IbkrSyncService.java
@@ -233,6 +233,12 @@ public class IbkrSyncService {
         }
         for (Map.Entry<String, HoldingDedup.HoldingAgg> entry : deduped.entrySet()) {
             HoldingDedup.HoldingAgg agg = entry.getValue();
+            if (agg.quantity().signum() == 0) {
+                // Mixed-sign positions (e.g. a short covered by an equal-and-opposite
+                // long lot) can net to exactly zero in vwapMerge -- a flat position, not
+                // a holding to persist.
+                continue;
+            }
             holdingRepository.save(AccountHolding.builder()
                 .account(account)
                 .ticker(entry.getKey())

--- a/backend/src/main/java/com/picsou/service/IbkrSyncService.java
+++ b/backend/src/main/java/com/picsou/service/IbkrSyncService.java
@@ -135,10 +135,12 @@ public class IbkrSyncService {
     }
 
     /**
-     * Scheduler entry point — no-op if the member has no connection. NEVER throws:
-     * {@code SchedulerService.dailyBankSync} calls it unwrapped (like the TR/Bourso
-     * siblings), so an escaping exception — including a DB error on the connection
-     * lookup itself — would halt the loop and skip every remaining member's sync.
+     * Scheduler entry point — no-op if the member has no connection. Swallows and logs
+     * sync failures so they do not propagate — but this is best effort, NOT a hard
+     * no-throw contract: when a repository call fails inside the sync, the shared
+     * transaction is marked rollback-only through the repository's own proxy, and
+     * Spring throws {@code UnexpectedRollbackException} at THIS method's proxy exit,
+     * after the catch below. Call sites must wrap accordingly (SchedulerService does).
      */
     public void resyncIfConnected(Long memberId) {
         try {

--- a/backend/src/main/java/com/picsou/service/IbkrSyncService.java
+++ b/backend/src/main/java/com/picsou/service/IbkrSyncService.java
@@ -61,6 +61,7 @@ public class IbkrSyncService {
     private final AccountService accountService;
     private final OpenFigiIsinConverter isinConverter;
     private final CryptoEncryption encryption;
+    private final IbkrStatusWriter statusWriter;
 
     /** Column limits of {@code account_holding} (see V11): ticker VARCHAR(30), name VARCHAR(100). */
     private static final int MAX_TICKER_LEN = 30;
@@ -136,8 +137,10 @@ public class IbkrSyncService {
         try {
             accounts = ibkrFlexPort.fetchOpenPositions(token, queryId);
         } catch (RuntimeException ex) {
-            connection.setStatus("ERROR");
-            connectionRepository.save(connection);
+            // A plain save here would be lost on the manual path: the rethrow marks this
+            // @Transactional method rollback-only, so the ERROR status never commits.
+            // statusWriter runs in its own REQUIRES_NEW transaction, which survives.
+            statusWriter.markError(connection.getId());
             throw ex;
         }
 

--- a/backend/src/main/java/com/picsou/service/IbkrSyncService.java
+++ b/backend/src/main/java/com/picsou/service/IbkrSyncService.java
@@ -181,6 +181,8 @@ public class IbkrSyncService {
             return Optional.empty();
         }
 
+        requireEurBaseCurrency(data);
+
         Account account;
         if (existing.isPresent()) {
             account = existing.get();
@@ -260,6 +262,31 @@ public class IbkrSyncService {
         accountService.upsertSnapshot(account, liveEur, LocalDate.now());
 
         return Optional.of(accountService.toResponse(account));
+    }
+
+    /**
+     * Guards against a non-EUR IBKR account base currency. {@code averageBuyIn} is
+     * stored converted via {@code fxRateToBase} into the account's IBKR base currency
+     * (see {@link #eurCostBasis}) -- if that base currency is not actually EUR, every
+     * invested-amount / per-holding P&L% figure derived from it is silently wrong. Net
+     * worth itself is unaffected (see the class javadoc: it is repriced live in EUR from
+     * tickers, never from the stored cost basis). Fail fast rather than persist
+     * quietly-wrong holdings for this account; a statement without the
+     * {@code AccountInformation} section (no {@code baseCurrency}) keeps today's
+     * assume-EUR behavior, with a once-per-account-sync WARN.
+     */
+    private void requireEurBaseCurrency(IbkrAccountData data) {
+        String baseCurrency = data.baseCurrency();
+        if (baseCurrency == null) {
+            log.warn("IBKR: account {} statement has no AccountInformation/baseCurrency; assuming EUR",
+                data.accountId());
+            return;
+        }
+        if (!"EUR".equalsIgnoreCase(baseCurrency)) {
+            throw new SyncException("IBKR account base currency is " + baseCurrency + "; Picsou currently "
+                + "supports EUR-based accounts — change the base currency in IBKR Account Settings, "
+                + "or reconnect after conversion support lands.");
+        }
     }
 
     /**

--- a/backend/src/main/java/com/picsou/service/IbkrSyncService.java
+++ b/backend/src/main/java/com/picsou/service/IbkrSyncService.java
@@ -66,7 +66,7 @@ public class IbkrSyncService {
     private final IbkrStatusWriter statusWriter;
 
     /** Column limits of {@code account_holding} (see V11): ticker VARCHAR(30), name VARCHAR(100). */
-    private static final int MAX_TICKER_LEN = 100000; // JUDGE-TEMP: guard disabled to prove no test covers it
+    private static final int MAX_TICKER_LEN = 30;
     private static final int MAX_NAME_LEN = 100;
 
     /**
@@ -379,13 +379,19 @@ public class IbkrSyncService {
         return new TickerResult(p.symbol(), p.description());
     }
 
-    /** Cost basis per unit in the account base currency (≈EUR). Null when unknown. */
+    /**
+     * Cost basis per unit in the account base currency (≈EUR). Null when unknown —
+     * including a non-EUR position WITHOUT {@code fxRateToBase}: "FX Rate to Base" is a
+     * column the user must tick on the Flex Query, and treating a missing rate as 1 would
+     * silently store a USD (or worse, JPY) price as if it were EUR. An unknown cost basis
+     * (no invested/P&L figures) is honest; a wrong one is not.
+     */
     private BigDecimal eurCostBasis(IbkrPosition p) {
         if (p.costBasisPrice() == null) {
             return null;
         }
-        BigDecimal rate = p.fxRateToBase() != null ? p.fxRateToBase() : BigDecimal.ONE;
-        return p.costBasisPrice().multiply(rate);
+        BigDecimal rate = fxToBaseOrNull(p);
+        return rate == null ? null : p.costBasisPrice().multiply(rate);
     }
 
     /**
@@ -397,8 +403,26 @@ public class IbkrSyncService {
         if (p.markPrice() == null) {
             return null;
         }
-        BigDecimal rate = p.fxRateToBase() != null ? p.fxRateToBase() : BigDecimal.ONE;
-        return p.markPrice().multiply(rate);
+        BigDecimal rate = fxToBaseOrNull(p);
+        return rate == null ? null : p.markPrice().multiply(rate);
+    }
+
+    /**
+     * FX rate to the account base currency, or null when it is genuinely unknown:
+     * absent rate + non-EUR position currency. Absent rate + EUR (or unspecified)
+     * currency keeps the historical assume-1 behavior.
+     */
+    private BigDecimal fxToBaseOrNull(IbkrPosition p) {
+        if (p.fxRateToBase() != null) {
+            return p.fxRateToBase();
+        }
+        if (p.currency() != null && !"EUR".equalsIgnoreCase(p.currency())) {
+            log.warn("IBKR: position {} is in {} but the statement has no fxRateToBase — enable "
+                + "the 'FX Rate to Base' column on the Flex Query; storing cost basis as unknown",
+                p.symbol(), p.currency());
+            return null;
+        }
+        return BigDecimal.ONE;
     }
 
     /** Truncates {@code s} to {@code max} chars so it fits its DB column; null-safe. */

--- a/backend/src/main/java/com/picsou/service/SchedulerService.java
+++ b/backend/src/main/java/com/picsou/service/SchedulerService.java
@@ -2,7 +2,6 @@ package com.picsou.service;
 
 import com.picsou.dto.FinaryAutoSyncResponse;
 import com.picsou.finary.FinaryApiSyncService;
-import com.picsou.ibkr.IbkrSyncService;
 import com.picsou.model.Account;
 import com.picsou.model.BalanceSnapshot;
 import com.picsou.model.FamilyMember;

--- a/backend/src/main/java/com/picsou/service/SchedulerService.java
+++ b/backend/src/main/java/com/picsou/service/SchedulerService.java
@@ -2,6 +2,7 @@ package com.picsou.service;
 
 import com.picsou.dto.FinaryAutoSyncResponse;
 import com.picsou.finary.FinaryApiSyncService;
+import com.picsou.ibkr.IbkrSyncService;
 import com.picsou.model.Account;
 import com.picsou.model.BalanceSnapshot;
 import com.picsou.model.FamilyMember;
@@ -37,6 +38,7 @@ public class SchedulerService {
     private final CryptoExchangeSyncService cryptoExchangeSyncService;
     private final WalletSyncService walletSyncService;
     private final FinaryApiSyncService finaryApiSyncService;
+    private final IbkrSyncService ibkrSyncService;
 
     public SchedulerService(
         AccountRepository accountRepository,
@@ -49,7 +51,8 @@ public class SchedulerService {
         PriceService priceService,
         CryptoExchangeSyncService cryptoExchangeSyncService,
         WalletSyncService walletSyncService,
-        FinaryApiSyncService finaryApiSyncService
+        FinaryApiSyncService finaryApiSyncService,
+        IbkrSyncService ibkrSyncService
     ) {
         this.accountRepository = accountRepository;
         this.snapshotRepository = snapshotRepository;
@@ -62,6 +65,7 @@ public class SchedulerService {
         this.cryptoExchangeSyncService = cryptoExchangeSyncService;
         this.walletSyncService = walletSyncService;
         this.finaryApiSyncService = finaryApiSyncService;
+        this.ibkrSyncService = ibkrSyncService;
     }
 
     /**
@@ -91,6 +95,7 @@ public class SchedulerService {
 
             trSyncService.resyncIfSessionActive(memberId);
             boursoSyncService.resyncIfSessionActive(memberId);
+            ibkrSyncService.resyncIfConnected(memberId);
 
             try {
                 cryptoExchangeSyncService.resyncAll(memberId);

--- a/backend/src/main/java/com/picsou/service/SchedulerService.java
+++ b/backend/src/main/java/com/picsou/service/SchedulerService.java
@@ -94,7 +94,18 @@ public class SchedulerService {
 
             trSyncService.resyncIfSessionActive(memberId);
             boursoSyncService.resyncIfSessionActive(memberId);
-            ibkrSyncService.resyncIfConnected(memberId);
+
+            try {
+                ibkrSyncService.resyncIfConnected(memberId);
+            } catch (Exception ex) {
+                // resyncIfConnected swallows sync failures itself, but Spring can still
+                // throw UnexpectedRollbackException AT THE PROXY EXIT: a repository call
+                // failing inside the sync marks the shared transaction rollback-only
+                // through the repository's own proxy, and the commit attempt happens
+                // after the method's internal catch. Without this wrapper that breaks
+                // the loop for every remaining member.
+                log.error("Daily IBKR auto-sync failed for member {}", memberId, ex);
+            }
 
             try {
                 cryptoExchangeSyncService.resyncAll(memberId);

--- a/backend/src/main/java/com/picsou/service/TradeRepublicSyncService.java
+++ b/backend/src/main/java/com/picsou/service/TradeRepublicSyncService.java
@@ -366,6 +366,14 @@ public class TradeRepublicSyncService {
             }
             for (Map.Entry<String, HoldingDedup.HoldingAgg> entry : deduped.entrySet()) {
                 HoldingDedup.HoldingAgg agg = entry.getValue();
+                if (agg.quantity().signum() == 0) {
+                    // vwapMerge is sign-aware and can net two positions to exactly zero
+                    // (shared with IBKR, which can carry short quantities) -- a flat
+                    // position, not a holding to persist. TR only ever feeds positive
+                    // quantities today, so this is unreachable here but keeps the
+                    // invariant true regardless.
+                    continue;
+                }
                 holdingRepository.save(AccountHolding.builder()
                     .account(account)
                     .ticker(entry.getKey())

--- a/backend/src/main/resources/db/migration/V56__ibkr_connection.sql
+++ b/backend/src/main/resources/db/migration/V56__ibkr_connection.sql
@@ -1,0 +1,24 @@
+-- V56: Interactive Brokers (IBKR) Flex Web Service connection.
+--
+-- Stores the per-member Flex Web Service credentials used to pull Open Positions
+-- once a day (EOD data). Both the token and the query id are AES-256-GCM encrypted
+-- at rest by CryptoEncryption, exactly like the other connector sessions
+-- (finary_session, bourso_session), hence the wide VARCHAR(500) columns
+-- (cf. V15__widen_encrypted_columns.sql: ciphertext is Base64 and longer than the
+-- plaintext token/query id).
+
+CREATE TABLE ibkr_connection (
+    id              BIGSERIAL PRIMARY KEY,
+    member_id       BIGINT        NOT NULL REFERENCES family_member(id) ON DELETE CASCADE,
+    -- Flex Web Service token (encrypted). Valid 6h–1y, read-only, generated in Client Portal.
+    token           VARCHAR(500)  NOT NULL,
+    -- Flex Query id (encrypted). Identifies the pre-built "Open Positions" query.
+    query_id        VARCHAR(500)  NOT NULL,
+    status          VARCHAR(20)   NOT NULL DEFAULT 'CONNECTED',
+    last_synced_at  TIMESTAMPTZ,
+    created_at      TIMESTAMPTZ   NOT NULL DEFAULT NOW(),
+    updated_at      TIMESTAMPTZ   NOT NULL DEFAULT NOW()
+);
+
+-- One connection per member (mirrors the single-session model of the other connectors).
+CREATE UNIQUE INDEX idx_ibkr_connection_member ON ibkr_connection(member_id);

--- a/backend/src/main/resources/db/migration/V57__ibkr_connection.sql
+++ b/backend/src/main/resources/db/migration/V57__ibkr_connection.sql
@@ -1,4 +1,6 @@
--- V56: Interactive Brokers (IBKR) Flex Web Service connection.
+-- V57: Interactive Brokers (IBKR) Flex Web Service connection.
+-- (V57 and not V56: main gained V56__persistent_session_previous_token while this
+-- branch was in review — same-version collisions are a hard Flyway boot failure.)
 --
 -- Stores the per-member Flex Web Service credentials used to pull Open Positions
 -- once a day (EOD data). Both the token and the query id are AES-256-GCM encrypted

--- a/backend/src/test/java/com/picsou/controller/IbkrControllerTest.java
+++ b/backend/src/test/java/com/picsou/controller/IbkrControllerTest.java
@@ -115,6 +115,22 @@ class IbkrControllerTest {
         verify(ibkrService, times(SYNC_BUDGET_PER_MINUTE)).sync(42L);
     }
 
+    /**
+     * Service failures must propagate untouched: the controller does no catching, so
+     * a SyncException reaches GlobalExceptionHandler (mapped there, not here) instead
+     * of being swallowed or rewrapped. Pinned by identity, not just by type.
+     */
+    @Test
+    void sync_propagatesServiceExceptions_untouched() {
+        when(userContext.currentMemberId()).thenReturn(42L);
+        com.picsou.exception.SyncException boom =
+            new com.picsou.exception.SyncException("Token expired. Please reconnect.");
+        when(ibkrService.sync(42L)).thenThrow(boom);
+
+        org.assertj.core.api.Assertions.assertThatThrownBy(() -> controller.sync(httpReq))
+            .isSameAs(boom);
+    }
+
     /** The budget is per client IP: exhausting one IP must not throttle another. */
     @Test
     void sync_rateLimitIsKeyedPerClientIp() {

--- a/backend/src/test/java/com/picsou/controller/IbkrControllerTest.java
+++ b/backend/src/test/java/com/picsou/controller/IbkrControllerTest.java
@@ -1,0 +1,133 @@
+package com.picsou.controller;
+
+import com.picsou.dto.AccountResponse;
+import com.picsou.dto.IbkrConnectRequest;
+import com.picsou.dto.IbkrConnectionStatusResponse;
+import com.picsou.service.IbkrSyncService;
+import com.picsou.service.UserContext;
+import io.github.bucket4j.Bucket;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
+import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Controller-level coverage for {@code /api/ibkr/*}: delegation to the service and,
+ * most importantly, per-IP rate-limit enforcement on {@code /sync} — the bucket
+ * store is real (a plain map + the production bucket factory), only the service
+ * and user context are mocked, mirroring {@link AuthControllerTest}'s style.
+ */
+@ExtendWith(MockitoExtension.class)
+class IbkrControllerTest {
+
+    private static final int SYNC_BUDGET_PER_MINUTE = 6;
+
+    @Mock IbkrSyncService ibkrService;
+    @Mock UserContext userContext;
+
+    Map<String, Bucket> ibkrSyncBuckets;
+    IbkrController controller;
+    MockHttpServletRequest httpReq;
+
+    @BeforeEach
+    void setUp() {
+        ibkrSyncBuckets = new HashMap<>();
+        controller = new IbkrController(ibkrService, userContext, ibkrSyncBuckets);
+        httpReq = new MockHttpServletRequest();
+        httpReq.setRemoteAddr("10.0.0.5");
+    }
+
+    @Test
+    void connect_delegatesToService_andReturns204() {
+        when(userContext.currentMemberId()).thenReturn(42L);
+
+        ResponseEntity<Void> res = controller.connect(new IbkrConnectRequest("flex-token", "1234567"));
+
+        assertThat(res.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+        verify(ibkrService).connect("flex-token", "1234567", 42L);
+    }
+
+    @Test
+    void getStatus_delegatesToService() {
+        when(userContext.currentMemberId()).thenReturn(42L);
+        IbkrConnectionStatusResponse status =
+            new IbkrConnectionStatusResponse(false, null, null, null, null);
+        when(ibkrService.getConnectionStatus(42L)).thenReturn(status);
+
+        assertThat(controller.getStatus()).isSameAs(status);
+    }
+
+    @Test
+    void clearConnection_delegatesToService_andReturns204() {
+        when(userContext.currentMemberId()).thenReturn(42L);
+
+        ResponseEntity<Void> res = controller.clearConnection();
+
+        assertThat(res.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+        verify(ibkrService).deleteConnection(42L);
+    }
+
+    @Test
+    void sync_returnsAccounts_whileWithinTheRateLimit() {
+        when(userContext.currentMemberId()).thenReturn(42L);
+        List<AccountResponse> accounts = List.of();
+        when(ibkrService.sync(42L)).thenReturn(accounts);
+
+        ResponseEntity<?> res = controller.sync(httpReq);
+
+        assertThat(res.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(res.getBody()).isSameAs(accounts);
+    }
+
+    /**
+     * The per-IP budget is 6 sync calls per minute ({@code createIbkrSyncBucket}):
+     * calls 1-6 must reach the service, call 7 must be rejected with 429 BEFORE
+     * touching the service — the limiter protects the shared Flex token's own
+     * server-side budget at IBKR.
+     */
+    @Test
+    void sync_returns429_andSkipsTheService_onceThePerIpBudgetIsExhausted() {
+        when(userContext.currentMemberId()).thenReturn(42L);
+        when(ibkrService.sync(42L)).thenReturn(List.of());
+
+        for (int i = 0; i < SYNC_BUDGET_PER_MINUTE; i++) {
+            assertThat(controller.sync(httpReq).getStatusCode()).isEqualTo(HttpStatus.OK);
+        }
+
+        ResponseEntity<?> rejected = controller.sync(httpReq);
+
+        assertThat(rejected.getStatusCode()).isEqualTo(HttpStatus.TOO_MANY_REQUESTS);
+        assertThat(((ProblemDetail) rejected.getBody()).getDetail()).contains("Too many sync requests");
+        verify(ibkrService, times(SYNC_BUDGET_PER_MINUTE)).sync(42L);
+    }
+
+    /** The budget is per client IP: exhausting one IP must not throttle another. */
+    @Test
+    void sync_rateLimitIsKeyedPerClientIp() {
+        when(userContext.currentMemberId()).thenReturn(42L);
+        when(ibkrService.sync(42L)).thenReturn(List.of());
+
+        for (int i = 0; i < SYNC_BUDGET_PER_MINUTE; i++) {
+            controller.sync(httpReq);
+        }
+        assertThat(controller.sync(httpReq).getStatusCode()).isEqualTo(HttpStatus.TOO_MANY_REQUESTS);
+
+        MockHttpServletRequest otherIp = new MockHttpServletRequest();
+        otherIp.setRemoteAddr("10.0.0.6");
+        assertThat(controller.sync(otherIp).getStatusCode()).isEqualTo(HttpStatus.OK);
+    }
+}

--- a/backend/src/test/java/com/picsou/ibkr/IbkrSyncServiceTest.java
+++ b/backend/src/test/java/com/picsou/ibkr/IbkrSyncServiceTest.java
@@ -1,0 +1,133 @@
+package com.picsou.ibkr;
+
+import com.picsou.adapter.OpenFigiIsinConverter;
+import com.picsou.adapter.OpenFigiIsinConverter.TickerResult;
+import com.picsou.config.CryptoEncryption;
+import com.picsou.dto.AccountResponse;
+import com.picsou.model.Account;
+import com.picsou.model.AccountHolding;
+import com.picsou.model.AccountType;
+import com.picsou.model.FamilyMember;
+import com.picsou.model.IbkrConnection;
+import com.picsou.port.IbkrFlexPort;
+import com.picsou.port.IbkrFlexPort.IbkrAccountData;
+import com.picsou.port.IbkrFlexPort.IbkrPosition;
+import com.picsou.repository.AccountHoldingRepository;
+import com.picsou.repository.AccountRepository;
+import com.picsou.repository.FamilyMemberRepository;
+import com.picsou.repository.IbkrConnectionRepository;
+import com.picsou.service.AccountService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class IbkrSyncServiceTest {
+
+    @Mock IbkrFlexPort ibkrFlexPort;
+    @Mock IbkrConnectionRepository connectionRepository;
+    @Mock AccountRepository accountRepository;
+    @Mock AccountHoldingRepository holdingRepository;
+    @Mock FamilyMemberRepository familyMemberRepository;
+    @Mock AccountService accountService;
+    @Mock OpenFigiIsinConverter isinConverter;
+    @Mock CryptoEncryption encryption;
+
+    @InjectMocks IbkrSyncService service;
+
+    /**
+     * IBKR reports cost basis in the security's native currency. The stored
+     * {@code averageBuyIn} must be converted to the account base currency (≈EUR) via
+     * {@code fxRateToBase}, and per-tax-lot ("LOT") duplicate rows must be dropped so a
+     * position is not double-counted.
+     *
+     * Scenario: 10 AAPL, costBasisPrice=150 USD, fxRateToBase=0.92, plus a LOT duplicate.
+     * Expected single holding: quantity=10, averageBuyIn = 150 * 0.92 = 138.
+     */
+    @Test
+    void sync_convertsCostBasisToBaseCurrencyAndDropsLotRows() {
+        Long memberId = 7L;
+        FamilyMember member = FamilyMember.builder().id(memberId).displayName("Owner").build();
+
+        IbkrConnection connection = IbkrConnection.builder()
+            .member(member)
+            .token("enc-token")
+            .queryId("enc-query")
+            .status("CONNECTED")
+            .build();
+        when(connectionRepository.findByMemberId(memberId)).thenReturn(Optional.of(connection));
+        when(encryption.decrypt("enc-token")).thenReturn("plain-token");
+        when(encryption.decrypt("enc-query")).thenReturn("plain-query");
+
+        IbkrPosition summary = new IbkrPosition(
+            "U123", "US0378331005", "AAPL", "APPLE INC", "USD", "STK", "SUMMARY",
+            bd("10"), bd("200"), bd("150"), bd("0.92"));
+        IbkrPosition lotDuplicate = new IbkrPosition(
+            "U123", "US0378331005", "AAPL", "APPLE INC", "USD", "STK", "LOT",
+            bd("10"), bd("200"), bd("150"), bd("0.92"));
+        IbkrAccountData accountData = new IbkrAccountData("U123", List.of(summary, lotDuplicate));
+        when(ibkrFlexPort.fetchOpenPositions("plain-token", "plain-query"))
+            .thenReturn(List.of(accountData));
+
+        when(isinConverter.resolve("US0378331005")).thenReturn(new TickerResult("AAPL", "Apple"));
+
+        when(accountRepository.findByExternalAccountIdAndMemberId("ibkr_U123", memberId))
+            .thenReturn(Optional.empty());
+        lenient().when(accountRepository.existsSoftDeletedByExternalAccountIdAndMemberId("ibkr_U123", memberId))
+            .thenReturn(false);
+        when(familyMemberRepository.findById(memberId)).thenReturn(Optional.of(member));
+        when(accountRepository.save(any(Account.class))).thenAnswer(inv -> {
+            Account a = inv.getArgument(0);
+            a.setId(1L);
+            return a;
+        });
+        when(accountService.liveBalanceEur(any(Account.class))).thenReturn(bd("1380"));
+        AccountResponse dummy = AccountResponse.from(
+            Account.builder().id(1L).name("IBKR U123").type(AccountType.COMPTE_TITRES).build(),
+            BigDecimal.ZERO);
+        when(accountService.toResponse(any(Account.class))).thenReturn(dummy);
+
+        List<AccountResponse> result = service.sync(memberId);
+
+        assertThat(result).hasSize(1);
+
+        // The LOT row must be filtered → exactly one holding saved.
+        ArgumentCaptor<AccountHolding> holdingCaptor = ArgumentCaptor.forClass(AccountHolding.class);
+        verify(holdingRepository, times(1)).save(holdingCaptor.capture());
+        AccountHolding saved = holdingCaptor.getValue();
+
+        assertThat(saved.getTicker()).isEqualTo("AAPL");
+        assertThat(saved.getQuantity()).isEqualByComparingTo("10");
+        // 150 USD × 0.92 = 138 EUR — the core currency-conversion contract.
+        assertThat(saved.getAverageBuyIn()).isEqualByComparingTo("138");
+
+        // Connection is marked freshly synced.
+        assertThat(connection.getStatus()).isEqualTo("CONNECTED");
+        assertThat(connection.getLastSyncedAt()).isNotNull();
+    }
+
+    @Test
+    void sync_withoutConnection_throws() {
+        when(connectionRepository.findByMemberId(99L)).thenReturn(Optional.empty());
+
+        org.assertj.core.api.Assertions.assertThatThrownBy(() -> service.sync(99L))
+            .isInstanceOf(com.picsou.exception.SyncException.class)
+            .hasMessageContaining("No Interactive Brokers connection");
+    }
+
+    private static BigDecimal bd(String v) { return new BigDecimal(v); }
+}

--- a/backend/src/test/java/com/picsou/ibkr/client/IbkrFlexClientTest.java
+++ b/backend/src/test/java/com/picsou/ibkr/client/IbkrFlexClientTest.java
@@ -79,8 +79,15 @@ class IbkrFlexClientTest {
         assertThat(positions).filteredOn(p -> "SUMMARY".equals(p.levelOfDetail())).hasSize(2);
     }
 
+    /**
+     * A fully liquidated portfolio is a valid FlexQueryResponse whose statement carries
+     * an empty {@code <OpenPositions/>}. The account MUST still be returned (with zero
+     * positions) so the sync purges its stale holdings — deriving accounts from
+     * {@code <OpenPosition>} rows alone made an emptied account vanish from the result
+     * and its old holdings were kept (and valued) forever.
+     */
     @Test
-    void parse_emptyPositionsYieldsNoAccounts() {
+    void parse_emptyPositionsYieldsTheAccountWithNoPositions() {
         String empty = """
             <FlexQueryResponse queryName="OpenPositions" type="AF">
               <FlexStatements count="1">
@@ -89,7 +96,11 @@ class IbkrFlexClientTest {
             </FlexQueryResponse>
             """;
 
-        assertThat(client.parseOpenPositions(empty)).isEmpty();
+        List<IbkrAccountData> accounts = client.parseOpenPositions(empty);
+
+        assertThat(accounts).hasSize(1);
+        assertThat(accounts.get(0).accountId()).isEqualTo("U1234567");
+        assertThat(accounts.get(0).positions()).isEmpty();
     }
 
     @Test

--- a/backend/src/test/java/com/picsou/ibkr/client/IbkrFlexClientTest.java
+++ b/backend/src/test/java/com/picsou/ibkr/client/IbkrFlexClientTest.java
@@ -123,4 +123,44 @@ class IbkrFlexClientTest {
         assertThat(shorty.costBasisPrice()).isNull();
         assertThat(shorty.fxRateToBase()).isNull();
     }
+
+    /**
+     * AccountInformation is an optional Flex Query section (Account ID, Account Alias,
+     * Currency) that can be enabled alongside Open Positions in the same Activity Flex
+     * Query; when present, its {@code currency} attribute is the account's IBKR base
+     * currency (plan 003 / issue B).
+     */
+    @Test
+    void parse_readsAccountInformationBaseCurrency() {
+        String xml = """
+            <FlexQueryResponse queryName="OpenPositions" type="AF">
+              <FlexStatements count="1">
+                <FlexStatement accountId="U1234567" fromDate="20260101" toDate="20260718"
+                               period="LastBusinessDay" whenGenerated="20260719;050000">
+                  <AccountInformation accountId="U1234567" currency="USD" />
+                  <OpenPositions>
+                    <OpenPosition accountId="U1234567" currency="USD" fxRateToBase="1"
+                        assetCategory="STK" symbol="AAPL" description="APPLE INC" conid="265598"
+                        isin="US0378331005" position="10" markPrice="200.00"
+                        costBasisPrice="150.00" levelOfDetail="SUMMARY" />
+                  </OpenPositions>
+                </FlexStatement>
+              </FlexStatements>
+            </FlexQueryResponse>
+            """;
+
+        List<IbkrAccountData> accounts = client.parseOpenPositions(xml);
+
+        assertThat(accounts).hasSize(1);
+        assertThat(accounts.get(0).baseCurrency()).isEqualTo("USD");
+    }
+
+    @Test
+    void parse_noAccountInformationSection_yieldsNullBaseCurrency() {
+        // The shared FIXTURE above has no AccountInformation element at all -- the
+        // common case today, since the parse must not assume the section is enabled.
+        List<IbkrAccountData> accounts = client.parseOpenPositions(FIXTURE);
+
+        assertThat(accounts.get(0).baseCurrency()).isNull();
+    }
 }

--- a/backend/src/test/java/com/picsou/ibkr/client/IbkrFlexClientTest.java
+++ b/backend/src/test/java/com/picsou/ibkr/client/IbkrFlexClientTest.java
@@ -1,0 +1,94 @@
+package com.picsou.ibkr.client;
+
+import com.picsou.port.IbkrFlexPort.IbkrAccountData;
+import com.picsou.port.IbkrFlexPort.IbkrPosition;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Parser tests for {@link IbkrFlexClient}. The fixture uses the exact IBKR Flex
+ * attribute names (validated against the reference parser github.com/csingley/ibflex),
+ * so this guards the single riskiest part of the integration: a renamed attribute would
+ * silently make holdings vanish or mis-value.
+ */
+class IbkrFlexClientTest {
+
+    private final IbkrFlexClient client = new IbkrFlexClient();
+
+    /** A realistic Open Positions FlexQueryResponse: two SUMMARY rows + one LOT duplicate. */
+    private static final String FIXTURE = """
+        <FlexQueryResponse queryName="OpenPositions" type="AF">
+          <FlexStatements count="1">
+            <FlexStatement accountId="U1234567" fromDate="20260101" toDate="20260718"
+                           period="LastBusinessDay" whenGenerated="20260719;050000">
+              <OpenPositions>
+                <OpenPosition accountId="U1234567" currency="USD" fxRateToBase="0.92"
+                    assetCategory="STK" symbol="AAPL" description="APPLE INC" conid="265598"
+                    isin="US0378331005" position="10" markPrice="200.00"
+                    costBasisPrice="150.00" costBasisMoney="1500.00" levelOfDetail="SUMMARY" />
+                <OpenPosition accountId="U1234567" currency="EUR" fxRateToBase="1"
+                    assetCategory="ETF" symbol="IWDA" description="ISHARES CORE MSCI WORLD"
+                    conid="100292928" isin="IE00B4L5Y983" position="5" markPrice="90.00"
+                    costBasisPrice="80.00" costBasisMoney="400.00" levelOfDetail="SUMMARY" />
+                <OpenPosition accountId="U1234567" currency="USD" fxRateToBase="0.92"
+                    assetCategory="STK" symbol="AAPL" description="APPLE INC" conid="265598"
+                    isin="US0378331005" position="10" markPrice="200.00"
+                    costBasisPrice="150.00" levelOfDetail="LOT" />
+              </OpenPositions>
+            </FlexStatement>
+          </FlexStatements>
+        </FlexQueryResponse>
+        """;
+
+    @Test
+    void parse_groupsPositionsByAccount() {
+        List<IbkrAccountData> accounts = client.parseOpenPositions(FIXTURE);
+
+        assertThat(accounts).hasSize(1);
+        assertThat(accounts.get(0).accountId()).isEqualTo("U1234567");
+        // The parser is intentionally non-filtering — SUMMARY + LOT are all returned here;
+        // dropping LOT rows is the sync service's job.
+        assertThat(accounts.get(0).positions()).hasSize(3);
+    }
+
+    @Test
+    void parse_readsAllAttributesOfAPosition() {
+        IbkrPosition aapl = client.parseOpenPositions(FIXTURE).get(0).positions().get(0);
+
+        assertThat(aapl.accountId()).isEqualTo("U1234567");
+        assertThat(aapl.isin()).isEqualTo("US0378331005");
+        assertThat(aapl.symbol()).isEqualTo("AAPL");
+        assertThat(aapl.description()).isEqualTo("APPLE INC");
+        assertThat(aapl.currency()).isEqualTo("USD");
+        assertThat(aapl.assetCategory()).isEqualTo("STK");
+        assertThat(aapl.levelOfDetail()).isEqualTo("SUMMARY");
+        assertThat(aapl.position()).isEqualByComparingTo("10");
+        assertThat(aapl.markPrice()).isEqualByComparingTo("200.00");
+        assertThat(aapl.costBasisPrice()).isEqualByComparingTo("150.00");
+        assertThat(aapl.fxRateToBase()).isEqualByComparingTo("0.92");
+    }
+
+    @Test
+    void parse_distinguishesLotRowsFromSummary() {
+        List<IbkrPosition> positions = client.parseOpenPositions(FIXTURE).get(0).positions();
+
+        assertThat(positions).filteredOn(p -> "LOT".equals(p.levelOfDetail())).hasSize(1);
+        assertThat(positions).filteredOn(p -> "SUMMARY".equals(p.levelOfDetail())).hasSize(2);
+    }
+
+    @Test
+    void parse_emptyPositionsYieldsNoAccounts() {
+        String empty = """
+            <FlexQueryResponse queryName="OpenPositions" type="AF">
+              <FlexStatements count="1">
+                <FlexStatement accountId="U1234567"><OpenPositions/></FlexStatement>
+              </FlexStatements>
+            </FlexQueryResponse>
+            """;
+
+        assertThat(client.parseOpenPositions(empty)).isEmpty();
+    }
+}

--- a/backend/src/test/java/com/picsou/ibkr/client/IbkrFlexClientTest.java
+++ b/backend/src/test/java/com/picsou/ibkr/client/IbkrFlexClientTest.java
@@ -1,5 +1,6 @@
 package com.picsou.ibkr.client;
 
+import com.picsou.exception.SyncException;
 import com.picsou.port.IbkrFlexPort.IbkrAccountData;
 import com.picsou.port.IbkrFlexPort.IbkrPosition;
 import org.junit.jupiter.api.Test;
@@ -7,6 +8,7 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Parser tests for {@link IbkrFlexClient}. The fixture uses the exact IBKR Flex
@@ -30,7 +32,7 @@ class IbkrFlexClientTest {
                     isin="US0378331005" position="10" markPrice="200.00"
                     costBasisPrice="150.00" costBasisMoney="1500.00" levelOfDetail="SUMMARY" />
                 <OpenPosition accountId="U1234567" currency="EUR" fxRateToBase="1"
-                    assetCategory="ETF" symbol="IWDA" description="ISHARES CORE MSCI WORLD"
+                    assetCategory="STK" symbol="IWDA" description="ISHARES CORE MSCI WORLD"
                     conid="100292928" isin="IE00B4L5Y983" position="5" markPrice="90.00"
                     costBasisPrice="80.00" costBasisMoney="400.00" levelOfDetail="SUMMARY" />
                 <OpenPosition accountId="U1234567" currency="USD" fxRateToBase="0.92"
@@ -101,6 +103,29 @@ class IbkrFlexClientTest {
         assertThat(accounts).hasSize(1);
         assertThat(accounts.get(0).accountId()).isEqualTo("U1234567");
         assertThat(accounts.get(0).positions()).isEmpty();
+    }
+
+    /**
+     * A multi-day query ("Breakout by Day" / date-ranged period) emits one FlexStatement
+     * PER DAY for the same account, each with a full positions snapshot — merging them
+     * would multiply every quantity by the number of days. The parser must refuse with
+     * an actionable message instead of silently inflating the portfolio.
+     */
+    @Test
+    void parse_multipleStatementsForSameAccount_throwsActionable() {
+        String breakout = """
+            <FlexQueryResponse queryName="OpenPositions" type="AF">
+              <FlexStatements count="2">
+                <FlexStatement accountId="U1234567"><OpenPositions/></FlexStatement>
+                <FlexStatement accountId="U1234567"><OpenPositions/></FlexStatement>
+              </FlexStatements>
+            </FlexQueryResponse>
+            """;
+
+        assertThatThrownBy(() -> client.parseOpenPositions(breakout))
+            .isInstanceOf(SyncException.class)
+            .hasMessageContaining("U1234567")
+            .hasMessageContaining("Last Business Day");
     }
 
     @Test

--- a/backend/src/test/java/com/picsou/ibkr/client/IbkrFlexClientTest.java
+++ b/backend/src/test/java/com/picsou/ibkr/client/IbkrFlexClientTest.java
@@ -91,4 +91,36 @@ class IbkrFlexClientTest {
 
         assertThat(client.parseOpenPositions(empty)).isEmpty();
     }
+
+    @Test
+    void parse_groupsMultipleAccountsAndReadsShortAndSparsePositions() {
+        // Two account ids in one statement; a short (negative) position; and a row
+        // missing the optional isin / costBasisPrice / fxRateToBase attributes.
+        String xml = """
+            <FlexQueryResponse queryName="OpenPositions" type="AF">
+              <FlexStatements count="1">
+                <FlexStatement accountId="U1">
+                  <OpenPositions>
+                    <OpenPosition accountId="U1" currency="USD" fxRateToBase="0.90" assetCategory="STK"
+                        symbol="AAPL" isin="US0378331005" position="10" markPrice="200"
+                        costBasisPrice="150" levelOfDetail="SUMMARY" />
+                    <OpenPosition accountId="U2" currency="EUR" assetCategory="STK"
+                        symbol="SHORTY" position="-5" markPrice="12" levelOfDetail="SUMMARY" />
+                  </OpenPositions>
+                </FlexStatement>
+              </FlexStatements>
+            </FlexQueryResponse>
+            """;
+
+        List<IbkrAccountData> accounts = client.parseOpenPositions(xml);
+
+        assertThat(accounts).hasSize(2);
+        assertThat(accounts).extracting(IbkrAccountData::accountId).containsExactly("U1", "U2");
+
+        IbkrPosition shorty = accounts.get(1).positions().get(0);
+        assertThat(shorty.position()).isEqualByComparingTo("-5");   // short parsed as negative
+        assertThat(shorty.isin()).isNull();                          // missing → null
+        assertThat(shorty.costBasisPrice()).isNull();
+        assertThat(shorty.fxRateToBase()).isNull();
+    }
 }

--- a/backend/src/test/java/com/picsou/service/HoldingDedupTest.java
+++ b/backend/src/test/java/com/picsou/service/HoldingDedupTest.java
@@ -56,15 +56,23 @@ class HoldingDedupTest {
         assertThat(merged.averageBuyIn()).isEqualByComparingTo("12.00000000");
     }
 
+    /**
+     * Superseded by plan 003 (issue D): the merge used to return {@code prev} unchanged
+     * (a stale non-zero position) whenever the total quantity was zero, purely to dodge
+     * the divide-by-zero. Now that IBKR positions can be signed, a zero net quantity is
+     * a real, common outcome (a covered short) and must produce a flat sentinel instead
+     * of resurrecting whichever side happened to be "prev".
+     */
     @Test
-    void vwapMerge_returnsPrevWhenTotalQuantityZero() {
-        // Cannot divide by zero — guard returns prev unchanged
+    void vwapMerge_totalQuantityZero_returnsZeroQuantitySentinel() {
+        // Two already-flat aggregates merging: still zero, not a divide-by-zero crash.
         HoldingAgg a = new HoldingAgg(BigDecimal.ZERO, bd("10"), bd("100"), "A");
         HoldingAgg b = new HoldingAgg(BigDecimal.ZERO, bd("20"), bd("110"), "B");
 
         HoldingAgg merged = HoldingDedup.vwapMerge(a, b);
 
-        assertThat(merged).isSameAs(a);
+        assertThat(merged.quantity()).isEqualByComparingTo("0");
+        assertThat(merged.averageBuyIn()).isNull();
     }
 
     @Test
@@ -82,6 +90,56 @@ class HoldingDedupTest {
         HoldingAgg b = new HoldingAgg(bd("1"), bd("1"), bd("42"), "B");
 
         assertThat(HoldingDedup.vwapMerge(a, b).currentPrice()).isEqualByComparingTo("42");
+    }
+
+    // -- Plan 003 / issue D: sign-aware merge (IBKR can carry short quantities) --------
+
+    @Test
+    void vwapMerge_oppositeSignsNettingToZero_returnsZeroQuantitySentinel() {
+        HoldingAgg longLeg = new HoldingAgg(bd("40"), bd("10"), bd("12"), "Acme");
+        HoldingAgg shortLeg = new HoldingAgg(bd("-40"), bd("15"), bd("12"), "Acme");
+
+        HoldingAgg merged = HoldingDedup.vwapMerge(longLeg, shortLeg);
+
+        assertThat(merged.quantity()).isEqualByComparingTo("0");
+        assertThat(merged.averageBuyIn()).isNull();
+    }
+
+    @Test
+    void vwapMerge_oppositeSignsNonZeroNet_netsQuantityAndKeepsLargerSideAverage() {
+        // +100 @ 10 vs -40 @ 20 -> net 60, average from the larger-|q| side (the +100 @ 10 leg).
+        HoldingAgg big = new HoldingAgg(bd("100"), bd("10"), bd("12"), "Acme");
+        HoldingAgg small = new HoldingAgg(bd("-40"), bd("20"), bd("12"), "Acme");
+
+        HoldingAgg merged = HoldingDedup.vwapMerge(big, small);
+
+        assertThat(merged.quantity()).isEqualByComparingTo("60");
+        assertThat(merged.averageBuyIn()).isEqualByComparingTo("10");
+    }
+
+    @Test
+    void vwapMerge_oppositeSignsNonZeroNet_isOrderIndependent() {
+        // Same scenario as above with the arguments swapped: the larger-|q| side's
+        // average must win regardless of which argument is "prev" and which is "next".
+        HoldingAgg big = new HoldingAgg(bd("100"), bd("10"), bd("12"), "Acme");
+        HoldingAgg small = new HoldingAgg(bd("-40"), bd("20"), bd("12"), "Acme");
+
+        HoldingAgg merged = HoldingDedup.vwapMerge(small, big);
+
+        assertThat(merged.quantity()).isEqualByComparingTo("60");
+        assertThat(merged.averageBuyIn()).isEqualByComparingTo("10");
+    }
+
+    @Test
+    void vwapMerge_sameSigns_unchangedVwapRegression() {
+        // +10 @ 5 and +30 @ 9 -> (10*5 + 30*9) / 40 = 320/40 = 8.
+        HoldingAgg a = new HoldingAgg(bd("10"), bd("5"), bd("100"), "Acme");
+        HoldingAgg b = new HoldingAgg(bd("30"), bd("9"), bd("100"), "Acme");
+
+        HoldingAgg merged = HoldingDedup.vwapMerge(a, b);
+
+        assertThat(merged.quantity()).isEqualByComparingTo("40");
+        assertThat(merged.averageBuyIn()).isEqualByComparingTo("8");
     }
 
     private static BigDecimal bd(String v) { return new BigDecimal(v); }

--- a/backend/src/test/java/com/picsou/service/IbkrStatusWriterTest.java
+++ b/backend/src/test/java/com/picsou/service/IbkrStatusWriterTest.java
@@ -1,0 +1,101 @@
+package com.picsou.service;
+
+import com.picsou.model.FamilyMember;
+import com.picsou.model.IbkrConnection;
+import com.picsou.repository.FamilyMemberRepository;
+import com.picsou.repository.IbkrConnectionRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Pins the one property {@link IbkrStatusWriter} exists for: the ERROR status write
+ * commits in its own REQUIRES_NEW transaction, so it survives the caller's rollback.
+ *
+ * <p>{@code IbkrSyncService.syncWithConnection} calls {@code markError} and then rethrows,
+ * which marks the surrounding {@code @Transactional} sync rollback-only on the manual path.
+ * A Mockito test can only verify that {@code markError} was <em>invoked</em>
+ * ({@code IbkrSyncServiceTest}); this slice test proves the write actually <em>persists</em>
+ * across that rollback — the exact behavior a naïve in-transaction save gets wrong.
+ *
+ * <p>Flyway is disabled and the schema hand-rolled (H2 cannot run the PostgreSQL-flavoured
+ * migrations — docs/conventions/testing.md). {@code @Transactional(NOT_SUPPORTED)} switches
+ * off @DataJpaTest's test-wrapping transaction so the caller/inner transaction pair is
+ * controlled explicitly with a {@link TransactionTemplate}, like production does via AOP.
+ */
+@DataJpaTest
+@Import(IbkrStatusWriter.class)
+@Transactional(propagation = Propagation.NOT_SUPPORTED)
+@TestPropertySource(properties = {
+    "spring.flyway.enabled=false",
+    "spring.jpa.hibernate.ddl-auto=none"
+})
+@Sql("classpath:sql/ibkr-status-writer-test-schema.sql")
+class IbkrStatusWriterTest {
+
+    @Autowired IbkrStatusWriter statusWriter;
+    @Autowired IbkrConnectionRepository connectionRepository;
+    @Autowired FamilyMemberRepository familyMemberRepository;
+    @Autowired PlatformTransactionManager transactionManager;
+
+    @Test
+    void markError_commitsEvenWhenTheCallingTransactionRollsBack() {
+        TransactionTemplate tx = new TransactionTemplate(transactionManager);
+
+        Long connectionId = tx.execute(status -> {
+            FamilyMember member = familyMemberRepository.save(
+                FamilyMember.builder().displayName("Owner").build());
+            return connectionRepository.save(IbkrConnection.builder()
+                .member(member)
+                .token("enc-token")
+                .queryId("enc-query")
+                .build()).getId();
+        });
+        assertThat(connectionId).isNotNull();
+
+        // Caller transaction: mark ERROR through the REQUIRES_NEW bean, then fail —
+        // exactly the manual-sync shape (markError, rethrow, outer rollback).
+        assertThatThrownBy(() -> tx.execute(status -> {
+            statusWriter.markError(connectionId);
+            throw new IllegalStateException("simulated sync failure after markError");
+        })).isInstanceOf(IllegalStateException.class);
+
+        // The outer transaction rolled back; the REQUIRES_NEW write must have survived.
+        assertThat(connectionRepository.findById(connectionId).orElseThrow().getStatus())
+            .isEqualTo("ERROR");
+    }
+
+    /** Control case: without the failure, the caller's own writes commit normally. */
+    @Test
+    void markError_isVisibleAfterAPlainCommit() {
+        TransactionTemplate tx = new TransactionTemplate(transactionManager);
+
+        Long connectionId = tx.execute(status -> {
+            FamilyMember member = familyMemberRepository.save(
+                FamilyMember.builder().displayName("Owner").build());
+            return connectionRepository.save(IbkrConnection.builder()
+                .member(member)
+                .token("enc-token")
+                .queryId("enc-query")
+                .build()).getId();
+        });
+
+        tx.execute(status -> {
+            statusWriter.markError(connectionId);
+            return null;
+        });
+
+        assertThat(connectionRepository.findById(connectionId).orElseThrow().getStatus())
+            .isEqualTo("ERROR");
+    }
+}

--- a/backend/src/test/java/com/picsou/service/IbkrSyncServiceTest.java
+++ b/backend/src/test/java/com/picsou/service/IbkrSyncServiceTest.java
@@ -166,6 +166,53 @@ class IbkrSyncServiceTest {
     }
 
     /**
+     * A credential that no longer decrypts (rotated CRYPTO_ENCRYPTION_KEY, corrupted row)
+     * must not bubble up as a raw crypto RuntimeException: the user gets an actionable
+     * SyncException telling them to reconnect, and the connection status flips to ERROR
+     * exactly like any other sync failure.
+     */
+    @Test
+    void sync_whenDecryptFails_marksErrorAndThrowsActionableSyncException() {
+        Long memberId = 7L;
+        FamilyMember member = FamilyMember.builder().id(memberId).displayName("Owner").build();
+        IbkrConnection connection = IbkrConnection.builder()
+            .id(42L)
+            .member(member).token("enc-token").queryId("enc-query").status("CONNECTED").build();
+        when(connectionRepository.findByMemberId(memberId)).thenReturn(Optional.of(connection));
+        when(encryption.decrypt("enc-token")).thenThrow(new IllegalStateException("bad key"));
+
+        assertThatThrownBy(() -> service.sync(memberId))
+            .isInstanceOf(com.picsou.exception.SyncException.class)
+            .hasMessageContaining("decrypt")
+            .hasMessageContaining("reconnect");
+
+        verify(statusWriter, times(1)).markError(42L);
+        verifyNoInteractions(ibkrFlexPort);
+    }
+
+    /**
+     * The read-only status endpoint must never 500 because a stored token stopped
+     * decrypting: it degrades to connected=true with an ERROR status and a fully
+     * masked token, so the Sync page can tell the user to reconnect.
+     */
+    @Test
+    void getConnectionStatus_whenDecryptFails_reportsErrorInsteadOfThrowing() {
+        Long memberId = 7L;
+        FamilyMember member = FamilyMember.builder().id(memberId).displayName("Owner").build();
+        IbkrConnection connection = IbkrConnection.builder()
+            .id(42L)
+            .member(member).token("enc-token").queryId("enc-query").status("CONNECTED").build();
+        when(connectionRepository.findByMemberId(memberId)).thenReturn(Optional.of(connection));
+        when(encryption.decrypt("enc-token")).thenThrow(new IllegalStateException("bad key"));
+
+        var status = service.getConnectionStatus(memberId);
+
+        assertThat(status.connected()).isTrue();
+        assertThat(status.status()).isEqualTo("ERROR");
+        assertThat(status.maskedToken()).doesNotContain("enc-token");
+    }
+
+    /**
      * Hardening against real-world Flex variety in one account: an ISIN that OpenFIGI
      * resolves, an ISIN that OpenFIGI misses (→ symbol fallback), a symbol-only line, a
      * cash line, a zero-quantity line, and an over-long derivative symbol. Only the three
@@ -323,6 +370,9 @@ class IbkrSyncServiceTest {
 
         verify(holdingRepository, never()).save(any(AccountHolding.class));
         verify(accountRepository, never()).save(any(Account.class));
+        // The guard failure is a sync failure like any other: the user must see ERROR
+        // in the UI, on the scheduled path too (where the exception is swallowed).
+        verify(statusWriter, times(1)).markError(any());
     }
 
     /** B: an explicit "EUR" base currency syncs exactly like today (no behavior change). */

--- a/backend/src/test/java/com/picsou/service/IbkrSyncServiceTest.java
+++ b/backend/src/test/java/com/picsou/service/IbkrSyncServiceTest.java
@@ -296,6 +296,64 @@ class IbkrSyncServiceTest {
         verify(holdingRepository, never()).save(any(AccountHolding.class));
     }
 
+    /**
+     * B: a non-EUR IBKR account base currency must fail that account's sync rather than
+     * silently persist a wrong-currency cost basis (averageBuyIn is converted via
+     * fxRateToBase into the account's base currency, not necessarily EUR). No holdings
+     * and no account row are persisted for it.
+     */
+    @Test
+    void sync_nonEurBaseCurrency_throwsAndPersistsNoHoldings() {
+        Long memberId = 7L;
+        FamilyMember member = FamilyMember.builder().id(memberId).displayName("Owner").build();
+        IbkrConnection connection = IbkrConnection.builder()
+            .member(member).token("enc-token").queryId("enc-query").status("CONNECTED").build();
+        when(connectionRepository.findByMemberId(memberId)).thenReturn(Optional.of(connection));
+        when(encryption.decrypt("enc-token")).thenReturn("plain-token");
+        when(encryption.decrypt("enc-query")).thenReturn("plain-query");
+
+        IbkrPosition aapl = pos("US0378331005", "AAPL", "STK", bd("10"), bd("150"), bd("1"));
+        IbkrAccountData accountData = new IbkrAccountData("U1", List.of(aapl), "USD");
+        when(ibkrFlexPort.fetchOpenPositions("plain-token", "plain-query")).thenReturn(List.of(accountData));
+
+        assertThatThrownBy(() -> service.sync(memberId))
+            .isInstanceOf(com.picsou.exception.SyncException.class)
+            .hasMessageContaining("IBKR account base currency is USD")
+            .hasMessageContaining("EUR-based accounts");
+
+        verify(holdingRepository, never()).save(any(AccountHolding.class));
+        verify(accountRepository, never()).save(any(Account.class));
+    }
+
+    /** B: an explicit "EUR" base currency syncs exactly like today (no behavior change). */
+    @Test
+    void sync_eurBaseCurrency_syncsNormally() {
+        Long memberId = 7L;
+        FamilyMember member = FamilyMember.builder().id(memberId).displayName("Owner").build();
+        IbkrConnection connection = IbkrConnection.builder()
+            .member(member).token("enc-token").queryId("enc-query").status("CONNECTED").build();
+        when(connectionRepository.findByMemberId(memberId)).thenReturn(Optional.of(connection));
+        when(encryption.decrypt("enc-token")).thenReturn("plain-token");
+        when(encryption.decrypt("enc-query")).thenReturn("plain-query");
+
+        IbkrPosition aapl = pos("US0378331005", "AAPL", "STK", bd("10"), bd("150"), bd("1"));
+        IbkrAccountData accountData = new IbkrAccountData("U1", List.of(aapl), "EUR");
+        when(ibkrFlexPort.fetchOpenPositions("plain-token", "plain-query")).thenReturn(List.of(accountData));
+
+        when(isinConverter.resolve("US0378331005")).thenReturn(new TickerResult("AAPL", "Apple"));
+        when(accountRepository.findByExternalAccountIdAndMemberId("ibkr_U1", memberId)).thenReturn(Optional.empty());
+        lenient().when(accountRepository.existsSoftDeletedByExternalAccountIdAndMemberId("ibkr_U1", memberId)).thenReturn(false);
+        when(familyMemberRepository.findById(memberId)).thenReturn(Optional.of(member));
+        when(accountRepository.save(any(Account.class))).thenAnswer(inv -> { Account a = inv.getArgument(0); a.setId(1L); return a; });
+        when(accountService.liveBalanceEur(any(Account.class))).thenReturn(bd("0"));
+        when(accountService.toResponse(any(Account.class))).thenReturn(
+            AccountResponse.from(Account.builder().id(1L).name("IBKR U1").type(AccountType.COMPTE_TITRES).build(), BigDecimal.ZERO));
+
+        service.sync(memberId);
+
+        verify(holdingRepository, times(1)).save(any(AccountHolding.class));
+    }
+
     /** Convenience builder for an account "U1" SUMMARY position. */
     private static IbkrPosition pos(String isin, String symbol, String assetCategory,
                                     BigDecimal position, BigDecimal costBasisPrice, BigDecimal fxRateToBase) {

--- a/backend/src/test/java/com/picsou/service/IbkrSyncServiceTest.java
+++ b/backend/src/test/java/com/picsou/service/IbkrSyncServiceTest.java
@@ -243,7 +243,8 @@ class IbkrSyncServiceTest {
      * resolves, an ISIN that OpenFIGI misses (→ symbol fallback), a symbol-only line, a
      * cash line, a zero-quantity line, and an over-long derivative symbol. Only the three
      * price-able equities become holdings; cash / zero-qty / over-long are dropped, and a
-     * null fxRateToBase leaves the cost basis unscaled.
+     * null fxRateToBase on a NON-EUR position leaves the cost basis unknown (null) —
+     * treating the missing rate as 1 would store a USD price as if it were EUR.
      */
     @Test
     void sync_handlesMixedAssetClassesAndSkipsUnsupportedRows() {
@@ -288,8 +289,8 @@ class IbkrSyncServiceTest {
         assertThat(byTicker.keySet()).containsExactlyInAnyOrder("AAPL", "TSLA", "PLTR");
         // ISIN hit: 150 × 0.90 = 135 EUR cost basis.
         assertThat(byTicker.get("AAPL").getAverageBuyIn()).isEqualByComparingTo("135");
-        // No fxRateToBase → cost basis left unscaled (× 1).
-        assertThat(byTicker.get("PLTR").getAverageBuyIn()).isEqualByComparingTo("40");
+        // No fxRateToBase on a USD position → cost basis is unknown, not "40 EUR".
+        assertThat(byTicker.get("PLTR").getAverageBuyIn()).isNull();
     }
 
     /**

--- a/backend/src/test/java/com/picsou/service/IbkrSyncServiceTest.java
+++ b/backend/src/test/java/com/picsou/service/IbkrSyncServiceTest.java
@@ -28,10 +28,13 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -45,6 +48,7 @@ class IbkrSyncServiceTest {
     @Mock AccountService accountService;
     @Mock OpenFigiIsinConverter isinConverter;
     @Mock CryptoEncryption encryption;
+    @Mock IbkrStatusWriter statusWriter;
 
     @InjectMocks IbkrSyncService service;
 
@@ -117,6 +121,8 @@ class IbkrSyncServiceTest {
         // Connection is marked freshly synced.
         assertThat(connection.getStatus()).isEqualTo("CONNECTED");
         assertThat(connection.getLastSyncedAt()).isNotNull();
+        // Happy path never touches the error-status writer.
+        verifyNoInteractions(statusWriter);
     }
 
     @Test
@@ -126,6 +132,37 @@ class IbkrSyncServiceTest {
         org.assertj.core.api.Assertions.assertThatThrownBy(() -> service.sync(99L))
             .isInstanceOf(com.picsou.exception.SyncException.class)
             .hasMessageContaining("No Interactive Brokers connection");
+    }
+
+    /**
+     * When the Flex port throws (network error, expired token, ...), the manual sync
+     * path must still end up with the connection's status persisted as ERROR. The
+     * naive fix (save inside the @Transactional method, then rethrow) does not survive
+     * on the manual path: the rethrow marks the transaction rollback-only and the save
+     * is lost. {@link IbkrStatusWriter} runs in its own REQUIRES_NEW transaction instead
+     * — this test pins that it is invoked with the right connection id, and that the
+     * original exception still propagates to the caller (the controller surfaces it).
+     */
+    @Test
+    void sync_whenPortThrows_marksErrorViaStatusWriterAndPropagates() {
+        Long memberId = 7L;
+        FamilyMember member = FamilyMember.builder().id(memberId).displayName("Owner").build();
+        IbkrConnection connection = IbkrConnection.builder()
+            .id(42L)
+            .member(member).token("enc-token").queryId("enc-query").status("CONNECTED").build();
+        when(connectionRepository.findByMemberId(memberId)).thenReturn(Optional.of(connection));
+        when(encryption.decrypt("enc-token")).thenReturn("plain-token");
+        when(encryption.decrypt("enc-query")).thenReturn("plain-query");
+
+        RuntimeException boom = new RuntimeException("IBKR: token expired");
+        when(ibkrFlexPort.fetchOpenPositions("plain-token", "plain-query")).thenThrow(boom);
+
+        assertThatThrownBy(() -> service.sync(memberId)).isSameAs(boom);
+
+        verify(statusWriter, times(1)).markError(42L);
+        // The old (broken) approach saved through connectionRepository directly inside
+        // the failing transaction; that must no longer happen on this path.
+        verify(connectionRepository, never()).save(any(IbkrConnection.class));
     }
 
     /**

--- a/backend/src/test/java/com/picsou/service/IbkrSyncServiceTest.java
+++ b/backend/src/test/java/com/picsou/service/IbkrSyncServiceTest.java
@@ -219,6 +219,46 @@ class IbkrSyncServiceTest {
         assertThat(byTicker.get("PLTR").getAverageBuyIn()).isEqualByComparingTo("40");
     }
 
+    /**
+     * Derivatives allowlist: an OPT position must never become a holding, even with a
+     * short OCC symbol ("SPY 240119C00470000" is 19 chars, well under the 30-char
+     * length guard that used to be the only defense) — same for FUT. A position with no
+     * assetCategory attribute at all is kept (conservative default for statements that
+     * omit the field, unchanged from today's behavior).
+     */
+    @Test
+    void sync_skipsDerivativeAssetCategoriesButKeepsAbsentCategory() {
+        Long memberId = 7L;
+        FamilyMember member = FamilyMember.builder().id(memberId).displayName("Owner").build();
+        IbkrConnection connection = IbkrConnection.builder()
+            .member(member).token("enc-token").queryId("enc-query").status("CONNECTED").build();
+        when(connectionRepository.findByMemberId(memberId)).thenReturn(Optional.of(connection));
+        when(encryption.decrypt("enc-token")).thenReturn("plain-token");
+        when(encryption.decrypt("enc-query")).thenReturn("plain-query");
+
+        IbkrPosition option = pos(null, "SPY 240119C00470000", "OPT", bd("1"), bd("5"), bd("1"));
+        IbkrPosition future = pos(null, "ES FUT", "FUT", bd("1"), bd("100"), bd("1"));
+        IbkrPosition absentCategory = pos(null, "PLTR", null, bd("8"), bd("40"), bd("1"));
+        when(ibkrFlexPort.fetchOpenPositions("plain-token", "plain-query"))
+            .thenReturn(List.of(new IbkrAccountData("U1", List.of(option, future, absentCategory))));
+
+        when(accountRepository.findByExternalAccountIdAndMemberId("ibkr_U1", memberId)).thenReturn(Optional.empty());
+        lenient().when(accountRepository.existsSoftDeletedByExternalAccountIdAndMemberId("ibkr_U1", memberId)).thenReturn(false);
+        when(familyMemberRepository.findById(memberId)).thenReturn(Optional.of(member));
+        when(accountRepository.save(any(Account.class))).thenAnswer(inv -> { Account a = inv.getArgument(0); a.setId(1L); return a; });
+        when(accountService.liveBalanceEur(any(Account.class))).thenReturn(bd("0"));
+        when(accountService.toResponse(any(Account.class))).thenReturn(
+            AccountResponse.from(Account.builder().id(1L).name("IBKR U1").type(AccountType.COMPTE_TITRES).build(), BigDecimal.ZERO));
+
+        service.sync(memberId);
+
+        // Only the absent-category row becomes a holding; OPT and FUT are skipped
+        // (asserted via the no-holding outcome, not by capturing the WARN log).
+        ArgumentCaptor<AccountHolding> captor = ArgumentCaptor.forClass(AccountHolding.class);
+        verify(holdingRepository, times(1)).save(captor.capture());
+        assertThat(captor.getValue().getTicker()).isEqualTo("PLTR");
+    }
+
     /** Convenience builder for an account "U1" SUMMARY position. */
     private static IbkrPosition pos(String isin, String symbol, String assetCategory,
                                     BigDecimal position, BigDecimal costBasisPrice, BigDecimal fxRateToBase) {

--- a/backend/src/test/java/com/picsou/service/IbkrSyncServiceTest.java
+++ b/backend/src/test/java/com/picsou/service/IbkrSyncServiceTest.java
@@ -476,6 +476,44 @@ class IbkrSyncServiceTest {
         verify(holdingRepository, times(1)).save(any(AccountHolding.class));
     }
 
+    /**
+     * A member who deleted their IBKR account must not have it silently resurrected by
+     * the next daily sync. When the account is absent but a soft-deleted row exists, that
+     * account is skipped entirely — no account row, no holdings — yet the sync still
+     * completes normally and leaves the connection CONNECTED (a deliberate skip is not a
+     * failure). Every other test stubs the soft-delete check to false, so this is the
+     * only one that exercises the guard branch.
+     */
+    @Test
+    void sync_softDeletedAccount_isSkippedButConnectionStaysConnected() {
+        Long memberId = 7L;
+        FamilyMember member = FamilyMember.builder().id(memberId).displayName("Owner").build();
+        IbkrConnection connection = IbkrConnection.builder()
+            .member(member).token("enc-token").queryId("enc-query").status("CONNECTED").build();
+        when(connectionRepository.findByMemberId(memberId)).thenReturn(Optional.of(connection));
+        when(encryption.decrypt("enc-token")).thenReturn("plain-token");
+        when(encryption.decrypt("enc-query")).thenReturn("plain-query");
+
+        IbkrPosition aapl = pos("US0378331005", "AAPL", "STK", bd("10"), bd("150"), bd("1"));
+        when(ibkrFlexPort.fetchOpenPositions("plain-token", "plain-query"))
+            .thenReturn(List.of(new IbkrAccountData("U1", List.of(aapl))));
+
+        when(accountRepository.findByExternalAccountIdAndMemberId("ibkr_U1", memberId))
+            .thenReturn(Optional.empty());
+        when(accountRepository.existsSoftDeletedByExternalAccountIdAndMemberId("ibkr_U1", memberId))
+            .thenReturn(true);
+
+        List<AccountResponse> result = service.sync(memberId);
+
+        assertThat(result).isEmpty();
+        verify(accountRepository, never()).save(any(Account.class));
+        verify(holdingRepository, never()).save(any(AccountHolding.class));
+        // Deliberate skip, not a failure: connection is left healthy and freshly synced.
+        assertThat(connection.getStatus()).isEqualTo("CONNECTED");
+        assertThat(connection.getLastSyncedAt()).isNotNull();
+        verifyNoInteractions(statusWriter);
+    }
+
     // ─── resyncIfConnected (scheduler entry point) ───────────────────────────
     // NB: these Mockito tests cover the in-method swallowing only. The proxy-level
     // UnexpectedRollbackException (rollback-only marked through a repository proxy,

--- a/backend/src/test/java/com/picsou/service/IbkrSyncServiceTest.java
+++ b/backend/src/test/java/com/picsou/service/IbkrSyncServiceTest.java
@@ -125,6 +125,30 @@ class IbkrSyncServiceTest {
         verifyNoInteractions(statusWriter);
     }
 
+    /**
+     * Positive connect() path: credentials are trimmed, encrypted before storage, and the
+     * connection lands with status CONNECTED — nothing plaintext ever reaches the repository.
+     */
+    @Test
+    void connect_encryptsTrimmedCredentials_andStoresConnectedConnection() {
+        Long memberId = 7L;
+        FamilyMember member = FamilyMember.builder().id(memberId).displayName("Owner").build();
+        when(familyMemberRepository.findById(memberId)).thenReturn(Optional.of(member));
+        when(connectionRepository.findByMemberId(memberId)).thenReturn(Optional.empty());
+        when(encryption.encrypt("flex-token")).thenReturn("enc-token");
+        when(encryption.encrypt("1234567")).thenReturn("enc-query");
+
+        service.connect("  flex-token  ", " 1234567 ", memberId);
+
+        ArgumentCaptor<IbkrConnection> captor = ArgumentCaptor.forClass(IbkrConnection.class);
+        verify(connectionRepository).save(captor.capture());
+        IbkrConnection saved = captor.getValue();
+        assertThat(saved.getToken()).isEqualTo("enc-token");
+        assertThat(saved.getQueryId()).isEqualTo("enc-query");
+        assertThat(saved.getStatus()).isEqualTo("CONNECTED");
+        assertThat(saved.getMember()).isSameAs(member);
+    }
+
     @Test
     void sync_withoutConnection_throws() {
         when(connectionRepository.findByMemberId(99L)).thenReturn(Optional.empty());

--- a/backend/src/test/java/com/picsou/service/IbkrSyncServiceTest.java
+++ b/backend/src/test/java/com/picsou/service/IbkrSyncServiceTest.java
@@ -128,5 +128,66 @@ class IbkrSyncServiceTest {
             .hasMessageContaining("No Interactive Brokers connection");
     }
 
+    /**
+     * Hardening against real-world Flex variety in one account: an ISIN that OpenFIGI
+     * resolves, an ISIN that OpenFIGI misses (→ symbol fallback), a symbol-only line, a
+     * cash line, a zero-quantity line, and an over-long derivative symbol. Only the three
+     * price-able equities become holdings; cash / zero-qty / over-long are dropped, and a
+     * null fxRateToBase leaves the cost basis unscaled.
+     */
+    @Test
+    void sync_handlesMixedAssetClassesAndSkipsUnsupportedRows() {
+        Long memberId = 7L;
+        FamilyMember member = FamilyMember.builder().id(memberId).displayName("Owner").build();
+        IbkrConnection connection = IbkrConnection.builder()
+            .member(member).token("enc-token").queryId("enc-query").status("CONNECTED").build();
+        when(connectionRepository.findByMemberId(memberId)).thenReturn(Optional.of(connection));
+        when(encryption.decrypt("enc-token")).thenReturn("plain-token");
+        when(encryption.decrypt("enc-query")).thenReturn("plain-query");
+
+        String longSymbol = "AAAAAAAAAABBBBBBBBBBCCCCCCCCCCDDDDD"; // 35 chars > 30
+        IbkrPosition hit     = pos("US0378331005", "AAPL", "STK", bd("10"), bd("150"), bd("0.90"));
+        IbkrPosition miss    = pos("US88160R1014", "TSLA", "STK", bd("3"),  bd("200"), bd("1"));
+        IbkrPosition noIsin  = pos(null,           "PLTR", "STK", bd("8"),  bd("40"),  null);
+        IbkrPosition cash    = pos(null,           "USD.CASH", "CASH", bd("500"), bd("1"), bd("1"));
+        IbkrPosition zeroQty = pos("US0000000000", "ZRO", "STK", bd("0"),  bd("5"),   bd("1"));
+        IbkrPosition longSym = pos(null,           longSymbol, "OPT", bd("1"), bd("2"), bd("1"));
+        when(ibkrFlexPort.fetchOpenPositions("plain-token", "plain-query"))
+            .thenReturn(List.of(new IbkrAccountData("U1", List.of(hit, miss, noIsin, cash, zeroQty, longSym))));
+
+        when(isinConverter.resolve("US0378331005")).thenReturn(new TickerResult("AAPL", "Apple"));
+        // OpenFIGI miss: returns the ISIN unchanged → mapping must fall back to the symbol.
+        when(isinConverter.resolve("US88160R1014")).thenReturn(new TickerResult("US88160R1014", null));
+
+        when(accountRepository.findByExternalAccountIdAndMemberId("ibkr_U1", memberId)).thenReturn(Optional.empty());
+        lenient().when(accountRepository.existsSoftDeletedByExternalAccountIdAndMemberId("ibkr_U1", memberId)).thenReturn(false);
+        when(familyMemberRepository.findById(memberId)).thenReturn(Optional.of(member));
+        when(accountRepository.save(any(Account.class))).thenAnswer(inv -> { Account a = inv.getArgument(0); a.setId(1L); return a; });
+        when(accountService.liveBalanceEur(any(Account.class))).thenReturn(bd("0"));
+        when(accountService.toResponse(any(Account.class))).thenReturn(
+            AccountResponse.from(Account.builder().id(1L).name("IBKR U1").type(AccountType.COMPTE_TITRES).build(), BigDecimal.ZERO));
+
+        service.sync(memberId);
+
+        ArgumentCaptor<AccountHolding> captor = ArgumentCaptor.forClass(AccountHolding.class);
+        verify(holdingRepository, times(3)).save(captor.capture());
+        var byTicker = captor.getAllValues().stream()
+            .collect(java.util.stream.Collectors.toMap(AccountHolding::getTicker, h -> h));
+
+        // Cash, zero-qty and the over-long option symbol are all dropped.
+        assertThat(byTicker.keySet()).containsExactlyInAnyOrder("AAPL", "TSLA", "PLTR");
+        // ISIN hit: 150 × 0.90 = 135 EUR cost basis.
+        assertThat(byTicker.get("AAPL").getAverageBuyIn()).isEqualByComparingTo("135");
+        // No fxRateToBase → cost basis left unscaled (× 1).
+        assertThat(byTicker.get("PLTR").getAverageBuyIn()).isEqualByComparingTo("40");
+    }
+
+    /** Convenience builder for an account "U1" SUMMARY position. */
+    private static IbkrPosition pos(String isin, String symbol, String assetCategory,
+                                    BigDecimal position, BigDecimal costBasisPrice, BigDecimal fxRateToBase) {
+        return new IbkrPosition("U1", isin, symbol, symbol, "USD", assetCategory, "SUMMARY",
+            position, bd("999"), costBasisPrice, fxRateToBase);
+    }
+
     private static BigDecimal bd(String v) { return new BigDecimal(v); }
 }

--- a/backend/src/test/java/com/picsou/service/IbkrSyncServiceTest.java
+++ b/backend/src/test/java/com/picsou/service/IbkrSyncServiceTest.java
@@ -476,6 +476,51 @@ class IbkrSyncServiceTest {
         verify(holdingRepository, times(1)).save(any(AccountHolding.class));
     }
 
+    // ─── resyncIfConnected (scheduler entry point) ───────────────────────────
+    // NB: these Mockito tests cover the in-method swallowing only. The proxy-level
+    // UnexpectedRollbackException (rollback-only marked through a repository proxy,
+    // thrown at method exit) cannot exist without Spring proxies — that path is
+    // guarded by the call-site wrapper in SchedulerService.
+
+    @Test
+    void resyncIfConnected_withoutConnection_isANoOp() {
+        when(connectionRepository.findByMemberId(7L)).thenReturn(Optional.empty());
+
+        service.resyncIfConnected(7L);
+
+        verifyNoInteractions(ibkrFlexPort);
+        verifyNoInteractions(statusWriter);
+    }
+
+    @Test
+    void resyncIfConnected_swallowsSyncException_afterMarkingError() {
+        FamilyMember member = FamilyMember.builder().id(7L).displayName("Owner").build();
+        IbkrConnection connection = IbkrConnection.builder()
+            .id(42L).member(member).token("enc-token").queryId("enc-query").status("CONNECTED").build();
+        when(connectionRepository.findByMemberId(7L)).thenReturn(Optional.of(connection));
+        when(encryption.decrypt("enc-token")).thenThrow(new IllegalStateException("bad key"));
+
+        service.resyncIfConnected(7L);  // must not throw
+
+        verify(statusWriter).markError(42L);
+    }
+
+    @Test
+    void resyncIfConnected_swallowsUnexpectedRuntimeExceptions() {
+        FamilyMember member = FamilyMember.builder().id(7L).displayName("Owner").build();
+        IbkrConnection connection = IbkrConnection.builder()
+            .id(42L).member(member).token("enc-token").queryId("enc-query").status("CONNECTED").build();
+        when(connectionRepository.findByMemberId(7L)).thenReturn(Optional.of(connection));
+        when(encryption.decrypt("enc-token")).thenReturn("plain-token");
+        when(encryption.decrypt("enc-query")).thenReturn("plain-query");
+        when(ibkrFlexPort.fetchOpenPositions("plain-token", "plain-query"))
+            .thenThrow(new NullPointerException("bug"));
+
+        service.resyncIfConnected(7L);  // must not throw
+
+        verify(statusWriter).markError(42L);
+    }
+
     /** Convenience builder for an account "U1" SUMMARY position. */
     private static IbkrPosition pos(String isin, String symbol, String assetCategory,
                                     BigDecimal position, BigDecimal costBasisPrice, BigDecimal fxRateToBase) {

--- a/backend/src/test/java/com/picsou/service/IbkrSyncServiceTest.java
+++ b/backend/src/test/java/com/picsou/service/IbkrSyncServiceTest.java
@@ -24,12 +24,14 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -358,13 +360,16 @@ class IbkrSyncServiceTest {
         lenient().when(accountRepository.existsSoftDeletedByExternalAccountIdAndMemberId("ibkr_U1", memberId)).thenReturn(false);
         when(familyMemberRepository.findById(memberId)).thenReturn(Optional.of(member));
         when(accountRepository.save(any(Account.class))).thenAnswer(inv -> { Account a = inv.getArgument(0); a.setId(1L); return a; });
-        when(accountService.liveBalanceEur(any(Account.class))).thenReturn(bd("0"));
+        // liveBalanceEur is deliberately NOT stubbed: with zero persisted holdings the
+        // sync now sets the balance to 0 directly (the live path's empty-holdings
+        // fallback would return the stale stored balance).
         when(accountService.toResponse(any(Account.class))).thenReturn(
             AccountResponse.from(Account.builder().id(1L).name("IBKR U1").type(AccountType.COMPTE_TITRES).build(), BigDecimal.ZERO));
 
         service.sync(memberId);
 
         verify(holdingRepository, never()).save(any(AccountHolding.class));
+        verify(accountService, never()).liveBalanceEur(any(Account.class));
     }
 
     /**
@@ -397,6 +402,48 @@ class IbkrSyncServiceTest {
         // The guard failure is a sync failure like any other: the user must see ERROR
         // in the UI, on the scheduled path too (where the exception is swallowed).
         verify(statusWriter, times(1)).markError(any());
+    }
+
+    /**
+     * A fully liquidated IBKR account — statement present, zero positions — must purge
+     * the stale holdings AND zero the balance. Two traps pinned here: (1) the account
+     * must still flow through the sync at all (the parser now emits it with an empty
+     * position list), and (2) the balance must NOT go through liveBalanceEur, whose
+     * empty-holdings fallback resurrects the stored (stale) currentBalance.
+     */
+    @Test
+    void sync_emptiedAccount_purgesHoldingsAndZeroesBalance() {
+        Long memberId = 7L;
+        FamilyMember member = FamilyMember.builder().id(memberId).displayName("Owner").build();
+        IbkrConnection connection = IbkrConnection.builder()
+            .member(member).token("enc-token").queryId("enc-query").status("CONNECTED").build();
+        when(connectionRepository.findByMemberId(memberId)).thenReturn(Optional.of(connection));
+        when(encryption.decrypt("enc-token")).thenReturn("plain-token");
+        when(encryption.decrypt("enc-query")).thenReturn("plain-query");
+
+        IbkrAccountData emptied = new IbkrAccountData("U1", List.of(), "EUR");
+        when(ibkrFlexPort.fetchOpenPositions("plain-token", "plain-query"))
+            .thenReturn(List.of(emptied));
+
+        Account existing = Account.builder()
+            .id(31L).member(member).name("IBKR U1").type(AccountType.COMPTE_TITRES)
+            .currency("EUR").currentBalance(bd("1234.56")).externalAccountId("ibkr_U1")
+            .build();
+        when(accountRepository.findByExternalAccountIdAndMemberId("ibkr_U1", memberId))
+            .thenReturn(Optional.of(existing));
+        when(accountRepository.save(any(Account.class))).thenAnswer(inv -> inv.getArgument(0));
+        when(accountService.toResponse(any(Account.class)))
+            .thenReturn(AccountResponse.from(existing, BigDecimal.ZERO));
+
+        List<AccountResponse> result = service.sync(memberId);
+
+        assertThat(result).hasSize(1);
+        verify(holdingRepository).deleteByAccountId(31L);
+        verify(holdingRepository, never()).save(any(AccountHolding.class));
+        // Balance forced to zero, NOT recomputed via the live path.
+        verify(accountService, never()).liveBalanceEur(any(Account.class));
+        assertThat(existing.getCurrentBalance()).isEqualByComparingTo("0");
+        verify(accountService).upsertSnapshot(eq(existing), eq(BigDecimal.ZERO), any(LocalDate.class));
     }
 
     /** B: an explicit "EUR" base currency syncs exactly like today (no behavior change). */

--- a/backend/src/test/java/com/picsou/service/IbkrSyncServiceTest.java
+++ b/backend/src/test/java/com/picsou/service/IbkrSyncServiceTest.java
@@ -1,4 +1,4 @@
-package com.picsou.ibkr;
+package com.picsou.service;
 
 import com.picsou.adapter.OpenFigiIsinConverter;
 import com.picsou.adapter.OpenFigiIsinConverter.TickerResult;
@@ -16,7 +16,6 @@ import com.picsou.repository.AccountHoldingRepository;
 import com.picsou.repository.AccountRepository;
 import com.picsou.repository.FamilyMemberRepository;
 import com.picsou.repository.IbkrConnectionRepository;
-import com.picsou.service.AccountService;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;

--- a/backend/src/test/java/com/picsou/service/IbkrSyncServiceTest.java
+++ b/backend/src/test/java/com/picsou/service/IbkrSyncServiceTest.java
@@ -259,6 +259,43 @@ class IbkrSyncServiceTest {
         assertThat(captor.getValue().getTicker()).isEqualTo("PLTR");
     }
 
+    /**
+     * Two positions resolving to the same ticker with opposite signs that net to
+     * exactly zero (e.g. a short fully covered by an equal long lot) must not persist a
+     * stale holding: {@code HoldingDedup.vwapMerge} returns a zero-quantity sentinel,
+     * and the post-merge persist loop must skip it rather than saving a phantom
+     * zero-quantity row.
+     */
+    @Test
+    void sync_positionsNettingToZero_savesNoHolding() {
+        Long memberId = 7L;
+        FamilyMember member = FamilyMember.builder().id(memberId).displayName("Owner").build();
+        IbkrConnection connection = IbkrConnection.builder()
+            .member(member).token("enc-token").queryId("enc-query").status("CONNECTED").build();
+        when(connectionRepository.findByMemberId(memberId)).thenReturn(Optional.of(connection));
+        when(encryption.decrypt("enc-token")).thenReturn("plain-token");
+        when(encryption.decrypt("enc-query")).thenReturn("plain-query");
+
+        IbkrPosition longLeg = pos("US0378331005", "AAPL", "STK", bd("40"), bd("100"), bd("1"));
+        IbkrPosition shortLeg = pos("US0378331005", "AAPL", "STK", bd("-40"), bd("120"), bd("1"));
+        when(ibkrFlexPort.fetchOpenPositions("plain-token", "plain-query"))
+            .thenReturn(List.of(new IbkrAccountData("U1", List.of(longLeg, shortLeg))));
+
+        when(isinConverter.resolve("US0378331005")).thenReturn(new TickerResult("AAPL", "Apple"));
+
+        when(accountRepository.findByExternalAccountIdAndMemberId("ibkr_U1", memberId)).thenReturn(Optional.empty());
+        lenient().when(accountRepository.existsSoftDeletedByExternalAccountIdAndMemberId("ibkr_U1", memberId)).thenReturn(false);
+        when(familyMemberRepository.findById(memberId)).thenReturn(Optional.of(member));
+        when(accountRepository.save(any(Account.class))).thenAnswer(inv -> { Account a = inv.getArgument(0); a.setId(1L); return a; });
+        when(accountService.liveBalanceEur(any(Account.class))).thenReturn(bd("0"));
+        when(accountService.toResponse(any(Account.class))).thenReturn(
+            AccountResponse.from(Account.builder().id(1L).name("IBKR U1").type(AccountType.COMPTE_TITRES).build(), BigDecimal.ZERO));
+
+        service.sync(memberId);
+
+        verify(holdingRepository, never()).save(any(AccountHolding.class));
+    }
+
     /** Convenience builder for an account "U1" SUMMARY position. */
     private static IbkrPosition pos(String isin, String symbol, String assetCategory,
                                     BigDecimal position, BigDecimal costBasisPrice, BigDecimal fxRateToBase) {

--- a/backend/src/test/resources/sql/ibkr-status-writer-test-schema.sql
+++ b/backend/src/test/resources/sql/ibkr-status-writer-test-schema.sql
@@ -1,0 +1,28 @@
+-- Minimal H2 schema for IbkrStatusWriterTest (@DataJpaTest).
+--
+-- Same rationale as transaction-repository-test-schema.sql: the real migrations are
+-- PostgreSQL-flavoured and cannot run on H2 (docs/conventions/testing.md), so this stands up
+-- just the two tables the test touches. Both entities extend AuditableEntity, whose
+-- created_at/updated_at are filled by Spring Data JPA auditing (@EnableJpaAuditing on
+-- PicsouApplication, which @DataJpaTest loads as the configuration root).
+
+-- IF NOT EXISTS: @Sql runs before every test method against the same in-memory H2.
+CREATE TABLE IF NOT EXISTS family_member (
+    id           BIGINT AUTO_INCREMENT PRIMARY KEY,
+    display_name VARCHAR(100) NOT NULL,
+    avatar_color VARCHAR(7)   NOT NULL,
+    is_managed   BOOLEAN      NOT NULL,
+    created_at   TIMESTAMP    NOT NULL,
+    updated_at   TIMESTAMP    NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS ibkr_connection (
+    id             BIGINT AUTO_INCREMENT PRIMARY KEY,
+    member_id      BIGINT       NOT NULL REFERENCES family_member(id),
+    token          VARCHAR(500) NOT NULL,
+    query_id       VARCHAR(500) NOT NULL,
+    status         VARCHAR(20)  NOT NULL,
+    last_synced_at TIMESTAMP,
+    created_at     TIMESTAMP    NOT NULL,
+    updated_at     TIMESTAMP    NOT NULL
+);

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -61,7 +61,7 @@
 | Dashboard — Liabilities separated from performance | 2026-07-08 | [dashboard-liabilities-separation.md](./features/dashboard-liabilities-separation.md) |
 | Bank sync | 2026-07-19 | [bank-sync.md](./features/bank-sync.md) |
 | Trade Republic | 2026-07-07 | [trade-republic.md](./features/trade-republic.md) |
-| Interactive Brokers (IBKR) sync ⚠ backend only | 2026-07-19 | [ibkr-sync.md](./features/ibkr-sync.md) |
+| Interactive Brokers (IBKR) sync | 2026-07-19 | [ibkr-sync.md](./features/ibkr-sync.md) |
 | Trade Republic — Holdings deduplication | 2026-05-18 | [trade-republic-holding-deduplication.md](./features/trade-republic-holding-deduplication.md) |
 | ISIN → Ticker conversion | 2026-04-13 | [ISIN_TO_TICKER_CONVERSION.md](./features/ISIN_TO_TICKER_CONVERSION.md) |
 | Encryption at rest | 2026-04-08 | [encryption-at-rest.md](./features/encryption-at-rest.md) |

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -46,6 +46,7 @@
 | 2026-07-12 | [UI controls follow the shadcn theme radius, not a pill shape](./decisions/2026-07-12-ui-controls-follow-shadcn-theme-radius.md) | Active |
 | 2026-07-17 | [EVM multichain wallets — one address, many chains](./decisions/2026-07-17-evm-multichain-wallets.md) | Active |
 | 2026-07-19 | [Caddy as an opt-in TLS terminator for the Docker stack](./decisions/2026-07-19-caddy-opt-in-tls-profile.md) | Active |
+| 2026-07-19 | [Interactive Brokers via the Flex Web Service (read-only, EOD)](./decisions/2026-07-19-ibkr-flex-web-service.md) | Active |
 
 ## Feature notes
 
@@ -60,6 +61,7 @@
 | Dashboard — Liabilities separated from performance | 2026-07-08 | [dashboard-liabilities-separation.md](./features/dashboard-liabilities-separation.md) |
 | Bank sync | 2026-07-19 | [bank-sync.md](./features/bank-sync.md) |
 | Trade Republic | 2026-07-07 | [trade-republic.md](./features/trade-republic.md) |
+| Interactive Brokers (IBKR) sync ⚠ backend only | 2026-07-19 | [ibkr-sync.md](./features/ibkr-sync.md) |
 | Trade Republic — Holdings deduplication | 2026-05-18 | [trade-republic-holding-deduplication.md](./features/trade-republic-holding-deduplication.md) |
 | ISIN → Ticker conversion | 2026-04-13 | [ISIN_TO_TICKER_CONVERSION.md](./features/ISIN_TO_TICKER_CONVERSION.md) |
 | Encryption at rest | 2026-04-08 | [encryption-at-rest.md](./features/encryption-at-rest.md) |

--- a/docs/decisions/2026-07-19-ibkr-flex-web-service.md
+++ b/docs/decisions/2026-07-19-ibkr-flex-web-service.md
@@ -1,0 +1,70 @@
+# ADR: Interactive Brokers via the Flex Web Service (read-only, EOD)
+
+> Date: 2026-07-19
+> Status: ✅ Active
+
+## Context
+
+Interactive Brokers was the main missing brokerage connector (Picsou already had Trade
+Republic and Finary). IBKR offers three programmatic access paths, with very different
+operational footprints for a **self-hosted, unattended** app that only needs to refresh a
+portfolio once a day. We had to pick one before building the connector.
+
+## Decision
+
+Integrate IBKR through the **Flex Web Service**, pulling an "Open Positions" Flex Query
+once a day. The user creates the query and a read-only token in Client Portal and pastes
+the token + query id into Picsou. Sync is the standard two-step flow (`SendRequest` →
+`GetStatement`), parsed into `AccountHolding` rows like the other brokers.
+
+## Alternatives considered
+
+### Flex Web Service (chosen)
+
+- **Pros**: read-only token (6h–1y), nothing to run alongside the app, HTTP + XML, data is
+  end-of-day which matches Picsou's daily snapshots, maps almost 1:1 onto the existing
+  Trade Republic broker→holdings pattern.
+- **Cons**: not real-time (EOD only); XML rather than JSON; two-step async flow needs
+  polling.
+
+### Client Portal API (Web API)
+
+- **Pros**: near real-time, REST/JSON, richer (live positions, orders).
+- **Cons**: requires running the **Client Portal Gateway** (a Java process) next to the
+  app, with a session that expires roughly daily and needs interactive 2FA re-auth — hostile
+  to unattended self-hosting.
+
+### TWS API
+
+- **Pros**: full-featured, real-time.
+- **Cons**: requires **TWS or IB Gateway** (a desktop app) kept open and logged in, socket
+  protocol, automatic daily disconnect. A non-starter for a headless container.
+
+## Reasoning
+
+Picsou already snapshots balances once a day and recomputes live valuations from tickers, so
+intraday IBKR data adds nothing here while both real-time options impose a long-lived,
+2FA-refreshed gateway/desktop process — exactly the kind of babysitting a self-hosted
+dashboard should avoid. The Flex Web Service needs only a stored token and an HTTP call, and
+slots into the existing `Port`/adapter + `SchedulerService` machinery with no new moving
+parts. XML is handled with the JDK's own DOM parser, so no dependency is added.
+
+## Trade-offs accepted
+
+- **End-of-day only.** No intraday IBKR position changes; acceptable given daily snapshots
+  and live ticker-based valuation.
+- **Manual query setup.** The user must build the Flex Query and generate a token once — more
+  onboarding friction than an OAuth flow, but it is the only read-only, gateway-free option.
+- **Base-currency caveat.** IBKR cost basis is converted to the account base currency via
+  `fxRateToBase`; the stored `averageBuyIn` (invested/PnL) is exact only when the IBKR base
+  currency is EUR. Net worth is unaffected — it is recomputed live in EUR from tickers.
+
+## Consequences
+
+- New `ibkr_connection` table (encrypted token + query id), `IbkrFlexPort` +
+  `IbkrFlexClient`, `IbkrSyncService`, `IbkrController` (`/api/ibkr/*`), and a daily
+  auto-sync hook in `SchedulerService`.
+- Reuses `OpenFigiIsinConverter`, `HoldingDedup`, `CryptoEncryption`, `AccountService`.
+- No new Maven dependency (JDK `HttpClient` + DOM parser).
+- Frontend connection card, i18n keys and the setup/integrations registry entry are a
+  follow-up; the backend endpoints are usable meanwhile.

--- a/docs/features/ibkr-sync.md
+++ b/docs/features/ibkr-sync.md
@@ -35,6 +35,8 @@ trusted for EUR valuation.
 - `db/migration/V56__ibkr_connection.sql` — `ibkr_connection` table
 - Reuses: `OpenFigiIsinConverter` (ISIN→ticker), `HoldingDedup` (VWAP), `CryptoEncryption`,
   `AccountService.liveBalanceEur` (net-worth valuation), `SchedulerService` (daily auto-sync)
+- `frontend/src/pages/sync/IbkrTab.tsx` — Sync-page connection tab (token + query id form →
+  connect, then sync/disconnect); `sync.ibkr.*` i18n keys in all four locales
 
 ### Flow
 
@@ -100,6 +102,12 @@ See the [ADR](../decisions/2026-07-19-ibkr-flex-web-service.md) for the full API
 
 - Related ADR: [Flex Web Service for IBKR](../decisions/2026-07-19-ibkr-flex-web-service.md)
 - IBKR Flex attribute reference: [csingley/ibflex](https://github.com/csingley/ibflex)
-- **Not yet done:** frontend connection card (settings) + i18n keys (fr/en/de/es) +
-  `IntegrationsService`/`SetupService` registry entry (`"ibkr"`). Backend is usable via the
-  `/api/ibkr/*` endpoints in the meantime.
+- **Frontend:** a tab on the Sync page (`IbkrTab.tsx`) — token + query id form → connect,
+  then sync/disconnect — with `sync.ibkr.*` keys in fr/en/de/es. Verified by typecheck,
+  ESLint and `IbkrTab.test.tsx` (3 render/interaction tests).
+- **Deliberately skipped:** the `SetupService.INTEGRATIONS` / `IntegrationsService` registry
+  entry (`"ibkr"`). The Sync-page tab is not gated on it (like the TR/Finary tabs), and
+  adding it would surface an unlabeled toggle in the setup wizard.
+- **Not yet exercised against a live IBKR account** — the parser is fixture-tested; a real
+  Flex statement is the true end-to-end validation (verify the `GetStatement` `q` param and
+  error codes on first live run).

--- a/docs/features/ibkr-sync.md
+++ b/docs/features/ibkr-sync.md
@@ -116,7 +116,10 @@ See the [ADR](../decisions/2026-07-19-ibkr-flex-web-service.md) for the full API
 - `IbkrFlexClientTest` — XML parser against a realistic fixture (exact IBKR attribute
   names, SUMMARY/LOT distinction, empty statement)
 - `IbkrSyncServiceTest` — mapping: cost-basis → base-currency conversion, LOT filtering,
-  "not connected" error
+  "not connected" error, error-status persistence, derivative asset-category filtering,
+  zero-net-quantity positions
+- `HoldingDedupTest` — VWAP merge (shared with TR/Bourso), including the sign-aware
+  cases IBKR can trigger (opposite-sign netting, netting to exactly zero)
 
 ## Links
 

--- a/docs/features/ibkr-sync.md
+++ b/docs/features/ibkr-sync.md
@@ -81,13 +81,23 @@ See the [ADR](../decisions/2026-07-19-ibkr-flex-web-service.md) for the full API
 - **LOT vs SUMMARY rows.** If the Flex Query has lots enabled, IBKR emits both a `SUMMARY`
   row and per-tax-lot `LOT` rows. The service keeps `SUMMARY`/absent and drops `LOT` to
   avoid double counting (`IbkrSyncService.isReportable`).
-- **Asset coverage.** Equities/ETFs price well (ISIN→ticker→Yahoo). Instruments without a
-  usable ISIN (some derivatives) fall back to the IBKR symbol and may not price — they then
-  contribute 0 to the live balance (logged), same graceful degradation as Trade Republic.
-  Cash lines (`assetCategory = CASH`) and zero-quantity positions are skipped. A resolved
-  ticker longer than the `account_holding.ticker` column (30 chars — long option/future
-  symbols) is skipped rather than crashing the whole account's sync; the display name is
-  clipped to 100 chars for the same reason.
+- **Asset coverage.** `isReportable` allowlists `assetCategory` in `STK` (covers stocks
+  *and* ETFs — IBKR has no separate ETF category), `FUND`, `BOND`, `CRYPTO`, or absent
+  (case-insensitive). Everything else — options (`OPT`), futures (`FUT`), future options
+  (`FOP`), CFDs, warrants, ... — is skipped with a WARN log naming the category and
+  symbol, so day-1 real data surfaces any category the allowlist got wrong. This replaced
+  an over-long-ticker guard alone, which does **not** catch derivatives: a standard OCC
+  option symbol like `"SPY 240119C00470000"` is 19 chars, under the 30-char
+  `account_holding.ticker` column limit, so it used to pass through as a mispriced stock
+  holding (per-share cost basis with the contract multiplier ignored, live value null).
+  The ticker-length guard is still kept as a backstop for whatever slips through the
+  allowlist. Cash lines (`assetCategory = CASH`) and zero-quantity positions are skipped
+  silently (expected, not a day-1 finding). Equities/ETFs price well (ISIN→ticker→Yahoo);
+  instruments without a usable ISIN fall back to the IBKR symbol and may not price — they
+  then contribute 0 to the live balance (logged), same graceful degradation as Trade
+  Republic. A resolved ticker longer than the `account_holding.ticker` column (30 chars)
+  is skipped rather than crashing the whole account's sync; the display name is clipped
+  to 100 chars for the same reason.
 - **Async statement generation.** `GetStatement` can answer "still generating" (IBKR error
   code 1019); the client polls with backoff (matched on code *and* message text so a code
   change does not turn a transient wait into a hard failure).

--- a/docs/features/ibkr-sync.md
+++ b/docs/features/ibkr-sync.md
@@ -1,6 +1,6 @@
 # Feature: Interactive Brokers (IBKR) sync
 
-> Last updated: 2026-07-19
+> Last updated: 2026-07-21
 
 ## Context
 
@@ -119,7 +119,7 @@ See the [ADR](../decisions/2026-07-19-ibkr-flex-web-service.md) for the full API
   transaction instead, so the `ERROR` status commits independently of the outer
   rollback on both the manual and scheduled paths.
 - **`GetStatement` `q` parameter.** Uses the **reference code** returned by `SendRequest`
-  (not the query id). Verify against a real statement on first live run.
+  (not the query id). Confirmed against a live statement on 2026-07-21.
 
 ## Tests
 
@@ -141,6 +141,14 @@ See the [ADR](../decisions/2026-07-19-ibkr-flex-web-service.md) for the full API
 - **Deliberately skipped:** the `SetupService.INTEGRATIONS` / `IntegrationsService` registry
   entry (`"ibkr"`). The Sync-page tab is not gated on it (like the TR/Finary tabs), and
   adding it would surface an unlabeled toggle in the setup wizard.
-- **Not yet exercised against a live IBKR account** — the parser is fixture-tested; a real
-  Flex statement is the true end-to-end validation (verify the `GetStatement` `q` param and
-  error codes on first live run).
+- **Validated against a live IBKR account (2026-07-21).** Full flow exercised on a real
+  Flex statement (dev instance, real credentials): `SendRequest` → reference code →
+  `GetStatement` returned the statement on the first poll; parsed 1 open position
+  (fractional `STK` share) into one `ibkr_<accountId>` account. `AccountInformation`
+  was present with `currency="EUR"`, so the base-currency guard took its happy path
+  (no WARN). Cost basis matched (`invested = quantity × averageBuyIn` to the cent),
+  live EUR valuation resolved via Yahoo, the daily `balance_snapshot` row was written,
+  and an immediate re-sync was idempotent (same account row, still one holding, no
+  duplicate snapshot thanks to the `(account_id, date)` unique constraint). Not yet
+  observed live: the 1019 "still generating" poll path and token-expiry `ERROR`
+  handling (fixture-tested only).

--- a/docs/features/ibkr-sync.md
+++ b/docs/features/ibkr-sync.md
@@ -34,7 +34,7 @@ trusted for EUR valuation.
 - `ibkr/client/IbkrFlexClient.java` — Flex Web Service HTTP + XML parsing (`IbkrFlexPort`)
 - `port/IbkrFlexPort.java` — provider abstraction + `IbkrPosition` / `IbkrAccountData`
 - `model/IbkrConnection.java`, `repository/IbkrConnectionRepository.java` — encrypted token + query id
-- `db/migration/V56__ibkr_connection.sql` — `ibkr_connection` table
+- `db/migration/V57__ibkr_connection.sql` — `ibkr_connection` table
 - Reuses: `OpenFigiIsinConverter` (ISIN→ticker), `HoldingDedup` (VWAP), `CryptoEncryption`,
   `AccountService.liveBalanceEur` (net-worth valuation), `SchedulerService` (daily auto-sync)
 - `frontend/src/pages/sync/IbkrTab.tsx` — Sync-page connection tab (token + query id form →

--- a/docs/features/ibkr-sync.md
+++ b/docs/features/ibkr-sync.md
@@ -73,11 +73,21 @@ See the [ADR](../decisions/2026-07-19-ibkr-flex-web-service.md) for the full API
 
 ## Gotchas / Pitfalls
 
-- **Base currency assumption.** `fxRateToBase` converts a position's native currency to the
-  user's **IBKR base currency**, not necessarily EUR. `averageBuyIn` (and therefore the
-  "invested" and PnL figures) is correct only when the IBKR base currency is EUR. **Net
-  worth is unaffected** — it is recomputed live in EUR from tickers, never from the stored
-  cost basis or IBKR prices. Document/expect a EUR IBKR base for accurate PnL.
+- **Base currency requirement (enforced).** `fxRateToBase` converts a position's native
+  currency to the user's **IBKR base currency**, not necessarily EUR. `averageBuyIn` (and
+  therefore the "invested" and PnL figures) is correct only when the IBKR base currency is
+  EUR. **Net worth is unaffected** — it is recomputed live in EUR from tickers, never from
+  the stored cost basis or IBKR prices. Since plan 003 (issue B), `IbkrSyncService`
+  actively guards this instead of silently trusting it: it reads the account's base
+  currency from the Flex statement's optional `AccountInformation` section (`currency`
+  attribute — a section the user must enable on the Flex Query alongside Open Positions);
+  if present and not `EUR`, the sync **throws `SyncException`** with a message telling the
+  user to change the IBKR account's base currency in Account Settings, and **no holdings
+  are persisted** for that account. If the statement has no `AccountInformation` section at
+  all (not enabled on the query), the base currency is unknown — sync proceeds assuming EUR
+  as before, logging one WARN per account per sync so this is visible on day 1. **Owner
+  operational note:** choosing EUR as the IBKR account base currency at account opening
+  neutralizes this entirely.
 - **LOT vs SUMMARY rows.** If the Flex Query has lots enabled, IBKR emits both a `SUMMARY`
   row and per-tax-lot `LOT` rows. The service keeps `SUMMARY`/absent and drops `LOT` to
   avoid double counting (`IbkrSyncService.isReportable`).

--- a/docs/features/ibkr-sync.md
+++ b/docs/features/ibkr-sync.md
@@ -29,6 +29,8 @@ trusted for EUR valuation.
 - `controller/IbkrController.java` — `/api/ibkr/connect|status|sync|connection`
 - `service/IbkrSyncService.java` — connect/status/sync + position→holding mapping
   (lives in `com.picsou.service` with the other broker sync services)
+- `service/IbkrStatusWriter.java` — persists the `ERROR` status in its own
+  `REQUIRES_NEW` transaction so it survives the sync transaction's rollback
 - `ibkr/client/IbkrFlexClient.java` — Flex Web Service HTTP + XML parsing (`IbkrFlexPort`)
 - `port/IbkrFlexPort.java` — provider abstraction + `IbkrPosition` / `IbkrAccountData`
 - `model/IbkrConnection.java`, `repository/IbkrConnectionRepository.java` — encrypted token + query id
@@ -90,7 +92,12 @@ See the [ADR](../decisions/2026-07-19-ibkr-flex-web-service.md) for the full API
   code 1019); the client polls with backoff (matched on code *and* message text so a code
   change does not turn a transient wait into a hard failure).
 - **Token expiry.** Flex tokens live 6h–1y. On failure the connection status flips to
-  `ERROR`; the user regenerates the token and reconnects.
+  `ERROR`; the user regenerates the token and reconnects. `IbkrSyncService` is
+  `@Transactional`, so a plain save-then-rethrow in the catch block would be rolled back
+  on the manual sync path (the exception marks the transaction rollback-only before it
+  reaches the controller) — `IbkrStatusWriter.markError` runs in its own `REQUIRES_NEW`
+  transaction instead, so the `ERROR` status commits independently of the outer
+  rollback on both the manual and scheduled paths.
 - **`GetStatement` `q` parameter.** Uses the **reference code** returned by `SendRequest`
   (not the query id). Verify against a real statement on first live run.
 

--- a/docs/features/ibkr-sync.md
+++ b/docs/features/ibkr-sync.md
@@ -27,7 +27,8 @@ trusted for EUR valuation.
 ### Key files
 
 - `controller/IbkrController.java` — `/api/ibkr/connect|status|sync|connection`
-- `ibkr/IbkrSyncService.java` — connect/status/sync + position→holding mapping
+- `service/IbkrSyncService.java` — connect/status/sync + position→holding mapping
+  (lives in `com.picsou.service` with the other broker sync services)
 - `ibkr/client/IbkrFlexClient.java` — Flex Web Service HTTP + XML parsing (`IbkrFlexPort`)
 - `port/IbkrFlexPort.java` — provider abstraction + `IbkrPosition` / `IbkrAccountData`
 - `model/IbkrConnection.java`, `repository/IbkrConnectionRepository.java` — encrypted token + query id

--- a/docs/features/ibkr-sync.md
+++ b/docs/features/ibkr-sync.md
@@ -1,0 +1,104 @@
+# Feature: Interactive Brokers (IBKR) sync
+
+> Last updated: 2026-07-19
+
+## Context
+
+Interactive Brokers is the reference broker for anyone holding US/global equities and
+ETFs, and it was the main gap in Picsou's brokerage coverage (which already had Trade
+Republic and Finary). This feature pulls IBKR **open positions** once a day and maps them
+onto Picsou accounts + holdings, so an IBKR portfolio shows up in net worth exactly like
+any other holdings account.
+
+## How it works
+
+IBKR exposes read-only portfolio data through the **Flex Web Service**: the user builds an
+"Open Positions" Flex Query and generates a token in Client Portal, both of which they
+paste into Picsou once. Sync is a two-step HTTP flow — `SendRequest` returns a reference
+code, `GetStatement` returns the statement XML once IBKR has generated it (polled with
+backoff). Data is end-of-day, which matches Picsou's daily snapshot cadence.
+
+Parsed positions become `AccountHolding` rows under one `Account` per IBKR account id
+(`external_account_id = "ibkr_<accountId>"`, type `COMPTE_TITRES`). Valuation reuses the
+existing live-price path: the dashboard recomputes each holding's EUR value from its ticker
+via `PriceService` (Yahoo/CoinGecko, FX-converted). The IBKR-reported prices are **not**
+trusted for EUR valuation.
+
+### Key files
+
+- `controller/IbkrController.java` — `/api/ibkr/connect|status|sync|connection`
+- `ibkr/IbkrSyncService.java` — connect/status/sync + position→holding mapping
+- `ibkr/client/IbkrFlexClient.java` — Flex Web Service HTTP + XML parsing (`IbkrFlexPort`)
+- `port/IbkrFlexPort.java` — provider abstraction + `IbkrPosition` / `IbkrAccountData`
+- `model/IbkrConnection.java`, `repository/IbkrConnectionRepository.java` — encrypted token + query id
+- `db/migration/V56__ibkr_connection.sql` — `ibkr_connection` table
+- Reuses: `OpenFigiIsinConverter` (ISIN→ticker), `HoldingDedup` (VWAP), `CryptoEncryption`,
+  `AccountService.liveBalanceEur` (net-worth valuation), `SchedulerService` (daily auto-sync)
+
+### Flow
+
+```
+Client Portal: build Open Positions Flex Query + generate token
+        │  (token + queryId pasted once)
+        ▼
+POST /api/ibkr/connect ─► IbkrConnection (token + queryId AES-256-GCM encrypted)
+        │
+POST /api/ibkr/sync ─► IbkrFlexClient
+        │   SendRequest?t&q&v=3            → <ReferenceCode>
+        │   GetStatement?t&q=refCode&v=3   → poll until <FlexQueryResponse>
+        ▼
+   parse <OpenPosition> rows  ─► group by accountId
+        ▼
+   per account: delete+recompute holdings (ISIN→ticker, VWAP de-dup,
+                cost basis → base ccy via fxRateToBase)
+        ▼
+   liveBalanceEur (Yahoo/CoinGecko) ─► currentBalance + daily snapshot
+```
+
+## Technical choices
+
+| Choice | Why | Rejected alternative |
+|--------|-----|----------------------|
+| Flex Web Service | Read-only token, no gateway/desktop process to run, EOD data fits daily snapshots | Client Portal API (needs a running gateway + daily 2FA re-auth); TWS API (needs TWS/IB Gateway desktop open) |
+| JDK DOM parser | Zero new dependency; mirrors the raw-`HttpClient` style of `FinaryApiClient` | `jackson-dataformat-xml` / JAXB (extra dependency for a flat, simple document) |
+| Value live in EUR via ticker | Net worth stays correct regardless of the user's IBKR base currency | Trusting IBKR `markPrice`/`positionValueInBase` (base-currency dependent) |
+| Store `averageBuyIn` as `costBasisPrice × fxRateToBase` | Best-effort EUR cost basis for the invested/PnL figures | Leaving it null (loses PnL for the common EUR-base case) |
+
+See the [ADR](../decisions/2026-07-19-ibkr-flex-web-service.md) for the full API-choice rationale.
+
+## Gotchas / Pitfalls
+
+- **Base currency assumption.** `fxRateToBase` converts a position's native currency to the
+  user's **IBKR base currency**, not necessarily EUR. `averageBuyIn` (and therefore the
+  "invested" and PnL figures) is correct only when the IBKR base currency is EUR. **Net
+  worth is unaffected** — it is recomputed live in EUR from tickers, never from the stored
+  cost basis or IBKR prices. Document/expect a EUR IBKR base for accurate PnL.
+- **LOT vs SUMMARY rows.** If the Flex Query has lots enabled, IBKR emits both a `SUMMARY`
+  row and per-tax-lot `LOT` rows. The service keeps `SUMMARY`/absent and drops `LOT` to
+  avoid double counting (`IbkrSyncService.isReportable`).
+- **Asset coverage.** Equities/ETFs price well (ISIN→ticker→Yahoo). Instruments without a
+  usable ISIN (some derivatives) fall back to the IBKR symbol and may not price — they then
+  contribute 0 to the live balance (logged), same graceful degradation as Trade Republic.
+  Cash lines (`assetCategory = CASH`) are skipped.
+- **Async statement generation.** `GetStatement` can answer "still generating" (IBKR error
+  code 1019); the client polls with backoff (matched on code *and* message text so a code
+  change does not turn a transient wait into a hard failure).
+- **Token expiry.** Flex tokens live 6h–1y. On failure the connection status flips to
+  `ERROR`; the user regenerates the token and reconnects.
+- **`GetStatement` `q` parameter.** Uses the **reference code** returned by `SendRequest`
+  (not the query id). Verify against a real statement on first live run.
+
+## Tests
+
+- `IbkrFlexClientTest` — XML parser against a realistic fixture (exact IBKR attribute
+  names, SUMMARY/LOT distinction, empty statement)
+- `IbkrSyncServiceTest` — mapping: cost-basis → base-currency conversion, LOT filtering,
+  "not connected" error
+
+## Links
+
+- Related ADR: [Flex Web Service for IBKR](../decisions/2026-07-19-ibkr-flex-web-service.md)
+- IBKR Flex attribute reference: [csingley/ibflex](https://github.com/csingley/ibflex)
+- **Not yet done:** frontend connection card (settings) + i18n keys (fr/en/de/es) +
+  `IntegrationsService`/`SetupService` registry entry (`"ibkr"`). Backend is usable via the
+  `/api/ibkr/*` endpoints in the meantime.

--- a/docs/features/ibkr-sync.md
+++ b/docs/features/ibkr-sync.md
@@ -82,7 +82,10 @@ See the [ADR](../decisions/2026-07-19-ibkr-flex-web-service.md) for the full API
 - **Asset coverage.** Equities/ETFs price well (ISIN→ticker→Yahoo). Instruments without a
   usable ISIN (some derivatives) fall back to the IBKR symbol and may not price — they then
   contribute 0 to the live balance (logged), same graceful degradation as Trade Republic.
-  Cash lines (`assetCategory = CASH`) are skipped.
+  Cash lines (`assetCategory = CASH`) and zero-quantity positions are skipped. A resolved
+  ticker longer than the `account_holding.ticker` column (30 chars — long option/future
+  symbols) is skipped rather than crashing the whole account's sync; the display name is
+  clipped to 100 chars for the same reason.
 - **Async statement generation.** `GetStatement` can answer "still generating" (IBKR error
   code 1019); the client polls with backoff (matched on code *and* message text so a code
   change does not turn a transient wait into a hard failure).

--- a/frontend/src/demo/index.ts
+++ b/frontend/src/demo/index.ts
@@ -335,6 +335,16 @@ handlers.set(key('POST', '/sync/1/retry'), () => [])
 // Sync - delete
 handlers.set(key('DELETE', '/sync/1'), () => null)
 
+// Interactive Brokers — same demo convention as Trade Republic below: reads report a
+// disconnected state, mutations fake-succeed with the real response shapes (without
+// these, unmapped routes resolve `{}` and the tab silently misbehaves).
+handlers.set(key('GET', '/ibkr/status'), () => ({
+  connected: false, connectionId: null, status: null, lastSyncedAt: null, maskedToken: null,
+}))
+handlers.set(key('POST', '/ibkr/connect'), () => null)
+handlers.set(key('POST', '/ibkr/sync'), () => [])
+handlers.set(key('DELETE', '/ibkr/connection'), () => null)
+
 // Trade Republic - session status
 handlers.set(key('GET', '/tr/status'), () => ({ isActive: false, expiresAt: null }))
 

--- a/frontend/src/features/accounts/hooks.ts
+++ b/frontend/src/features/accounts/hooks.ts
@@ -36,8 +36,10 @@ function recomputeWithLivePrice(
   const costBasisEur = input.averageBuyIn != null ? input.quantity * input.averageBuyIn : null
   const currentValueEur = input.quantity * livePrice
   const pnlEur = costBasisEur != null ? currentValueEur - costBasisEur : null
+  // Math.abs: a short position has a negative cost basis — dividing by it would flip
+  // the sign and show a winning short as a loss. Mirrors the backend formula.
   const pnlPercent = costBasisEur != null && costBasisEur !== 0
-    ? (pnlEur! / costBasisEur) * 100
+    ? (pnlEur! / Math.abs(costBasisEur)) * 100
     : null
   return { currentValueEur, costBasisEur, pnlEur, pnlPercent }
 }

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -444,6 +444,28 @@
         "unknownError": "Ein unerwarteter Fehler ist aufgetreten."
       }
     },
+    "ibkr": {
+      "title": "Interactive Brokers",
+      "setupHint": "Erstellen Sie im IBKR Client Portal eine „Open Positions“-Flex-Abfrage und generieren Sie ein Flex-Web-Service-Token, und fügen Sie beide unten ein.",
+      "token": "Flex-Web-Service-Token",
+      "tokenPlaceholder": "z. B. 123456789012345678901234",
+      "queryId": "Flex-Abfrage-ID",
+      "queryIdPlaceholder": "z. B. 987654",
+      "connect": "Verbinden",
+      "sync": "Synchronisieren",
+      "syncing": "Wird synchronisiert…",
+      "disconnect": "Trennen",
+      "disconnectConfirm": "Gespeicherte Interactive-Brokers-Verbindung entfernen?",
+      "connected": "Verbunden",
+      "statusError": "Letzte Synchronisierung fehlgeschlagen",
+      "lastSync": "Letzte Sync",
+      "neverSynced": "Nie synchronisiert",
+      "syncedToast": "Interactive Brokers synchronisiert: {{count}} Konto/Konten",
+      "errors": {
+        "connectFailed": "Verbindung konnte nicht gespeichert werden. Prüfen Sie Token und Abfrage-ID.",
+        "syncFailed": "Interactive-Brokers-Synchronisierung fehlgeschlagen. Prüfen Sie Ihr Token oder versuchen Sie es erneut."
+      }
+    },
     "exchanges": {
       "title": "Exchanges",
       "add": "Exchange hinzufügen",

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -463,7 +463,8 @@
       "syncedToast": "Interactive Brokers synchronisiert: {{count}} Konto/Konten",
       "errors": {
         "connectFailed": "Verbindung konnte nicht gespeichert werden. Prüfen Sie Token und Abfrage-ID.",
-        "syncFailed": "Interactive-Brokers-Synchronisierung fehlgeschlagen. Prüfen Sie Ihr Token oder versuchen Sie es erneut."
+        "syncFailed": "Interactive-Brokers-Synchronisierung fehlgeschlagen. Prüfen Sie Ihr Token oder versuchen Sie es erneut.",
+        "disconnectFailed": "Verbindung konnte nicht entfernt werden. Bitte versuchen Sie es erneut."
       }
     },
     "exchanges": {

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -470,7 +470,8 @@
       "syncedToast": "Interactive Brokers synced: {{count}} account(s)",
       "errors": {
         "connectFailed": "Could not save the connection. Check the token and query id.",
-        "syncFailed": "Interactive Brokers sync failed. Check your token or try again."
+        "syncFailed": "Interactive Brokers sync failed. Check your token or try again.",
+        "disconnectFailed": "Could not remove the connection. Please try again."
       }
     },
     "exchanges": {

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -451,6 +451,28 @@
         "unknownError": "An unexpected error occurred."
       }
     },
+    "ibkr": {
+      "title": "Interactive Brokers",
+      "setupHint": "In IBKR Client Portal, create an \"Open Positions\" Flex Query and generate a Flex Web Service token, then paste both below.",
+      "token": "Flex Web Service token",
+      "tokenPlaceholder": "e.g. 123456789012345678901234",
+      "queryId": "Flex Query ID",
+      "queryIdPlaceholder": "e.g. 987654",
+      "connect": "Connect",
+      "sync": "Sync",
+      "syncing": "Syncing…",
+      "disconnect": "Disconnect",
+      "disconnectConfirm": "Remove the stored Interactive Brokers connection?",
+      "connected": "Connected",
+      "statusError": "Last sync failed",
+      "lastSync": "Last sync",
+      "neverSynced": "Never synced",
+      "syncedToast": "Interactive Brokers synced: {{count}} account(s)",
+      "errors": {
+        "connectFailed": "Could not save the connection. Check the token and query id.",
+        "syncFailed": "Interactive Brokers sync failed. Check your token or try again."
+      }
+    },
     "exchanges": {
       "title": "Exchanges",
       "add": "Add exchange",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -463,7 +463,8 @@
       "syncedToast": "Interactive Brokers sincronizado: {{count}} cuenta(s)",
       "errors": {
         "connectFailed": "No se pudo guardar la conexión. Verifica el token y el ID de consulta.",
-        "syncFailed": "Falló la sincronización de Interactive Brokers. Verifica tu token o inténtalo de nuevo."
+        "syncFailed": "Falló la sincronización de Interactive Brokers. Verifica tu token o inténtalo de nuevo.",
+        "disconnectFailed": "No se pudo eliminar la conexión. Inténtalo de nuevo."
       }
     },
     "exchanges": {

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -444,6 +444,28 @@
         "unknownError": "Se ha producido un error inesperado."
       }
     },
+    "ibkr": {
+      "title": "Interactive Brokers",
+      "setupHint": "En el Client Portal de IBKR, crea una consulta Flex «Open Positions» y genera un token de Flex Web Service; luego pega ambos abajo.",
+      "token": "Token de Flex Web Service",
+      "tokenPlaceholder": "p. ej. 123456789012345678901234",
+      "queryId": "ID de la consulta Flex",
+      "queryIdPlaceholder": "p. ej. 987654",
+      "connect": "Conectar",
+      "sync": "Sincronizar",
+      "syncing": "Sincronizando…",
+      "disconnect": "Desconectar",
+      "disconnectConfirm": "¿Eliminar la conexión de Interactive Brokers guardada?",
+      "connected": "Conectado",
+      "statusError": "Falló la última sincronización",
+      "lastSync": "Última sync",
+      "neverSynced": "Nunca sincronizado",
+      "syncedToast": "Interactive Brokers sincronizado: {{count}} cuenta(s)",
+      "errors": {
+        "connectFailed": "No se pudo guardar la conexión. Verifica el token y el ID de consulta.",
+        "syncFailed": "Falló la sincronización de Interactive Brokers. Verifica tu token o inténtalo de nuevo."
+      }
+    },
     "exchanges": {
       "title": "Exchanges",
       "add": "Añadir exchange",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -451,6 +451,28 @@
         "unknownError": "Une erreur inattendue s'est produite."
       }
     },
+    "ibkr": {
+      "title": "Interactive Brokers",
+      "setupHint": "Dans le Client Portal IBKR, créez une requête Flex « Open Positions » et générez un jeton Flex Web Service, puis collez les deux ci-dessous.",
+      "token": "Jeton Flex Web Service",
+      "tokenPlaceholder": "ex. 123456789012345678901234",
+      "queryId": "ID de la requête Flex",
+      "queryIdPlaceholder": "ex. 987654",
+      "connect": "Connecter",
+      "sync": "Synchroniser",
+      "syncing": "Synchronisation…",
+      "disconnect": "Déconnecter",
+      "disconnectConfirm": "Supprimer la connexion Interactive Brokers enregistrée ?",
+      "connected": "Connecté",
+      "statusError": "Échec de la dernière synchro",
+      "lastSync": "Dernière sync",
+      "neverSynced": "Jamais synchronisé",
+      "syncedToast": "Interactive Brokers synchronisé : {{count}} compte(s)",
+      "errors": {
+        "connectFailed": "Impossible d'enregistrer la connexion. Vérifiez le jeton et l'ID de requête.",
+        "syncFailed": "Échec de la synchronisation Interactive Brokers. Vérifiez votre jeton ou réessayez."
+      }
+    },
     "exchanges": {
       "title": "Exchanges",
       "add": "Ajouter un exchange",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -470,7 +470,8 @@
       "syncedToast": "Interactive Brokers synchronisé : {{count}} compte(s)",
       "errors": {
         "connectFailed": "Impossible d'enregistrer la connexion. Vérifiez le jeton et l'ID de requête.",
-        "syncFailed": "Échec de la synchronisation Interactive Brokers. Vérifiez votre jeton ou réessayez."
+        "syncFailed": "Échec de la synchronisation Interactive Brokers. Vérifiez votre jeton ou réessayez.",
+        "disconnectFailed": "Impossible de supprimer la connexion. Réessayez."
       }
     },
     "exchanges": {

--- a/frontend/src/pages/sync/IbkrTab.test.tsx
+++ b/frontend/src/pages/sync/IbkrTab.test.tsx
@@ -1,0 +1,86 @@
+import '@testing-library/jest-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ReactNode } from 'react'
+
+const { apiGet, apiPost, apiDelete } = vi.hoisted(() => ({
+  apiGet: vi.fn(),
+  apiPost: vi.fn(),
+  apiDelete: vi.fn(),
+}))
+
+vi.mock('@/lib/api-client', () => ({
+  api: { get: apiGet, post: apiPost, delete: apiDelete },
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}))
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}))
+
+const { IbkrTab } = await import('./IbkrTab')
+
+function renderTab() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  })
+  function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  }
+  render(<IbkrTab />, { wrapper: Wrapper })
+}
+
+describe('IbkrTab', () => {
+  beforeEach(() => {
+    apiGet.mockReset()
+    apiPost.mockReset()
+    apiDelete.mockReset()
+  })
+
+  it('stores the trimmed token + query id when connecting', async () => {
+    apiGet.mockResolvedValue({ data: { connected: false, connectionId: null, status: null, lastSyncedAt: null, maskedToken: null } })
+    apiPost.mockResolvedValue({ data: null })
+
+    renderTab()
+
+    fireEvent.change(await screen.findByLabelText('sync.ibkr.token'), { target: { value: '  tok-123  ' } })
+    fireEvent.change(screen.getByLabelText('sync.ibkr.queryId'), { target: { value: ' 987654 ' } })
+    fireEvent.click(screen.getByRole('button', { name: 'sync.ibkr.connect' }))
+
+    await vi.waitFor(() =>
+      expect(apiPost).toHaveBeenCalledWith('/ibkr/connect', { token: 'tok-123', queryId: '987654' }),
+    )
+  })
+
+  it('shows the sync + disconnect controls and syncs when connected', async () => {
+    apiGet.mockResolvedValue({
+      data: { connected: true, connectionId: 1, status: 'CONNECTED', lastSyncedAt: null, maskedToken: '••••3F29' },
+    })
+    apiPost.mockResolvedValue({ data: [] })
+
+    renderTab()
+
+    // Masked token surfaces; the connect form is gone.
+    expect(await screen.findByText('••••3F29')).toBeInTheDocument()
+    expect(screen.queryByLabelText('sync.ibkr.token')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'sync.ibkr.sync' }))
+    await vi.waitFor(() => expect(apiPost).toHaveBeenCalledWith('/ibkr/sync'))
+  })
+
+  it('surfaces an error when the sync fails', async () => {
+    apiGet.mockResolvedValue({
+      data: { connected: true, connectionId: 1, status: 'CONNECTED', lastSyncedAt: null, maskedToken: '••••3F29' },
+    })
+    apiPost.mockRejectedValue({ response: { status: 500, data: { detail: 'Interactive Brokers: token has expired (code 1015)' } } })
+
+    renderTab()
+
+    fireEvent.click(await screen.findByRole('button', { name: 'sync.ibkr.sync' }))
+    expect(await screen.findByText('Interactive Brokers: token has expired (code 1015)')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/pages/sync/IbkrTab.tsx
+++ b/frontend/src/pages/sync/IbkrTab.tsx
@@ -1,0 +1,198 @@
+import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { toast } from 'sonner'
+import { api } from '@/lib/api-client'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Badge } from '@/components/ui/badge'
+import { Card, CardContent } from '@/components/ui/card'
+import { ConfirmDialog } from '@/components/shared/ConfirmDialog'
+import { RefreshCw, LogOut, KeyRound, Hash, AlertTriangle, Loader2 } from 'lucide-react'
+import type { Account, IbkrConnectionStatus } from '@/types/api'
+import { extractErrorMessage } from '@/lib/errors'
+import { formatDateTime } from '@/lib/utils'
+
+export function IbkrTab() {
+  const { t } = useTranslation()
+  const queryClient = useQueryClient()
+
+  const [token, setToken] = useState('')
+  const [queryId, setQueryId] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const [showDisconnectConfirm, setShowDisconnectConfirm] = useState(false)
+
+  const { data: status, isLoading: statusLoading } = useQuery<IbkrConnectionStatus>({
+    queryKey: ['sync', 'ibkr', 'status'],
+    queryFn: () => api.get<IbkrConnectionStatus>('/ibkr/status').then((r) => r.data),
+  })
+
+  const isConnected = status?.connected ?? false
+  const isError = status?.status === 'ERROR'
+
+  const connectMutation = useMutation({
+    mutationFn: (params: { token: string; queryId: string }) =>
+      api.post('/ibkr/connect', params).then((r) => r.data),
+    onSuccess: () => {
+      setToken('')
+      setQueryId('')
+      setError(null)
+      queryClient.invalidateQueries({ queryKey: ['sync', 'ibkr', 'status'] })
+    },
+    onError: (err: unknown) => setError(extractErrorMessage(err, t('sync.ibkr.errors.connectFailed'))),
+  })
+
+  const syncMutation = useMutation({
+    mutationFn: () => api.post<Account[]>('/ibkr/sync').then((r) => r.data),
+    onSuccess: (accounts) => {
+      setError(null)
+      queryClient.invalidateQueries({ queryKey: ['sync', 'ibkr', 'status'] })
+      queryClient.invalidateQueries({ queryKey: ['accounts'] })
+      queryClient.invalidateQueries({ queryKey: ['dashboard'] })
+      toast.success(t('sync.ibkr.syncedToast', { count: accounts.length }))
+    },
+    onError: (err: unknown) => setError(extractErrorMessage(err, t('sync.ibkr.errors.syncFailed'))),
+  })
+
+  const disconnectMutation = useMutation({
+    mutationFn: () => api.delete('/ibkr/connection').then((r) => r.data),
+    onSuccess: () => {
+      setShowDisconnectConfirm(false)
+      setError(null)
+      queryClient.invalidateQueries({ queryKey: ['sync', 'ibkr', 'status'] })
+    },
+  })
+
+  function handleConnect(e: React.FormEvent) {
+    e.preventDefault()
+    if (!token.trim() || !queryId.trim()) return
+    connectMutation.mutate({ token: token.trim(), queryId: queryId.trim() })
+  }
+
+  if (statusLoading) {
+    return <p className="text-sm text-muted-foreground">{t('common.loading')}</p>
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Connection status card */}
+      {isConnected && status && (
+        <Card size="sm">
+          <CardContent className="flex items-center justify-between py-4">
+            <div className="flex flex-wrap items-center gap-3">
+              {isError ? (
+                <Badge className="bg-destructive/10 text-destructive">{t('sync.ibkr.statusError')}</Badge>
+              ) : (
+                <Badge className="bg-green-500/10 text-green-600 dark:text-green-400">
+                  {t('sync.ibkr.connected')}
+                </Badge>
+              )}
+              {status.maskedToken && (
+                <span className="text-sm text-muted-foreground">{status.maskedToken}</span>
+              )}
+              {status.lastSyncedAt ? (
+                <span className="text-xs text-muted-foreground">
+                  {t('sync.ibkr.lastSync')}: {formatDateTime(status.lastSyncedAt)}
+                </span>
+              ) : (
+                <span className="text-xs text-muted-foreground">{t('sync.ibkr.neverSynced')}</span>
+              )}
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Error banner */}
+      {error && (
+        <Card size="sm" className="border-destructive/30">
+          <CardContent className="flex items-center gap-3 py-4">
+            <AlertTriangle className="size-5 shrink-0 text-destructive" />
+            <p className="flex-1 text-sm text-destructive">{error}</p>
+          </CardContent>
+        </Card>
+      )}
+
+      {isConnected ? (
+        /* Connected: sync + disconnect */
+        <div className="flex flex-wrap gap-3">
+          <Button onClick={() => syncMutation.mutate()} disabled={syncMutation.isPending}>
+            {syncMutation.isPending ? (
+              <>
+                <Loader2 className="size-4 animate-spin" />
+                {t('sync.ibkr.syncing')}
+              </>
+            ) : (
+              <>
+                <RefreshCw className="size-4" />
+                {t('sync.ibkr.sync')}
+              </>
+            )}
+          </Button>
+          <Button
+            variant="destructive"
+            onClick={() => setShowDisconnectConfirm(true)}
+            disabled={disconnectMutation.isPending}
+          >
+            <LogOut className="size-4" />
+            {t('sync.ibkr.disconnect')}
+          </Button>
+        </div>
+      ) : (
+        /* Not connected: token + query id form */
+        <form onSubmit={handleConnect} className="mx-auto max-w-lg space-y-4">
+          <p className="text-sm text-muted-foreground">{t('sync.ibkr.setupHint')}</p>
+          <Card size="sm">
+            <CardContent className="space-y-4 py-4">
+              <div className="space-y-2">
+                <Label htmlFor="ibkr-token">
+                  <KeyRound className="mr-1 inline-block size-4" />
+                  {t('sync.ibkr.token')}
+                </Label>
+                <Input
+                  id="ibkr-token"
+                  value={token}
+                  onChange={(e) => setToken(e.target.value)}
+                  placeholder={t('sync.ibkr.tokenPlaceholder')}
+                  autoComplete="off"
+                  required
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="ibkr-query">
+                  <Hash className="mr-1 inline-block size-4" />
+                  {t('sync.ibkr.queryId')}
+                </Label>
+                <Input
+                  id="ibkr-query"
+                  value={queryId}
+                  onChange={(e) => setQueryId(e.target.value)}
+                  placeholder={t('sync.ibkr.queryIdPlaceholder')}
+                  autoComplete="off"
+                  required
+                />
+              </div>
+              <Button
+                type="submit"
+                disabled={connectMutation.isPending || !token.trim() || !queryId.trim()}
+                className="w-full"
+              >
+                {connectMutation.isPending && <Loader2 className="size-4 animate-spin" />}
+                {t('sync.ibkr.connect')}
+              </Button>
+            </CardContent>
+          </Card>
+        </form>
+      )}
+
+      <ConfirmDialog
+        open={showDisconnectConfirm}
+        onOpenChange={setShowDisconnectConfirm}
+        title={t('sync.ibkr.disconnect')}
+        description={t('sync.ibkr.disconnectConfirm')}
+        onConfirm={() => disconnectMutation.mutate()}
+        loading={disconnectMutation.isPending}
+      />
+    </div>
+  )
+}

--- a/frontend/src/pages/sync/IbkrTab.tsx
+++ b/frontend/src/pages/sync/IbkrTab.tsx
@@ -62,6 +62,11 @@ export function IbkrTab() {
       setError(null)
       queryClient.invalidateQueries({ queryKey: ['sync', 'ibkr', 'status'] })
     },
+    onError: (err: unknown) => {
+      // Close the dialog so the page-level error banner is actually visible.
+      setShowDisconnectConfirm(false)
+      setError(extractErrorMessage(err, t('sync.ibkr.errors.disconnectFailed')))
+    },
   })
 
   function handleConnect(e: React.FormEvent) {

--- a/frontend/src/pages/sync/SyncPage.tsx
+++ b/frontend/src/pages/sync/SyncPage.tsx
@@ -6,6 +6,7 @@ import { BankSyncTab } from './BankSyncTab'
 import { CryptoExchangeTab } from './CryptoExchangeTab'
 import { CryptoWalletTab } from './CryptoWalletTab'
 import { TradeRepublicTab } from './TradeRepublicTab'
+import { IbkrTab } from './IbkrTab'
 import { FinaryTab } from './FinaryTab'
 // BoursoTab hidden for 1.0.0 — sidecar integration not finished.
 
@@ -23,6 +24,7 @@ export function SyncPage() {
           <TabsTrigger value="exchanges">{t('sync.exchanges.title')}</TabsTrigger>
           <TabsTrigger value="wallets">{t('sync.wallets.title')}</TabsTrigger>
           <TabsTrigger value="tr">{t('sync.tr.title')}</TabsTrigger>
+          <TabsTrigger value="ibkr">{t('sync.ibkr.title')}</TabsTrigger>
           <TabsTrigger value="finary">{t('sync.finary.title')}</TabsTrigger>
         </TabsList>
         <TabsContent value="banks" className="mt-6">
@@ -36,6 +38,9 @@ export function SyncPage() {
         </TabsContent>
         <TabsContent value="tr" className="mt-6">
           <TradeRepublicTab />
+        </TabsContent>
+        <TabsContent value="ibkr" className="mt-6">
+          <IbkrTab />
         </TabsContent>
         <TabsContent value="finary" className="mt-6">
           <FinaryTab />

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -254,6 +254,14 @@ export interface TrSessionStatus {
   expiresAt: string | null
 }
 
+export interface IbkrConnectionStatus {
+  connected: boolean
+  connectionId: number | null
+  status: string | null
+  lastSyncedAt: string | null
+  maskedToken: string | null
+}
+
 export interface BoursoSessionStatus {
   isActive: boolean
   expiresAt: string | null


### PR DESCRIPTION
﻿Adds an **Interactive Brokers** connector — the main missing broker next to Trade Republic and Finary — via the **Flex Web Service**: the user creates an "Open Positions" Flex Query + read-only token once in Client Portal, pastes both into a new tab on the Sync page, and their IBKR portfolio shows up in net worth like any other holdings account (daily auto-sync included).

> Rebased on `main` after #60 merged — this PR is now the `ibkr` commits only. (The sync rate-limit builds on #60's `ClientIp` resolver and bounded bucket store, both on `main` now.)

## Why Flex Web Service (and not the Client Portal / TWS APIs)

Read-only token, plain HTTP + XML, nothing to run next to the app — the other two options require a gateway or desktop process with roughly daily interactive re-auth, hostile to unattended self-hosting. Data is end-of-day, which matches the daily snapshot cadence; live EUR valuation is recomputed from tickers anyway. Full rationale in the included ADR (`docs/decisions/2026-07-19-ibkr-flex-web-service.md`).

## Design

- `SendRequest` → reference code → `GetStatement` (polled with backoff on IBKR's "still generating" 1019), parsed with the JDK DOM parser — **zero new backend dependencies**.
- Positions map onto one `Account` per IBKR account id + `AccountHolding` rows, reusing the existing machinery: `OpenFigiIsinConverter` (ISIN→ticker), `HoldingDedup` (VWAP, made sign-aware for short positions), `CryptoEncryption` (token + query id encrypted at rest), `SchedulerService` (daily auto-sync).
- **IBKR prices are never trusted for valuation** — EUR value is recomputed live from tickers via the existing price path, so net worth stays correct regardless of the account's base currency.
- Safeguards: non-EUR base currency is detected from the statement's `AccountInformation` section and fails the sync with an actionable message (cost basis would otherwise be silently wrong); derivatives (`OPT`/`FUT`/CFD/…) are excluded via an `assetCategory` allowlist instead of slipping through as mispriced stock holdings; `LOT` rows are dropped to avoid double counting; sync failures persist an `ERROR` connection status in a `REQUIRES_NEW` transaction so the status survives the rollback.
- Frontend: an IBKR tab on the Sync page (connect → sync/disconnect), i18n keys in all four locales.

## Validation

- Backend suite on this branch: **697 tests, 0 failures, 0 errors, 9 skipped** (the usual Testcontainers self-skips without Docker). Parser and mapping are fixture-tested against realistic Flex XML.
- Frontend on this exact tree: `tsc` typecheck + ESLint clean, `IbkrTab` vitest 3/3.
- **Exercised end-to-end against a live IBKR account (2026-07-21)**: real statement fetched on first poll, fractional STK position parsed and mapped, cost basis exact to the cent, live EUR valuation resolved, daily snapshot written, and an immediate re-sync was fully idempotent. Details recorded in `docs/features/ibkr-sync.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)




