### PR TITLE
fix(crypto): pin UTF-8 and validate key length in CryptoEncryption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (generic `422`) as defense-in-depth, so a bad RPC response can never surface as a
   raw `500` even on an unwrapped call path.
 
+### Security
+
+- **At-rest encryption now pins UTF-8 and validates the key length at startup.**
+  `CryptoEncryption` encoded/decoded secrets with the platform-default charset,
+  so a non-ASCII secret (e.g. a passphrase with accented characters) could
+  round-trip incorrectly on a non-UTF-8 JVM; both directions now use
+  `StandardCharsets.UTF_8`. `CRYPTO_ENCRYPTION_KEY` is also validated at bean
+  construction — an invalid-base64 or wrong-length key fails fast with a clear
+  message instead of silently selecting a weaker AES variant or throwing a
+  cryptic `InvalidKeyException` at the first encrypt/decrypt.
+
 ## [1.0.13] — 2026-07-07
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,13 +134,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 
 - **At-rest encryption now pins UTF-8 and validates the key length at startup.**
-  `CryptoEncryption` encoded/decoded secrets with the platform-default charset,
-  so a non-ASCII secret (e.g. a passphrase with accented characters) could
-  round-trip incorrectly on a non-UTF-8 JVM; both directions now use
-  `StandardCharsets.UTF_8`. `CRYPTO_ENCRYPTION_KEY` is also validated at bean
-  construction — an invalid-base64 or wrong-length key fails fast with a clear
-  message instead of silently selecting a weaker AES variant or throwing a
-  cryptic `InvalidKeyException` at the first encrypt/decrypt.
+  `CryptoEncryption` encoded/decoded secrets with the platform-default charset.
+  A single JVM with a stable charset round-trips fine, but the moment the
+  charset differs across the boundary — a non-UTF-8 JVM writing and a UTF-8 one
+  reading (or vice versa), or interop with any UTF-8 consumer — a non-ASCII
+  secret (e.g. an accented passphrase) decodes to garbage. Both directions now
+  pin `StandardCharsets.UTF_8` for deterministic behaviour. (Migration note:
+  any non-ASCII ciphertext written by a *non*-UTF-8 JVM before this change would
+  now read back mangled — effectively impossible on Java 21, whose default is
+  UTF-8, unless `-Dfile.encoding` was overridden.) `CRYPTO_ENCRYPTION_KEY` is
+  also validated at bean construction — an invalid-base64 or wrong-length key
+  fails fast with a clear message instead of silently selecting a weaker AES
+  variant or throwing a cryptic `InvalidKeyException` at the first
+  encrypt/decrypt.
 
 ## [1.0.13] — 2026-07-07
 

--- a/backend/src/main/java/com/picsou/config/CryptoEncryption.java
+++ b/backend/src/main/java/com/picsou/config/CryptoEncryption.java
@@ -9,6 +9,7 @@ import javax.crypto.Cipher;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.GCMParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
 import java.security.SecureRandom;
 import java.util.Base64;
 
@@ -29,7 +30,25 @@ public class CryptoEncryption {
                 "CRYPTO_ENCRYPTION_KEY is required. Generate one with: " +
                 "openssl rand -base64 32");
         }
-        this.key = new SecretKeySpec(Base64.getDecoder().decode(base64Key), "AES");
+        byte[] keyBytes;
+        try {
+            keyBytes = Base64.getDecoder().decode(base64Key);
+        } catch (IllegalArgumentException ex) {
+            throw new IllegalStateException(
+                "CRYPTO_ENCRYPTION_KEY is not valid base64. Generate one with: " +
+                "openssl rand -base64 32", ex);
+        }
+        // Fail fast on a misconfigured key length. new SecretKeySpec accepts any
+        // length, so an accidentally-truncated key would otherwise silently pick a
+        // weaker AES variant (or throw a cryptic InvalidKeyException only at the
+        // first encrypt/decrypt, long after startup).
+        if (keyBytes.length != 16 && keyBytes.length != 24 && keyBytes.length != 32) {
+            throw new IllegalStateException(
+                "CRYPTO_ENCRYPTION_KEY must decode to 16, 24 or 32 bytes " +
+                "(AES-128/192/256); got " + keyBytes.length + " bytes. Generate a " +
+                "256-bit key with: openssl rand -base64 32");
+        }
+        this.key = new SecretKeySpec(keyBytes, "AES");
     }
 
     public String encrypt(String plainText) {
@@ -40,7 +59,7 @@ public class CryptoEncryption {
             random.nextBytes(iv);
             Cipher cipher = Cipher.getInstance(ALGORITHM);
             cipher.init(Cipher.ENCRYPT_MODE, key, new GCMParameterSpec(GCM_TAG_LENGTH, iv));
-            byte[] encrypted = cipher.doFinal(plainText.getBytes());
+            byte[] encrypted = cipher.doFinal(plainText.getBytes(StandardCharsets.UTF_8));
             byte[] combined = new byte[iv.length + encrypted.length];
             System.arraycopy(iv, 0, combined, 0, iv.length);
             System.arraycopy(encrypted, 0, combined, iv.length, encrypted.length);
@@ -59,7 +78,7 @@ public class CryptoEncryption {
             Cipher cipher = Cipher.getInstance(ALGORITHM);
             cipher.init(Cipher.DECRYPT_MODE, key, new GCMParameterSpec(GCM_TAG_LENGTH, iv));
             byte[] decrypted = cipher.doFinal(combined, iv.length, combined.length - iv.length);
-            return new String(decrypted);
+            return new String(decrypted, StandardCharsets.UTF_8);
         } catch (Exception ex) {
             throw new RuntimeException("Decryption failed", ex);
         }

--- a/backend/src/test/java/com/picsou/config/CryptoEncryptionTest.java
+++ b/backend/src/test/java/com/picsou/config/CryptoEncryptionTest.java
@@ -24,9 +24,12 @@ class CryptoEncryptionTest {
     }
 
     @Test
-    void roundTrips_nonAsciiValue_regardlessOfPlatformCharset() {
-        // The bug this guards: encrypt used the platform-default charset, so a
-        // non-ASCII secret could round-trip incorrectly on a non-UTF-8 JVM.
+    void roundTripsNonAsciiValue() {
+        // Same-JVM round-trip smoke test for non-ASCII secrets. Note: this can't by
+        // itself distinguish the fix from the bug — with a *single* consistent
+        // charset both encrypt and decrypt agree, so it passes either way. The real
+        // value of pinning UTF-8 is deterministic behaviour across JVMs / interop;
+        // this just guards that non-ASCII input survives the round-trip at all.
         CryptoEncryption crypto = crypto();
         String secret = "clé-très-secrète_日本語_🔐";
 

--- a/backend/src/test/java/com/picsou/config/CryptoEncryptionTest.java
+++ b/backend/src/test/java/com/picsou/config/CryptoEncryptionTest.java
@@ -1,0 +1,81 @@
+package com.picsou.config;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Base64;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class CryptoEncryptionTest {
+
+    private static final String KEY_256 = Base64.getEncoder().encodeToString(new byte[32]);
+
+    private CryptoEncryption crypto() {
+        return new CryptoEncryption(KEY_256);
+    }
+
+    @Test
+    void roundTrips_asciiValue() {
+        CryptoEncryption crypto = crypto();
+        String secret = "sk_live_0123456789";
+
+        assertThat(crypto.decrypt(crypto.encrypt(secret))).isEqualTo(secret);
+    }
+
+    @Test
+    void roundTrips_nonAsciiValue_regardlessOfPlatformCharset() {
+        // The bug this guards: encrypt used the platform-default charset, so a
+        // non-ASCII secret could round-trip incorrectly on a non-UTF-8 JVM.
+        CryptoEncryption crypto = crypto();
+        String secret = "clé-très-secrète_日本語_🔐";
+
+        assertThat(crypto.decrypt(crypto.encrypt(secret))).isEqualTo(secret);
+    }
+
+    @Test
+    void producesDifferentCiphertextEachTime_randomNonce() {
+        CryptoEncryption crypto = crypto();
+
+        assertThat(crypto.encrypt("same-input")).isNotEqualTo(crypto.encrypt("same-input"));
+    }
+
+    @Test
+    void nullValuesPassThrough() {
+        CryptoEncryption crypto = crypto();
+
+        assertThat(crypto.encrypt(null)).isNull();
+        assertThat(crypto.decrypt(null)).isNull();
+    }
+
+    @Test
+    void rejectsBlankKey() {
+        assertThatThrownBy(() -> new CryptoEncryption("  "))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("CRYPTO_ENCRYPTION_KEY is required");
+    }
+
+    @Test
+    void rejectsInvalidBase64Key() {
+        assertThatThrownBy(() -> new CryptoEncryption("not base64!!!"))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("not valid base64");
+    }
+
+    @Test
+    void rejectsWrongKeyLength() {
+        String twentyBytes = Base64.getEncoder().encodeToString(new byte[20]);
+
+        assertThatThrownBy(() -> new CryptoEncryption(twentyBytes))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("16, 24 or 32 bytes")
+            .hasMessageContaining("got 20 bytes");
+    }
+
+    @Test
+    void acceptsAes128And192KeyLengths() {
+        // 16 and 24-byte keys are valid AES sizes; only lengths outside {16,24,32} fail.
+        assertThat(new CryptoEncryption(Base64.getEncoder().encodeToString(new byte[16]))).isNotNull();
+        assertThat(new CryptoEncryption(Base64.getEncoder().encodeToString(new byte[24]))).isNotNull();
+    }
+}


### PR DESCRIPTION
Two robustness fixes to the AES-256-GCM at-rest encryption:

- **Encode/decode with `StandardCharsets.UTF_8`** instead of the platform default. A non-ASCII secret (e.g. an accented passphrase) could round-trip incorrectly on a JVM whose default charset is not UTF-8.
- **Validate `CRYPTO_ENCRYPTION_KEY` at construction**: reject non-base64 and any decoded length outside {16, 24, 32} bytes with a clear message, instead of silently picking a weaker AES variant or throwing a cryptic `InvalidKeyException` only at the first encrypt/decrypt.

New `CryptoEncryptionTest` covers round-trips (incl. non-ASCII), nonce uniqueness, null passthrough and the key-validation paths. `mvn test` green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Improved at-rest encryption reliability by explicitly using UTF-8 for text encoding and decoding.
  - Encryption keys are now validated when configured, with clear errors for invalid Base64 values or unsupported key lengths.
  - Supports valid AES-128, AES-192, and AES-256 key sizes.
  - Documented the encryption updates in the unreleased changelog.

- **Tests**
  - Added coverage for multilingual text, randomized encryption, null values, and invalid or unsupported keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->