### PR TITLE
fix(settings): point the About GitHub link to picsou-finance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The GitHub link in Settings → About now points to the right repository.** It
+  linked to `github.com/zoeille/picsou`, which does not exist; the repository is
+  `github.com/zoeille/picsou-finance`.
 - **Restoring several tabs at once no longer logs you out everywhere.** When
   multiple tabs were restored together they each presented the same "Remember
   Me" token; the first request rotated it and the rest looked like a replayed

--- a/frontend/src/pages/settings/SettingsPage.tsx
+++ b/frontend/src/pages/settings/SettingsPage.tsx
@@ -374,12 +374,12 @@ export function SettingsPage() {
           <div className="space-y-1 sm:justify-self-end sm:text-right">
             <p className="text-muted-foreground">GitHub</p>
             <a
-              href="https://github.com/zoeille/picsou"
+              href="https://github.com/zoeille/picsou-finance"
               target="_blank"
               rel="noreferrer"
               className="inline-flex min-h-10 max-w-full items-center gap-2 rounded-xl font-medium text-foreground transition-colors hover:text-muted-foreground"
             >
-              <span className="truncate">github.com/zoeille/picsou</span>
+              <span className="truncate">github.com/zoeille/picsou-finance</span>
               <ExternalLink className="size-4 text-muted-foreground" />
             </a>
           </div>


### PR DESCRIPTION
The About section linked to github.com/zoeille/picsou, which does not exist. The repository is github.com/zoeille/picsou-finance.