### PR TITLE
fix(logging): redact Enable Banking session id from log statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (generic `422`) as defense-in-depth, so a bad RPC response can never surface as a
   raw `500` even on an unwrapped call path.
 
+### Security
+
+- **Enable Banking session ids are no longer written to logs in the clear.** The
+  raw session id (stored as `Requisition.requisitionId`) was printed by several
+  sync log statements; it is now replaced with the non-sensitive requisition
+  database id in `SyncService`, and with a short non-reversible SHA-256
+  fingerprint in the low-level connector where only the raw value is available.
+  A new `LogSanitizer.fingerprint(...)` helper keeps the fingerprints stable so
+  log lines can still be correlated during debugging. Defense-in-depth against
+  log aggregators with weaker access control than the primary database (#44).
+
 ## [1.0.13] — 2026-07-07
 
 ### Changed

--- a/backend/src/main/java/com/picsou/adapter/EnableBankingBankConnector.java
+++ b/backend/src/main/java/com/picsou/adapter/EnableBankingBankConnector.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.picsou.config.EnableBankingConfigProvider;
 import com.picsou.exception.SyncException;
 import com.picsou.port.BankConnectorPort;
+import com.picsou.util.LogSanitizer;
 import io.jsonwebtoken.Jwts;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -142,7 +143,7 @@ public class EnableBankingBankConnector implements BankConnectorPort {
             throw new SyncException("Empty session response from Enable Banking /sessions");
         }
 
-        log.info("Enable Banking session created: {}", session.sessionId());
+        log.info("Enable Banking session created: {}", LogSanitizer.fingerprint(session.sessionId()));
         return session.sessionId();
     }
 
@@ -184,12 +185,12 @@ public class EnableBankingBankConnector implements BankConnectorPort {
 
             if (session != null && session.accounts() != null && !session.accounts().isEmpty()) {
                 log.info("Session {} has {} accounts (attempt {}, status={})",
-                    sessionId, session.accounts().size(), attempt, session.status());
+                    LogSanitizer.fingerprint(sessionId), session.accounts().size(), attempt, session.status());
                 return session.accounts();
             }
 
             log.info("Session {} has no accounts yet (attempt {}/{}, status={})",
-                sessionId, attempt, maxAttempts,
+                LogSanitizer.fingerprint(sessionId), attempt, maxAttempts,
                 session != null ? session.status() : "null");
 
             if (attempt < maxAttempts) {
@@ -198,7 +199,7 @@ public class EnableBankingBankConnector implements BankConnectorPort {
         }
 
         log.warn("Session {} still has no accounts after {} attempts — returning empty so the caller can retry asynchronously",
-            sessionId, maxAttempts);
+            LogSanitizer.fingerprint(sessionId), maxAttempts);
         return List.of();
     }
 

--- a/backend/src/main/java/com/picsou/service/SyncService.java
+++ b/backend/src/main/java/com/picsou/service/SyncService.java
@@ -138,7 +138,7 @@ public class SyncService {
         Requisition req = requisitionRepository.findByIdAndMemberId(id, memberId)
             .orElseThrow(() -> new ResourceNotFoundException("Requisition not found"));
 
-        log.info("Retrying sync for {} (session={})", req.getInstitutionName(), req.getRequisitionId());
+        log.info("Retrying sync for {} (requisition #{})", req.getInstitutionName(), req.getId());
         ensureLogoUrl(req);
 
         List<BankConnectorPort.AccountData> accountDataList;
@@ -185,8 +185,8 @@ public class SyncService {
             try {
                 retrySync(req.getId(), memberId);
             } catch (Exception ex) {
-                log.warn("Scheduled retry failed for {} (session={}): {}",
-                    req.getInstitutionName(), req.getRequisitionId(), ex.getMessage());
+                log.warn("Scheduled retry failed for {} (requisition #{}): {}",
+                    req.getInstitutionName(), req.getId(), ex.getMessage());
             }
         }
     }
@@ -256,15 +256,15 @@ public class SyncService {
         // transient provider gap than a broken link. Demoting it would make the status
         // flap LINKED → FAILED on every scheduled resync — keep it LINKED and just skip.
         if (requisition.getStatus() == RequisitionStatus.LINKED) {
-            log.warn("Enable Banking session {} returned no accounts during {} — keeping LINKED, skipping update",
-                requisition.getRequisitionId(), operation);
+            log.warn("Enable Banking requisition #{} returned no accounts during {} — keeping LINKED, skipping update",
+                requisition.getId(), operation);
             return true;
         }
 
         requisition.setStatus(RequisitionStatus.FAILED);
         requisitionRepository.save(requisition);
-        log.info("Enable Banking session {} returned no accounts during {} — marking retryable",
-            requisition.getRequisitionId(), operation);
+        log.info("Enable Banking requisition #{} returned no accounts during {} — marking retryable",
+            requisition.getId(), operation);
         return true;
     }
 

--- a/backend/src/main/java/com/picsou/util/LogSanitizer.java
+++ b/backend/src/main/java/com/picsou/util/LogSanitizer.java
@@ -1,5 +1,8 @@
 package com.picsou.util;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -11,6 +14,8 @@ import java.util.HexFormat;
  * the primary database).
  */
 public final class LogSanitizer {
+
+    private static final Logger log = LoggerFactory.getLogger(LogSanitizer.class);
 
     private LogSanitizer() {}
 
@@ -33,7 +38,12 @@ public final class LogSanitizer {
             // 4 bytes -> 8 hex chars: enough to correlate, far too little to reverse.
             return "sha256:" + HexFormat.of().formatHex(digest, 0, 4);
         } catch (NoSuchAlgorithmException e) {
-            // SHA-256 is a mandatory JVM algorithm; fail closed rather than leak.
+            // SHA-256 is a mandatory JVM algorithm (JCA spec), so this is
+            // effectively unreachable. Surface it if the impossible happens, but
+            // NEVER throw: this helper only feeds log statements, and a throwing
+            // logger would turn a benign log call into a broken sync/auth flow.
+            // Fail closed — redact rather than leak the raw value.
+            log.error("SHA-256 unavailable — cannot fingerprint value for logging; redacting", e);
             return "<redacted>";
         }
     }

--- a/backend/src/main/java/com/picsou/util/LogSanitizer.java
+++ b/backend/src/main/java/com/picsou/util/LogSanitizer.java
@@ -1,0 +1,40 @@
+package com.picsou.util;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+
+/**
+ * Helpers for keeping sensitive values out of log statements (defense-in-depth
+ * against log aggregators / retention systems with weaker access control than
+ * the primary database).
+ */
+public final class LogSanitizer {
+
+    private LogSanitizer() {}
+
+    /**
+     * Returns a short, stable, non-reversible fingerprint of an opaque secret
+     * identifier (e.g. an Enable Banking session id) that is safe to log.
+     *
+     * <p>The raw value is never emitted. Two log lines referring to the same id
+     * still share the same fingerprint, so they can be correlated while
+     * debugging without exposing the id itself. Returns {@code "<none>"} for a
+     * null or blank input.
+     */
+    public static String fingerprint(String value) {
+        if (value == null || value.isBlank()) {
+            return "<none>";
+        }
+        try {
+            byte[] digest = MessageDigest.getInstance("SHA-256")
+                .digest(value.getBytes(StandardCharsets.UTF_8));
+            // 4 bytes -> 8 hex chars: enough to correlate, far too little to reverse.
+            return "sha256:" + HexFormat.of().formatHex(digest, 0, 4);
+        } catch (NoSuchAlgorithmException e) {
+            // SHA-256 is a mandatory JVM algorithm; fail closed rather than leak.
+            return "<redacted>";
+        }
+    }
+}

--- a/backend/src/test/java/com/picsou/util/LogSanitizerTest.java
+++ b/backend/src/test/java/com/picsou/util/LogSanitizerTest.java
@@ -2,9 +2,26 @@ package com.picsou.util;
 
 import org.junit.jupiter.api.Test;
 
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 class LogSanitizerTest {
+
+    @Test
+    void fingerprint_isTheSha256Prefix_notJustAnyDigest() throws NoSuchAlgorithmException {
+        // Pin the actual computation, not just the shape: a regression that swapped
+        // the algorithm (MD5) or the truncation offset would still satisfy the
+        // format-only assertions, but not this.
+        String input = "eb-session-fixture-2026";
+        byte[] digest = MessageDigest.getInstance("SHA-256").digest(input.getBytes(StandardCharsets.UTF_8));
+        String expected = "sha256:" + HexFormat.of().formatHex(digest, 0, 4);
+
+        assertThat(LogSanitizer.fingerprint(input)).isEqualTo(expected);
+    }
 
     @Test
     void fingerprint_neverContainsTheRawValue() {

--- a/backend/src/test/java/com/picsou/util/LogSanitizerTest.java
+++ b/backend/src/test/java/com/picsou/util/LogSanitizerTest.java
@@ -1,0 +1,46 @@
+package com.picsou.util;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LogSanitizerTest {
+
+    @Test
+    void fingerprint_neverContainsTheRawValue() {
+        String sessionId = "b3f1c0de-2a4e-4f6a-9c8d-0123456789ab-super-secret";
+
+        String out = LogSanitizer.fingerprint(sessionId);
+
+        assertThat(out).doesNotContain(sessionId);
+        assertThat(out).startsWith("sha256:");
+    }
+
+    @Test
+    void fingerprint_isStableForTheSameInput() {
+        assertThat(LogSanitizer.fingerprint("session-abc"))
+            .isEqualTo(LogSanitizer.fingerprint("session-abc"));
+    }
+
+    @Test
+    void fingerprint_differsForDifferentInputs() {
+        assertThat(LogSanitizer.fingerprint("session-abc"))
+            .isNotEqualTo(LogSanitizer.fingerprint("session-xyz"));
+    }
+
+    @Test
+    void fingerprint_hasCompactFixedShape() {
+        // "sha256:" (7) + 8 hex chars = 15 chars, regardless of input length.
+        assertThat(LogSanitizer.fingerprint("short")).hasSize(15);
+        assertThat(LogSanitizer.fingerprint("a-considerably-longer-session-identifier-value"))
+            .hasSize(15)
+            .matches("sha256:[0-9a-f]{8}");
+    }
+
+    @Test
+    void fingerprint_returnsPlaceholderForNullOrBlank() {
+        assertThat(LogSanitizer.fingerprint(null)).isEqualTo("<none>");
+        assertThat(LogSanitizer.fingerprint("")).isEqualTo("<none>");
+        assertThat(LogSanitizer.fingerprint("   ")).isEqualTo("<none>");
+    }
+}


### PR DESCRIPTION
Closes #44.

The raw Enable Banking session id (stored as `Requisition.requisitionId`) was printed by several sync log statements. It is not a standalone bank credential (API calls also require the app's RS256 JWT), but keeping it out of logs is worthwhile defense-in-depth against log aggregators with weaker access control than the primary DB.

**What**
- `SyncService`: log the non-sensitive requisition **database id** (`getId()`) instead of the session id, across `retrySync`, `retryAllFailed` and `markRetryableIfEmpty`.
- `EnableBankingBankConnector`: the low-level adapter only has the raw session string, so it now logs a short **non-reversible SHA-256 fingerprint** via a new `LogSanitizer.fingerprint()` helper — stable enough to correlate log lines without ever emitting the id. This also covers the three polling log sites in the same file, per the issue's "no new raw session id logging" criterion.

**Tests:** new `LogSanitizerTest`; full `mvn test` green. CHANGELOG updated under `[Unreleased] › Security`.