### PR TITLE
fix(auth): probe the session from PublicOnly so /login doesn't flash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Opening `/login` after a restart no longer flashes the form when you have a
+  session.** `isAuthenticated` mirrors `sessionStorage`, which is wiped on every
+  tab/browser close — but the HttpOnly cookies can keep a "Remember Me" session
+  alive for 90 days. Only `RequireAuth` probed the cookie-backed session, so
+  navigating straight to `/login` showed the login form even though the session
+  was restorable. `PublicOnly` now runs the same probe (shared query key, so
+  it's a single request) and redirects into the app when the session
+  rehydrates; the mid-login MFA challenge page opts out (`probe={false}`).
 - **Wallet sync and removal failures now say why.** Both buttons reported nothing
   at all when they failed — the row simply re-enabled, and the delete dialog sat
   there — so a `422` from an RPC outage was indistinguishable from success. The

--- a/frontend/src/app/routes.tsx
+++ b/frontend/src/app/routes.tsx
@@ -48,9 +48,11 @@ export const router = createBrowserRouter([
   {
     // /login/mfa is also for unauthenticated visitors — the user is mid-login
     // (mfa_challenge cookie set, access_token NOT yet set), so PublicOnly applies.
+    // No session to restore yet, so skip the probe (a /auth/refresh here would
+    // 401 and just flash a skeleton over the challenge form).
     path: '/login/mfa',
     element: (
-      <PublicOnly>
+      <PublicOnly probe={false}>
         <SuspensePage>
           <MfaChallengePage />
         </SuspensePage>

--- a/frontend/src/features/auth/guards.test.tsx
+++ b/frontend/src/features/auth/guards.test.tsx
@@ -1,0 +1,86 @@
+import '@testing-library/jest-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+function memoryStorage(): Storage {
+  const m = new Map<string, string>()
+  return {
+    getItem: (key) => m.get(key) ?? null,
+    setItem: (key, value) => void m.set(key, String(value)),
+    removeItem: (key) => void m.delete(key),
+    clear: () => m.clear(),
+    key: (index) => [...m.keys()][index] ?? null,
+    get length() { return m.size },
+  } as Storage
+}
+
+vi.stubGlobal('localStorage', memoryStorage())
+vi.stubGlobal('sessionStorage', memoryStorage())
+
+const { refresh } = vi.hoisted(() => ({ refresh: vi.fn() }))
+vi.mock('@/features/auth/api', () => ({ authApi: { refresh } }))
+
+const { PublicOnly } = await import('./guards')
+const { useAuthStore } = await import('@/stores/auth-store')
+const { useAppStore } = await import('@/stores/app-store')
+
+const USER = { username: 'alice', role: 'ADMIN', memberId: 1, displayName: 'Alice' }
+
+function renderPublicOnly(probe = true) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter initialEntries={['/login']}>
+        <PublicOnly probe={probe}>
+          <div>login-form</div>
+        </PublicOnly>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  )
+}
+
+describe('PublicOnly session probe', () => {
+  beforeEach(() => {
+    refresh.mockReset()
+    useAuthStore.setState({ user: null, isAuthenticated: false })
+    useAppStore.setState({ demoMode: false })
+  })
+
+  it('shows the login form when no session is restorable', async () => {
+    refresh.mockRejectedValue(new Error('401'))
+
+    renderPublicOnly()
+
+    await waitFor(() => expect(screen.getByText('login-form')).toBeInTheDocument())
+    expect(refresh).toHaveBeenCalledTimes(1)
+  })
+
+  it('holds the form and rehydrates the session when the cookie is still valid', async () => {
+    refresh.mockResolvedValue(USER)
+
+    renderPublicOnly()
+
+    // The login form must never flash while a restorable session is being probed.
+    expect(screen.queryByText('login-form')).not.toBeInTheDocument()
+    await waitFor(() => expect(useAuthStore.getState().isAuthenticated).toBe(true))
+    expect(screen.queryByText('login-form')).not.toBeInTheDocument()
+  })
+
+  it('skips the probe on the MFA challenge page (probe=false)', () => {
+    renderPublicOnly(false)
+
+    expect(screen.getByText('login-form')).toBeInTheDocument()
+    expect(refresh).not.toHaveBeenCalled()
+  })
+
+  it('redirects an already-authenticated visitor without probing', () => {
+    useAuthStore.setState({ user: USER, isAuthenticated: true })
+
+    renderPublicOnly()
+
+    expect(screen.queryByText('login-form')).not.toBeInTheDocument()
+    expect(refresh).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/features/auth/guards.test.tsx
+++ b/frontend/src/features/auth/guards.test.tsx
@@ -83,4 +83,13 @@ describe('PublicOnly session probe', () => {
     expect(screen.queryByText('login-form')).not.toBeInTheDocument()
     expect(refresh).not.toHaveBeenCalled()
   })
+
+  it('redirects in demo mode without probing', () => {
+    useAppStore.setState({ demoMode: true })
+
+    renderPublicOnly()
+
+    expect(screen.queryByText('login-form')).not.toBeInTheDocument()
+    expect(refresh).not.toHaveBeenCalled()
+  })
 })

--- a/frontend/src/features/auth/guards.tsx
+++ b/frontend/src/features/auth/guards.tsx
@@ -22,11 +22,36 @@ export function RequireAuth({ children }: { children: React.ReactNode }) {
   return <Navigate to="/login" replace />
 }
 
-export function PublicOnly({ children }: { children: React.ReactNode }) {
+export function PublicOnly({
+  children,
+  probe = true,
+}: {
+  children: React.ReactNode
+  /**
+   * Probe the cookie-backed session before showing a public-only page. On by
+   * default so opening `/login` after a tab/browser restart rehydrates a
+   * restorable "Remember Me" session and redirects into the app, instead of
+   * showing the login form. Set `false` on the mid-login MFA challenge page,
+   * where there is no session to restore yet. Shares the same query key as
+   * `RequireAuth`, so a single probe is reused across guards.
+   */
+  probe?: boolean
+}) {
   const isAuthenticated = useAuthStore(s => s.isAuthenticated)
+  const login = useAuthStore(s => s.login)
   const demoMode = useAppStore(s => s.demoMode)
 
+  const shouldProbe = probe && !demoMode && !isAuthenticated
+  const sessionProbe = useSessionProbe(shouldProbe)
+
+  useEffect(() => {
+    if (sessionProbe.isSuccess) login(sessionProbe.data)
+  }, [sessionProbe.isSuccess, sessionProbe.data, login])
+
   if (demoMode || isAuthenticated) return <Navigate to="/" replace />
+  // While the probe resolves (only when actually enabled), hold the form back so
+  // a restorable session redirects into the app rather than flashing /login.
+  if (shouldProbe && (sessionProbe.isPending || sessionProbe.isSuccess)) return <LoadingSkeleton />
 
   return <>{children}</>
 }


### PR DESCRIPTION
`isAuthenticated` mirrors `sessionStorage`, which is wiped on every tab/browser close, while the HttpOnly cookies can keep a "Remember Me" session alive for 90 days. Only `RequireAuth` probed the cookie-backed session, so opening `/login` directly after a restart showed the login form despite a restorable session.

**What**
- `PublicOnly` now runs `useSessionProbe` too. It shares `RequireAuth`'s query key, so React Query dedupes it into a **single probe reused across guards** (the "single bootstrap probe" the docs asked for).
- A restorable session rehydrates the store and redirects into the app instead of flashing the form.
- The mid-login MFA challenge page opts out via `probe={false}` (no session to restore; a `/auth/refresh` there would 401).

Addresses the documented follow-up (2) in `docs/features/mfa-and-remember-me.md`. New `guards.test.tsx`; typecheck, lint and vitest green.