### PR TITLE
refactor(price): depend on PriceProviderPort instead of concrete adapters

### DIFF
--- a/backend/src/main/java/com/picsou/adapter/CompositePriceProvider.java
+++ b/backend/src/main/java/com/picsou/adapter/CompositePriceProvider.java
@@ -1,0 +1,72 @@
+package com.picsou.adapter;
+
+import com.picsou.port.PriceProviderPort;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Component;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Routing {@link PriceProviderPort} that keeps the crypto-vs-stock decision in a
+ * single place so services depend on the port abstraction rather than the
+ * concrete adapters.
+ *
+ * <p>Routing preserves the historical behaviour: CoinGecko handles the tickers
+ * it recognises as crypto; <em>everything else</em> — including ISINs that Yahoo
+ * itself reports as unsupported — falls back to Yahoo Finance. It is therefore a
+ * deliberate {@code coinGecko.supports(t) ? coinGecko : yahoo} fallback, not a
+ * "first provider whose supports() is true" scan.
+ */
+@Component
+@Primary
+public class CompositePriceProvider implements PriceProviderPort {
+
+    private final CoinGeckoPriceProvider coinGecko;
+    private final YahooFinancePriceProvider yahoo;
+
+    public CompositePriceProvider(CoinGeckoPriceProvider coinGecko, YahooFinancePriceProvider yahoo) {
+        this.coinGecko = coinGecko;
+        this.yahoo = yahoo;
+    }
+
+    private PriceProviderPort providerFor(String ticker) {
+        return coinGecko.supports(ticker) ? coinGecko : yahoo;
+    }
+
+    @Override
+    public Map<String, BigDecimal> getPricesEur(Set<String> tickers) {
+        if (tickers == null || tickers.isEmpty()) return Map.of();
+
+        Set<String> crypto = new HashSet<>();
+        Set<String> other = new HashSet<>();
+        for (String ticker : tickers) {
+            (coinGecko.supports(ticker) ? crypto : other).add(ticker);
+        }
+
+        Map<String, BigDecimal> result = new HashMap<>();
+        if (!crypto.isEmpty()) result.putAll(coinGecko.getPricesEur(crypto));
+        if (!other.isEmpty()) result.putAll(yahoo.getPricesEur(other));
+        return result;
+    }
+
+    @Override
+    public boolean supports(String ticker) {
+        return coinGecko.supports(ticker) || yahoo.supports(ticker);
+    }
+
+    @Override
+    public Map<LocalDate, BigDecimal> getHistoricalPricesEur(String ticker, LocalDate from, LocalDate to) {
+        return providerFor(ticker).getHistoricalPricesEur(ticker, from, to);
+    }
+
+    @Override
+    public Map<LocalDateTime, BigDecimal> getIntradayPricesEur(String ticker, LocalDateTime from, LocalDateTime to) {
+        return providerFor(ticker).getIntradayPricesEur(ticker, from, to);
+    }
+}

--- a/backend/src/main/java/com/picsou/port/PriceProviderPort.java
+++ b/backend/src/main/java/com/picsou/port/PriceProviderPort.java
@@ -13,8 +13,10 @@ import java.util.Set;
 public interface PriceProviderPort {
 
     /**
-     * Returns prices in EUR for the given tickers.
-     * Tickers not found in this provider return empty (caller tries next provider).
+     * Returns prices in EUR for the given tickers. A ticker this provider cannot
+     * price is omitted from the returned map. {@link com.picsou.adapter.CompositePriceProvider}
+     * routes each ticker to the right concrete provider, so callers depend only
+     * on this port rather than picking a provider themselves.
      */
     Map<String, BigDecimal> getPricesEur(Set<String> tickers);
 

--- a/backend/src/main/java/com/picsou/port/PriceProviderPort.java
+++ b/backend/src/main/java/com/picsou/port/PriceProviderPort.java
@@ -1,6 +1,8 @@
 package com.picsou.port;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.Map;
 import java.util.Set;
 
@@ -18,4 +20,14 @@ public interface PriceProviderPort {
 
     /** Whether this provider supports the given ticker. */
     boolean supports(String ticker);
+
+    /**
+     * Daily historical prices in EUR for a ticker over {@code [from, to]}.
+     * Returns an empty map for an expected upstream failure (the caller treats
+     * anything thrown as a genuine bug).
+     */
+    Map<LocalDate, BigDecimal> getHistoricalPricesEur(String ticker, LocalDate from, LocalDate to);
+
+    /** Intraday (hourly) prices in EUR for a ticker over {@code [from, to]}. */
+    Map<LocalDateTime, BigDecimal> getIntradayPricesEur(String ticker, LocalDateTime from, LocalDateTime to);
 }

--- a/backend/src/main/java/com/picsou/service/PriceService.java
+++ b/backend/src/main/java/com/picsou/service/PriceService.java
@@ -1,8 +1,7 @@
 package com.picsou.service;
 
-import com.picsou.adapter.CoinGeckoPriceProvider;
-import com.picsou.adapter.YahooFinancePriceProvider;
 import com.picsou.model.PriceSnapshot;
+import com.picsou.port.PriceProviderPort;
 import com.picsou.repository.PriceSnapshotRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -21,17 +20,15 @@ public class PriceService {
     private static final Logger log = LoggerFactory.getLogger(PriceService.class);
     private static final long CACHE_TTL_SECONDS = 900; // 15 minutes
 
-    private final CoinGeckoPriceProvider coinGecko;
-    private final YahooFinancePriceProvider yahoo;
+    private final PriceProviderPort priceProvider;
     private final PriceSnapshotRepository priceSnapshotRepository;
 
     // Simple in-memory price cache: ticker → (price, cachedAt)
     private final Map<String, CachedPrice> priceCache = new ConcurrentHashMap<>();
 
-    public PriceService(CoinGeckoPriceProvider coinGecko, YahooFinancePriceProvider yahoo,
+    public PriceService(PriceProviderPort priceProvider,
                         PriceSnapshotRepository priceSnapshotRepository) {
-        this.coinGecko = coinGecko;
-        this.yahoo = yahoo;
+        this.priceProvider = priceProvider;
         this.priceSnapshotRepository = priceSnapshotRepository;
     }
 
@@ -53,15 +50,8 @@ public class PriceService {
             return cached.price();
         }
 
-        // Fetch from appropriate provider
-        Set<String> singleTicker = Set.of(upper);
-        Map<String, BigDecimal> prices;
-
-        if (coinGecko.supports(upper)) {
-            prices = coinGecko.getPricesEur(singleTicker);
-        } else {
-            prices = yahoo.getPricesEur(singleTicker);
-        }
+        // Fetch through the port; the composite provider routes crypto vs. stock.
+        Map<String, BigDecimal> prices = priceProvider.getPricesEur(Set.of(upper));
 
         BigDecimal price = prices.get(upper);
         if (price != null) {
@@ -78,29 +68,20 @@ public class PriceService {
 
         Map<String, BigDecimal> result = new HashMap<>();
 
-        Set<String> cryptoTickers = new HashSet<>();
-        Set<String> stockTickers = new HashSet<>();
-
+        // EUR needs no conversion; everything else goes through the port, which
+        // routes crypto to CoinGecko and the rest to Yahoo and batches each call.
+        Set<String> toFetch = new HashSet<>();
         for (String ticker : tickers) {
             String upper = ticker.toUpperCase(Locale.ROOT);
             if ("EUR".equals(upper)) {
                 result.put(upper, BigDecimal.ONE);
-            } else if (coinGecko.supports(upper)) {
-                cryptoTickers.add(upper);
             } else {
-                stockTickers.add(upper);
+                toFetch.add(upper);
             }
         }
 
-        if (!cryptoTickers.isEmpty()) {
-            coinGecko.getPricesEur(cryptoTickers).forEach((k, v) -> {
-                priceCache.put(k, new CachedPrice(v, Instant.now()));
-                result.put(k, v);
-            });
-        }
-
-        if (!stockTickers.isEmpty()) {
-            yahoo.getPricesEur(stockTickers).forEach((k, v) -> {
+        if (!toFetch.isEmpty()) {
+            priceProvider.getPricesEur(toFetch).forEach((k, v) -> {
                 priceCache.put(k, new CachedPrice(v, Instant.now()));
                 result.put(k, v);
             });
@@ -178,12 +159,7 @@ public class PriceService {
             // Guard per ticker: this runs from PriceBackfillRunner, an ApplicationRunner, so
             // an unguarded throw here would fail Spring Boot startup outright.
             try {
-                Map<LocalDate, BigDecimal> prices;
-                if (coinGecko.supports(upper)) {
-                    prices = coinGecko.getHistoricalPricesEur(upper, from, to);
-                } else {
-                    prices = yahoo.getHistoricalPricesEur(upper, from, to);
-                }
+                Map<LocalDate, BigDecimal> prices = priceProvider.getHistoricalPricesEur(upper, from, to);
 
                 for (var entry : prices.entrySet()) {
                     if (priceSnapshotRepository.findByTickerAndDate(upper, entry.getKey()).isEmpty()) {
@@ -234,7 +210,7 @@ public class PriceService {
 
     /**
      * Fetch intraday (hourly) prices for a ticker over the given time range.
-     * Routes to CoinGecko for crypto, Yahoo Finance for stocks/ETFs.
+     * The port's composite provider routes crypto to CoinGecko, the rest to Yahoo.
      */
     public Map<LocalDateTime, BigDecimal> getIntradayPricesEur(String ticker, LocalDateTime from, LocalDateTime to) {
         if (ticker == null || ticker.isBlank() || "EUR".equalsIgnoreCase(ticker)) {
@@ -242,11 +218,6 @@ public class PriceService {
         }
 
         String upper = ticker.toUpperCase(Locale.ROOT);
-
-        if (coinGecko.supports(upper)) {
-            return coinGecko.getIntradayPricesEur(upper, from, to);
-        } else {
-            return yahoo.getIntradayPricesEur(upper, from, to);
-        }
+        return priceProvider.getIntradayPricesEur(upper, from, to);
     }
 }

--- a/backend/src/test/java/com/picsou/adapter/CompositePriceProviderTest.java
+++ b/backend/src/test/java/com/picsou/adapter/CompositePriceProviderTest.java
@@ -1,0 +1,90 @@
+package com.picsou.adapter;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Map;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class CompositePriceProviderTest {
+
+    @Mock CoinGeckoPriceProvider coinGecko;
+    @Mock YahooFinancePriceProvider yahoo;
+
+    private CompositePriceProvider composite() {
+        return new CompositePriceProvider(coinGecko, yahoo);
+    }
+
+    @Test
+    void getPricesEur_splitsCryptoToCoinGecko_restToYahoo_andMerges() {
+        when(coinGecko.supports("BTC")).thenReturn(true);
+        when(coinGecko.supports("AAPL")).thenReturn(false);
+        when(coinGecko.getPricesEur(Set.of("BTC"))).thenReturn(Map.of("BTC", new BigDecimal("50000")));
+        when(yahoo.getPricesEur(Set.of("AAPL"))).thenReturn(Map.of("AAPL", new BigDecimal("200")));
+
+        Map<String, BigDecimal> prices = composite().getPricesEur(Set.of("BTC", "AAPL"));
+
+        assertThat(prices)
+            .containsEntry("BTC", new BigDecimal("50000"))
+            .containsEntry("AAPL", new BigDecimal("200"));
+    }
+
+    @Test
+    void getPricesEur_empty_callsNoProvider() {
+        assertThat(composite().getPricesEur(Set.of())).isEmpty();
+        verifyNoInteractions(coinGecko, yahoo);
+    }
+
+    @Test
+    void historical_routesCryptoToCoinGecko() {
+        LocalDate from = LocalDate.of(2026, 1, 1);
+        LocalDate to = LocalDate.of(2026, 6, 1);
+        when(coinGecko.supports("ETH")).thenReturn(true);
+        when(coinGecko.getHistoricalPricesEur("ETH", from, to)).thenReturn(Map.of(from, new BigDecimal("3000")));
+
+        assertThat(composite().getHistoricalPricesEur("ETH", from, to)).containsEntry(from, new BigDecimal("3000"));
+        verify(yahoo, org.mockito.Mockito.never()).getHistoricalPricesEur(any(), any(), any());
+    }
+
+    @Test
+    void historical_routesUnsupportedToYahoo_evenWhenYahooAlsoReportsUnsupported() {
+        // ISINs: CoinGecko says no, Yahoo says no too — historically they still fall through to Yahoo.
+        LocalDate from = LocalDate.of(2026, 1, 1);
+        LocalDate to = LocalDate.of(2026, 6, 1);
+        String isin = "US0378331005";
+        when(coinGecko.supports(isin)).thenReturn(false);
+        when(yahoo.getHistoricalPricesEur(eq(isin), any(), any())).thenReturn(Map.of(from, new BigDecimal("42")));
+
+        assertThat(composite().getHistoricalPricesEur(isin, from, to)).containsEntry(from, new BigDecimal("42"));
+    }
+
+    @Test
+    void intraday_routesUnsupportedToYahoo() {
+        LocalDateTime from = LocalDateTime.of(2026, 1, 1, 0, 0);
+        LocalDateTime to = LocalDateTime.of(2026, 1, 2, 0, 0);
+        when(coinGecko.supports("AAPL")).thenReturn(false);
+        when(yahoo.getIntradayPricesEur("AAPL", from, to)).thenReturn(Map.of(from, new BigDecimal("199")));
+
+        assertThat(composite().getIntradayPricesEur("AAPL", from, to)).containsEntry(from, new BigDecimal("199"));
+    }
+
+    @Test
+    void supports_isTrueIfEitherProviderSupports() {
+        when(coinGecko.supports("BTC")).thenReturn(true);
+
+        assertThat(composite().supports("BTC")).isTrue();
+    }
+}

--- a/backend/src/test/java/com/picsou/adapter/CompositePriceProviderTest.java
+++ b/backend/src/test/java/com/picsou/adapter/CompositePriceProviderTest.java
@@ -14,6 +14,7 @@ import java.util.Set;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -29,17 +30,28 @@ class CompositePriceProviderTest {
     }
 
     @Test
-    void getPricesEur_splitsCryptoToCoinGecko_restToYahoo_andMerges() {
+    void getPricesEur_splitsCryptoToCoinGecko_restToYahoo_andBatchesEachProviderOnce() {
+        // Two crypto + two stock tickers, so "one batch call per provider" is
+        // distinguishable from a per-ticker regression (the whole point of #35).
         when(coinGecko.supports("BTC")).thenReturn(true);
+        when(coinGecko.supports("ETH")).thenReturn(true);
         when(coinGecko.supports("AAPL")).thenReturn(false);
-        when(coinGecko.getPricesEur(Set.of("BTC"))).thenReturn(Map.of("BTC", new BigDecimal("50000")));
-        when(yahoo.getPricesEur(Set.of("AAPL"))).thenReturn(Map.of("AAPL", new BigDecimal("200")));
+        when(coinGecko.supports("MC.PA")).thenReturn(false);
+        when(coinGecko.getPricesEur(Set.of("BTC", "ETH")))
+            .thenReturn(Map.of("BTC", new BigDecimal("50000"), "ETH", new BigDecimal("3000")));
+        when(yahoo.getPricesEur(Set.of("AAPL", "MC.PA")))
+            .thenReturn(Map.of("AAPL", new BigDecimal("200"), "MC.PA", new BigDecimal("700")));
 
-        Map<String, BigDecimal> prices = composite().getPricesEur(Set.of("BTC", "AAPL"));
+        Map<String, BigDecimal> prices = composite().getPricesEur(Set.of("BTC", "ETH", "AAPL", "MC.PA"));
 
         assertThat(prices)
             .containsEntry("BTC", new BigDecimal("50000"))
-            .containsEntry("AAPL", new BigDecimal("200"));
+            .containsEntry("ETH", new BigDecimal("3000"))
+            .containsEntry("AAPL", new BigDecimal("200"))
+            .containsEntry("MC.PA", new BigDecimal("700"));
+        // Each provider is called exactly once, with the full batch — not per ticker.
+        verify(coinGecko, times(1)).getPricesEur(Set.of("BTC", "ETH"));
+        verify(yahoo, times(1)).getPricesEur(Set.of("AAPL", "MC.PA"));
     }
 
     @Test

--- a/backend/src/test/java/com/picsou/adapter/CompositePriceProviderTest.java
+++ b/backend/src/test/java/com/picsou/adapter/CompositePriceProviderTest.java
@@ -94,6 +94,17 @@ class CompositePriceProviderTest {
     }
 
     @Test
+    void intraday_routesCryptoToCoinGecko() {
+        LocalDateTime from = LocalDateTime.of(2026, 1, 1, 0, 0);
+        LocalDateTime to = LocalDateTime.of(2026, 1, 2, 0, 0);
+        when(coinGecko.supports("BTC")).thenReturn(true);
+        when(coinGecko.getIntradayPricesEur("BTC", from, to)).thenReturn(Map.of(from, new BigDecimal("45000")));
+
+        assertThat(composite().getIntradayPricesEur("BTC", from, to)).containsEntry(from, new BigDecimal("45000"));
+        verify(yahoo, org.mockito.Mockito.never()).getIntradayPricesEur(any(), any(), any());
+    }
+
+    @Test
     void supports_isTrueIfEitherProviderSupports() {
         when(coinGecko.supports("BTC")).thenReturn(true);
 

--- a/backend/src/test/java/com/picsou/service/PriceServiceTest.java
+++ b/backend/src/test/java/com/picsou/service/PriceServiceTest.java
@@ -3,8 +3,7 @@ package com.picsou.service;
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
-import com.picsou.adapter.CoinGeckoPriceProvider;
-import com.picsou.adapter.YahooFinancePriceProvider;
+import com.picsou.port.PriceProviderPort;
 import com.picsou.repository.PriceSnapshotRepository;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -43,8 +42,7 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class PriceServiceTest {
 
-    @Mock CoinGeckoPriceProvider coinGecko;
-    @Mock YahooFinancePriceProvider yahoo;
+    @Mock PriceProviderPort priceProvider;
     @Mock PriceSnapshotRepository priceSnapshotRepository;
 
     @InjectMocks PriceService priceService;
@@ -72,12 +70,10 @@ class PriceServiceTest {
     @Test
     void backfill_continuesPastAFailingTicker_andLogsItAtError() {
         LocalDate from = LocalDate.of(2026, 1, 1);
-        when(coinGecko.supports("BTC")).thenReturn(true);
-        when(coinGecko.supports("ETH")).thenReturn(true);
         // BTC blows up with a genuine bug; ETH must still be backfilled.
-        when(coinGecko.getHistoricalPricesEur(eq("BTC"), any(), any()))
+        when(priceProvider.getHistoricalPricesEur(eq("BTC"), any(), any()))
             .thenThrow(new IllegalStateException("a real bug"));
-        when(coinGecko.getHistoricalPricesEur(eq("ETH"), any(), any()))
+        when(priceProvider.getHistoricalPricesEur(eq("ETH"), any(), any()))
             .thenReturn(Map.of(from, new BigDecimal("3000")));
         when(priceSnapshotRepository.findByTickerAndDate(any(), any())).thenReturn(Optional.empty());
 
@@ -101,10 +97,9 @@ class PriceServiceTest {
     }
 
     @Test
-    void backfill_routesToYahoo_forTickersCoinGeckoDoesNotSupport() {
+    void backfill_savesPricesReturnedByThePort() {
         LocalDate from = LocalDate.of(2026, 1, 1);
-        when(coinGecko.supports("AAPL")).thenReturn(false);
-        when(yahoo.getHistoricalPricesEur(eq("AAPL"), any(), any()))
+        when(priceProvider.getHistoricalPricesEur(eq("AAPL"), any(), any()))
             .thenReturn(Map.of(from, new BigDecimal("200")));
         when(priceSnapshotRepository.findByTickerAndDate(any(), any())).thenReturn(Optional.empty());
 

--- a/docs/decisions/2026-01-01-ports-and-adapters.md
+++ b/docs/decisions/2026-01-01-ports-and-adapters.md
@@ -19,7 +19,7 @@ The 5 port interfaces:
 | `TradeRepublicPort` | `TradeRepublicAdapter` |
 | `CryptoExchangePort` | `BinanceAdapter` |
 | `WalletPort` | `BitcoinWalletAdapter`, `EvmWalletAdapter`, `SolanaWalletAdapter` |
-| `PriceProviderPort` | `CoinGeckoPriceProvider`, `YahooFinancePriceProvider` |
+| `PriceProviderPort` | `CompositePriceProvider` (`@Primary`, routes crypto → CoinGecko, rest → Yahoo), delegating to `CoinGeckoPriceProvider` and `YahooFinancePriceProvider` |
 
 Swapping a provider means implementing the port and swapping the `@Primary` bean.
 

--- a/docs/features/price-service.md
+++ b/docs/features/price-service.md
@@ -10,12 +10,14 @@ Picsou needs EUR prices for crypto assets (BTC, ETH, SOL, etc.) and stocks/ETFs 
 
 ### Provider routing
 
-`PriceService.getPriceEur(ticker)` routes each ticker to the appropriate provider:
+`PriceService` depends only on the `PriceProviderPort` abstraction; the crypto-vs-stock routing lives in `CompositePriceProvider` (the `@Primary` port bean), which picks a provider per ticker:
 
 - **CoinGecko** (`CoinGeckoPriceProvider`): Handles crypto tickers (BTC, ETH, SOL, BNB, ADA, XRP, DOGE, DOT, MATIC, AVAX, LINK, UNI, ATOM, LTC, NEAR, ARB, OP, SHIB, PEPE, SUI). Uses the `/simple/price` endpoint with `vs_currencies=eur`. Supports batch queries (all tickers in one request).
 - **Yahoo Finance** (`YahooFinancePriceProvider`): Handles everything CoinGecko does not -- stocks, ETFs, indices. Uses the unofficial `/v8/finance/chart/{ticker}` endpoint. Fetched per-ticker (no batch). Tickers like `IWDA.AS`, `MC.PA` are already EUR-denominated; foreign-currency tickers (USD/JPY/GBp/...) are converted to EUR inside the adapter via Yahoo's own `{CURRENCY}EUR=X` chart endpoint, with a 15-minute FX cache mirroring the price cache TTL. See [ADR 2026-05-19](../decisions/2026-05-19-yahoo-fx-conversion.md).
 
-Both providers implement `PriceProviderPort` with `supports(ticker)` and `getPricesEur(tickers)`.
+Routing is a deliberate `coinGecko.supports(ticker) ? coinGecko : yahoo` fallback (not a "first provider whose `supports()` is true" scan), so a ticker CoinGecko does not recognise — including a plain ISIN that Yahoo itself reports as unsupported — still falls through to Yahoo.
+
+All three providers (`CoinGeckoPriceProvider`, `YahooFinancePriceProvider`, `CompositePriceProvider`) implement `PriceProviderPort`, which exposes `supports(ticker)`, `getPricesEur(tickers)`, `getHistoricalPricesEur(...)` and `getIntradayPricesEur(...)`.
 
 ### Caching
 
@@ -39,7 +41,8 @@ Both providers implement `PriceProviderPort` with `supports(ticker)` and `getPri
 - `backend/src/main/java/com/picsou/service/SchedulerService.java` -- Hourly price refresh cron
 - `backend/src/main/java/com/picsou/adapter/CoinGeckoPriceProvider.java` -- CoinGecko `/simple/price` with ticker-to-ID mapping
 - `backend/src/main/java/com/picsou/adapter/YahooFinancePriceProvider.java` -- Yahoo Finance `/v8/finance/chart/{ticker}`
-- `backend/src/main/java/com/picsou/port/PriceProviderPort.java` -- Port interface with `supports()` and `getPricesEur()`
+- `backend/src/main/java/com/picsou/adapter/CompositePriceProvider.java` -- `@Primary` port bean; routes crypto to CoinGecko and everything else to Yahoo
+- `backend/src/main/java/com/picsou/port/PriceProviderPort.java` -- Port interface: `supports()`, `getPricesEur()`, `getHistoricalPricesEur()`, `getIntradayPricesEur()`
 
 ### Flow
 

--- a/docs/features/price-service.md
+++ b/docs/features/price-service.md
@@ -37,7 +37,7 @@ All three providers (`CoinGeckoPriceProvider`, `YahooFinancePriceProvider`, `Com
 
 ### Key files
 
-- `backend/src/main/java/com/picsou/service/PriceService.java` -- Price routing, caching, conversion
+- `backend/src/main/java/com/picsou/service/PriceService.java` -- Caching, EUR conversion, snapshot persistence (routing delegated to the port)
 - `backend/src/main/java/com/picsou/service/SchedulerService.java` -- Hourly price refresh cron
 - `backend/src/main/java/com/picsou/adapter/CoinGeckoPriceProvider.java` -- CoinGecko `/simple/price` with ticker-to-ID mapping
 - `backend/src/main/java/com/picsou/adapter/YahooFinancePriceProvider.java` -- Yahoo Finance `/v8/finance/chart/{ticker}`
@@ -60,7 +60,7 @@ Check cache: CachedPrice for "BTC"
         +-- miss or expired
                 |
                 v
-        CoinGeckoPriceProvider.supports("BTC") --> true
+        PriceProviderPort.getPricesEur({"BTC"})  (CompositePriceProvider routes: supports("BTC") --> CoinGecko)
                 |
                 v
         GET api.coingecko.com/api/v3/simple/price?ids=bitcoin&vs_currencies=eur
@@ -80,7 +80,7 @@ Collect all non-null tickers from accounts
 PriceService.refreshPrices(tickers)
         |
         v
-Partition: crypto --> CoinGecko | stocks --> Yahoo
+PriceProviderPort.getPricesEur(tickers)  (CompositePriceProvider partitions: crypto --> CoinGecko | rest --> Yahoo)
         |
         v
 Bulk fetch, update cache

--- a/docs/features/price-service.md
+++ b/docs/features/price-service.md
@@ -108,7 +108,8 @@ Bulk fetch, update cache
 
 ## Tests
 
-- `PriceServiceTest` -- unit tests for caching, routing, conversion
+- `PriceServiceTest` -- unit tests for caching, conversion, backfill guard
+- `CompositePriceProviderTest` -- unit tests for crypto/stock routing and batching
 - `CoinGeckoPriceProviderTest` -- unit tests for ticker mapping
 - `YahooFinancePriceProviderTest` -- unit tests for response parsing
 


### PR DESCRIPTION
Closes #35.

`PriceService` referenced `CoinGeckoPriceProvider` and `YahooFinancePriceProvider` directly, against the ports-and-adapters convention.

**What**
- New `CompositePriceProvider` (`@Primary PriceProviderPort`) holds both adapters and does the crypto-vs-stock routing internally, so `PriceService` depends only on the port.
- `PriceProviderPort` gains `getHistoricalPricesEur` / `getIntradayPricesEur` (both adapters already implemented them).
- Routing preserves the **exact** existing behaviour: `coinGecko.supports(t) ? coinGecko : yahoo` — a ticker CoinGecko doesn't recognise (including a plain ISIN Yahoo itself reports as unsupported) still falls through to Yahoo, rather than a "first provider whose supports() is true" scan.

**Tests:** `PriceServiceTest` now mocks the port; routing coverage moved to new `CompositePriceProviderTest`; full `mvn test` green.