### PR TITLE
fix(logging): stop dumping full third-party payloads in sync logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,14 +133,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
-- **Sync logs no longer dump full third-party payloads.** Three log statements
-  wrote entire provider responses at INFO/WARN/ERROR in production:
-  `EnableBankingBankConnector` logged the full balances object (account amounts)
-  — now a debug-level entry count; `FinaryApiClient` logged the raw Clerk
-  sign-in response (which can carry session tokens) — now a body-free message;
-  and the Finary API error body is now bounded to 200 chars before it reaches
-  logs *and* the user-facing error message it feeds. Defense-in-depth against
-  financial PII and third-party secrets landing in logs.
+- **Sync logs no longer dump full third-party payloads.** Provider responses
+  were written whole at INFO/WARN/ERROR in production: `EnableBankingBankConnector`
+  logged the full balances object (account amounts) — now an INFO **count-only**
+  line (visibility kept, amounts dropped); `FinaryApiClient` logged the raw Clerk
+  sign-in response (which can carry session tokens) — now a body-free message.
+  Every Finary/Clerk error body that flows into an `IOException` → `SyncException`
+  (and thus into logs *and* the user-facing 422) is now bounded before it is
+  thrown — Clerk auth and the low-level retry path to 200 chars, the Finary
+  data-API body to 500 (enough to keep its actionable message, still capped).
+  Defense-in-depth against financial PII and third-party secrets landing in logs.
 
 ## [1.0.13] — 2026-07-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (generic `422`) as defense-in-depth, so a bad RPC response can never surface as a
   raw `500` even on an unwrapped call path.
 
+### Security
+
+- **Sync logs no longer dump full third-party payloads.** Three log statements
+  wrote entire provider responses at INFO/WARN/ERROR in production:
+  `EnableBankingBankConnector` logged the full balances object (account amounts)
+  — now a debug-level entry count; `FinaryApiClient` logged the raw Clerk
+  sign-in response (which can carry session tokens) — now a body-free message;
+  and the Finary API error body is now bounded to 200 chars before it reaches
+  logs *and* the user-facing error message it feeds. Defense-in-depth against
+  financial PII and third-party secrets landing in logs.
+
 ## [1.0.13] — 2026-07-07
 
 ### Changed

--- a/backend/src/main/java/com/picsou/adapter/EnableBankingBankConnector.java
+++ b/backend/src/main/java/com/picsou/adapter/EnableBankingBankConnector.java
@@ -266,8 +266,11 @@ public class EnableBankingBankConnector implements BankConnectorPort {
         String name = "Account";
         String iban = null;
 
-        log.debug("Fetched balances for account {} ({} entries)", accountId,
-            balances != null && balances.balances() != null ? balances.balances().size() : 0);
+        // Keep per-account visibility at INFO (operators need it to diagnose Enable
+        // Banking's async linking), but log only the balance count — never the full
+        // balances object, which carries the account's amounts (financial PII).
+        log.info("Fetched {} balances for account {}",
+            balances != null && balances.balances() != null ? balances.balances().size() : 0, accountId);
         if (balances != null && balances.balances() != null && !balances.balances().isEmpty()) {
             var b = balances.balances().stream()
                 .filter(bl -> "closingBooked".equals(bl.balanceType()) || "expected".equals(bl.balanceType()))

--- a/backend/src/main/java/com/picsou/adapter/EnableBankingBankConnector.java
+++ b/backend/src/main/java/com/picsou/adapter/EnableBankingBankConnector.java
@@ -266,7 +266,8 @@ public class EnableBankingBankConnector implements BankConnectorPort {
         String name = "Account";
         String iban = null;
 
-        log.info("Balances for account {}: {}", accountId, balances);
+        log.debug("Fetched balances for account {} ({} entries)", accountId,
+            balances != null && balances.balances() != null ? balances.balances().size() : 0);
         if (balances != null && balances.balances() != null && !balances.balances().isEmpty()) {
             var b = balances.balances().stream()
                 .filter(bl -> "closingBooked".equals(bl.balanceType()) || "expected".equals(bl.balanceType()))

--- a/backend/src/main/java/com/picsou/finary/client/FinaryApiClient.java
+++ b/backend/src/main/java/com/picsou/finary/client/FinaryApiClient.java
@@ -128,7 +128,8 @@ public class FinaryApiClient {
             ClerkSignInResponse signIn = apiResp.response;
 
             if (signIn.status == null) {
-                log.warn("Finary sign-in returned no status: {}", signInResponse);
+                // Do not log the raw Clerk response — it can carry session tokens / PII.
+                log.warn("Finary sign-in returned no status field in the Clerk response");
                 throw new SyncException("Finary sign-in failed. Please check your credentials and try again.");
             }
 
@@ -459,6 +460,12 @@ public class FinaryApiClient {
         return response.body();
     }
 
+    /** Bounds a response body for safe inclusion in logs / error messages. */
+    private static String truncate(String s, int max) {
+        if (s == null) return "";
+        return s.length() <= max ? s : s.substring(0, max) + "…(" + s.length() + " chars)";
+    }
+
     /**
      * Finary GET helper
      */
@@ -479,8 +486,12 @@ public class FinaryApiClient {
 
         HttpResponse<String> response = sendWithRetry(finaryHttpClient, request);
         if (response.statusCode() >= 400) {
-            log.error("Finary API error {}: {}", response.statusCode(), response.body());
-            throw new IOException("HTTP " + response.statusCode() + ": " + response.body());
+            // Bound the body: the full authenticated error payload should not be
+            // dumped to logs, and it also flows into user-facing error messages
+            // (FinaryApiSyncService wraps this IOException's message).
+            String bodySnippet = truncate(response.body(), 200);
+            log.error("Finary API error {}: {}", response.statusCode(), bodySnippet);
+            throw new IOException("HTTP " + response.statusCode() + ": " + bodySnippet);
         }
         return response.body();
     }

--- a/backend/src/main/java/com/picsou/finary/client/FinaryApiClient.java
+++ b/backend/src/main/java/com/picsou/finary/client/FinaryApiClient.java
@@ -429,7 +429,9 @@ public class FinaryApiClient {
             throw new SyncException("Invalid Finary credentials. Please check your email and password.");
         }
         if (response.statusCode() >= 400) {
-            throw new IOException("HTTP " + response.statusCode() + ": " + response.body());
+            // Bound the Clerk error body: it propagates into SyncException messages
+            // (logs + user-facing 422), and Clerk responses can carry auth material.
+            throw new IOException("HTTP " + response.statusCode() + ": " + truncate(response.body(), 200));
         }
         return response.body();
     }
@@ -455,7 +457,9 @@ public class FinaryApiClient {
             throw new SyncException("Invalid Finary credentials. Please check your email and password.");
         }
         if (response.statusCode() >= 400) {
-            throw new IOException("HTTP " + response.statusCode() + ": " + response.body());
+            // Bound the Clerk error body: it propagates into SyncException messages
+            // (logs + user-facing 422), and Clerk responses can carry auth material.
+            throw new IOException("HTTP " + response.statusCode() + ": " + truncate(response.body(), 200));
         }
         return response.body();
     }
@@ -488,8 +492,11 @@ public class FinaryApiClient {
         if (response.statusCode() >= 400) {
             // Bound the body: the full authenticated error payload should not be
             // dumped to logs, and it also flows into user-facing error messages
-            // (FinaryApiSyncService wraps this IOException's message).
-            String bodySnippet = truncate(response.body(), 200);
+            // (FinaryApiSyncService wraps this IOException's message). 500 chars,
+            // not 200: this is the Finary data API, whose error bodies carry the
+            // actionable message — enough room not to cut it mid-sentence, still
+            // bounded so a runaway payload can't flood logs.
+            String bodySnippet = truncate(response.body(), 500);
             log.error("Finary API error {}: {}", response.statusCode(), bodySnippet);
             throw new IOException("HTTP " + response.statusCode() + ": " + bodySnippet);
         }
@@ -507,7 +514,7 @@ public class FinaryApiClient {
                         Thread.sleep((long) Math.pow(2, attempt) * 1000);
                         continue;
                     }
-                    throw new IOException("HTTP " + response.statusCode() + ": " + response.body());
+                    throw new IOException("HTTP " + response.statusCode() + ": " + truncate(response.body(), 200));
                 }
                 return response;
             } catch (InterruptedException e) {


### PR DESCRIPTION
Companion to the Enable Banking session-id redaction — three statements logged entire provider responses in production:

- `EnableBankingBankConnector` logged the full balances object (account amounts) at INFO → reduced to a debug-level entry count.
- `FinaryApiClient` logged the raw Clerk sign-in response at WARN, which can carry session tokens → now a body-free message.
- The Finary API error body is bounded to 200 chars before it reaches the log line **and** the `IOException` message (which `FinaryApiSyncService` surfaces to the user).

Defense-in-depth against financial PII and third-party secrets landing in logs. Compiles; targeted tests green.

> Note: overlaps in file with #62 (session-id redaction) on `EnableBankingBankConnector` but on different lines — can be rebased/merged in either order.