### PR TITLE
refactor(ui): harmonize every corner radius behind the ladder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,6 +139,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **UI controls realigned to the shadcn theme radius.** Pill-shape overrides on
   buttons, chips, and tabs were reverted to the theme tokens; Mira
   design-system pass completed with a sidebar style toggle (#46).
+- **Every corner in the UI now follows one radius ladder.** The same kind of
+  element was rendering at three or four different radii — inline alerts at
+  8/10/14px, segmented controls at 10 or 18px, selects at 8 or 14px, checkboxes
+  at 4/6/8px — and 29 buttons across the setup wizard and login pages still
+  carried a `rounded-full` override. Each element now takes a fixed rung keyed on
+  what it is: surface 26px (cards, modals, sidebar), panel 18px, row 14px,
+  control 10px, micro 8px, hairline 6px. Controls moved one rung up so a button
+  sits nearer the cards it lives beside, and modals now match the cards behind
+  them instead of being visibly less round.
 - **PnL no longer counts outstanding debt as an investment loss (#18).** Loans
   contribute 0 to `pnl` in every aggregation path (history points, live PnL,
   MCP `get_profit_and_loss`); `rangePnl` compares only holdings priced on both

--- a/frontend/src/components/layout/AppSidebar.tsx
+++ b/frontend/src/components/layout/AppSidebar.tsx
@@ -84,7 +84,7 @@ function NavItem({
       asChild
       variant={isActive ? 'muted' : 'default'}
       className={cn(
-        'min-h-[72px] rounded-xl px-4 py-3',
+        'min-h-[72px] px-4 py-3',
         isActive && 'bg-muted ring-1 ring-border',
       )}
     >
@@ -150,7 +150,7 @@ export function AppSidebar() {
   return (
     <nav
       className={cn(
-        'hidden shrink-0 flex-col rounded-xl bg-background px-3 py-4 md:flex',
+        'hidden shrink-0 flex-col rounded-4xl bg-background px-3 py-4 md:flex',
         isClassic ? 'h-fit max-h-[calc(100vh-2rem)] w-60' : 'h-[calc(100vh-2rem)] w-72',
       )}
     >
@@ -191,7 +191,7 @@ export function AppSidebar() {
             <Item
               asChild
               variant="default"
-              className="mt-3 min-h-[72px] rounded-xl px-4 py-3 text-left transition-colors hover:bg-muted"
+              className="mt-3 min-h-[72px] px-4 py-3 text-left transition-colors hover:bg-muted"
             >
               <button
                 type="button"
@@ -270,7 +270,7 @@ export function AppSidebar() {
               <Item
                 asChild
                 variant="default"
-                className="min-h-[72px] flex-1 rounded-xl px-4 py-3 text-left transition-colors hover:bg-muted"
+                className="min-h-[72px] flex-1 px-4 py-3 text-left transition-colors hover:bg-muted"
               >
                 <button type="button" aria-label={t('nav.account')}>
                   <Avatar className="size-10 shrink-0 rounded-lg">

--- a/frontend/src/components/layout/MobileBottomNav.tsx
+++ b/frontend/src/components/layout/MobileBottomNav.tsx
@@ -53,7 +53,7 @@ export function MobileBottomNav() {
 
   return (
     <nav className="fixed bottom-4 inset-x-4 z-50 md:hidden">
-      <div className="flex items-center justify-between rounded-xl bg-background px-3 py-3 ring-1 ring-border">
+      <div className="flex items-center justify-between rounded-2xl bg-background px-3 py-3 ring-1 ring-border">
         {/* Left items */}
         <div className="flex gap-2">
           {NAV_ITEMS.slice(0, 2).map((item) => (

--- a/frontend/src/components/layout/SidebarStylePromptModal.tsx
+++ b/frontend/src/components/layout/SidebarStylePromptModal.tsx
@@ -104,7 +104,7 @@ export function SidebarStylePromptModal({ open, onOpenChange }: SidebarStyleProm
               role="radio"
               aria-checked={sidebarStyle === option.value}
               onClick={() => choose(option.value)}
-              className="flex flex-col gap-2 rounded-lg border border-border p-2 text-left transition-colors hover:border-primary/60 hover:bg-muted/40"
+              className="flex flex-col gap-2 rounded-2xl border border-border p-2 text-left transition-colors hover:border-primary/60 hover:bg-muted/40"
             >
               <SidebarPreview variant={option.value} />
               <span className="text-sm font-medium">{t(option.labelKey)}</span>

--- a/frontend/src/components/loan/LoanCostSummaryTable.tsx
+++ b/frontend/src/components/loan/LoanCostSummaryTable.tsx
@@ -53,7 +53,7 @@ export function LoanCostSummaryTable({ summary }: LoanCostSummaryTableProps) {
 
 function Column({ title, total, children }: { title: string; total: number; children: React.ReactNode }) {
   return (
-    <div className="flex flex-col gap-2 p-3 rounded-lg border bg-card/50">
+    <div className="flex flex-col gap-2 p-3 rounded-2xl border bg-card/50">
       <div className="flex items-center justify-between border-b pb-2 mb-1">
         <span className="text-xs text-muted-foreground">{title}</span>
         <CurrencyDisplay value={total} className="text-base font-semibold" />

--- a/frontend/src/components/property/AddPropertyModal.tsx
+++ b/frontend/src/components/property/AddPropertyModal.tsx
@@ -32,7 +32,7 @@ const CATEGORIES: PropertyCategory[] = [
 ]
 
 const selectControlClassName =
-  'flex h-10 w-full rounded-md border border-input bg-input/20 px-4 text-sm outline-none dark:bg-input/30'
+  'flex h-10 w-full rounded-lg border border-input bg-input/20 px-4 text-sm outline-none dark:bg-input/30'
 
 const num = (v: string): number | undefined => (v.trim() === '' ? undefined : parseAmount(v))
 
@@ -203,7 +203,7 @@ export function AddPropertyModal({ open, onOpenChange }: AddPropertyModalProps) 
                       type="button"
                       onClick={() => setKind(value)}
                       aria-pressed={kind === value}
-                      className={`flex items-center gap-2 rounded-md border p-3 text-left text-sm transition-colors
+                      className={`flex items-center gap-2 rounded-xl border p-3 text-left text-sm transition-colors
                         ${kind === value ? 'border-primary bg-primary/5' : 'hover:bg-muted/40'}`}
                     >
                       <Icon className="size-4 shrink-0" />
@@ -307,7 +307,7 @@ export function AddPropertyModal({ open, onOpenChange }: AddPropertyModalProps) 
             </div>
 
             {isApartment && (
-              <div className="flex items-center justify-between gap-3 rounded-lg border px-4 py-2">
+              <div className="flex items-center justify-between gap-3 rounded-xl border px-4 py-2">
                 <span className="text-sm">{t('property.form.hasElevator')}</span>
                 <Switch checked={hasElevator} onCheckedChange={setHasElevator}
                   aria-label={t('property.form.hasElevator')} />

--- a/frontend/src/components/property/AddressAutocomplete.tsx
+++ b/frontend/src/components/property/AddressAutocomplete.tsx
@@ -57,7 +57,7 @@ export function AddressAutocomplete({
       </div>
 
       {open && suggestions.length > 0 && (
-        <ul className="absolute z-50 mt-1 max-h-60 w-full overflow-auto rounded-lg border bg-popover p-1 shadow-md">
+        <ul className="absolute z-50 mt-1 max-h-60 w-full overflow-auto rounded-xl border bg-popover p-1 shadow-md">
           {suggestions.map(suggestion => (
             <li key={`${suggestion.label}-${suggestion.inseeCode}`}>
               <button

--- a/frontend/src/components/property/OwnershipEditor.tsx
+++ b/frontend/src/components/property/OwnershipEditor.tsx
@@ -150,7 +150,7 @@ function OwnershipForm({ accountId, ownership, rows, canEdit }: {
         )}
 
         {!overAllocated && unassigned > 0.01 && (
-          <p className="flex items-start gap-2 rounded-md bg-muted/50 p-3 text-xs text-muted-foreground">
+          <p className="flex items-start gap-2 rounded-xl bg-muted/50 p-3 text-xs text-muted-foreground">
             <AlertTriangle className="mt-0.5 size-4 shrink-0" />
             {t('property.ownership.unassigned', { percent: unassigned.toFixed(1) })}
           </p>

--- a/frontend/src/components/property/PropertyFinancingCard.tsx
+++ b/frontend/src/components/property/PropertyFinancingCard.tsx
@@ -56,7 +56,7 @@ export function PropertyFinancingCard({ line }: PropertyFinancingCardProps) {
               <button
                 type="button"
                 onClick={() => navigate(`/accounts/${loan.accountId}`)}
-                className="flex w-full items-center justify-between gap-3 rounded-lg px-2 py-1.5 text-left hover:bg-muted/40"
+                className="flex w-full items-center justify-between gap-3 rounded-xl px-2 py-1.5 text-left hover:bg-muted/40"
               >
                 <span className="min-w-0">
                   <span className="block truncate text-sm font-medium">{loan.name}</span>

--- a/frontend/src/components/property/PropertyMetadataForm.tsx
+++ b/frontend/src/components/property/PropertyMetadataForm.tsx
@@ -55,7 +55,7 @@ const propertySchema = z.object({
 type PropertyFormData = z.infer<typeof propertySchema>
 
 const selectControlClassName =
-  'flex h-10 w-full rounded-md border border-input bg-input/20 px-4 text-sm outline-none dark:bg-input/30'
+  'flex h-10 w-full rounded-lg border border-input bg-input/20 px-4 text-sm outline-none dark:bg-input/30'
 
 const PROPERTY_KINDS = ['HOUSE', 'APARTMENT', 'BUILDING', 'LAND', 'PARKING', 'COMMERCIAL'] as const
 const CATEGORIES = ['PRIMARY_RESIDENCE', 'SECONDARY_RESIDENCE', 'RENTAL', 'LAND', 'OTHER'] as const
@@ -159,7 +159,7 @@ export function PropertyMetadataForm({ accountId, metadata, onSaved }: PropertyM
           <textarea
             id="description"
             rows={2}
-            className="flex w-full rounded-md border border-input bg-input/20 px-4 py-2 text-sm outline-none dark:bg-input/30"
+            className="flex w-full rounded-lg border border-input bg-input/20 px-4 py-2 text-sm outline-none dark:bg-input/30"
             {...register('description')}
           />
         </Field>
@@ -282,7 +282,7 @@ export function PropertyMetadataForm({ accountId, metadata, onSaved }: PropertyM
       </Section>
 
       <Section title={t('property.form.valuationMode')}>
-        <div className="col-span-full flex items-center justify-between gap-4 rounded-lg border p-3">
+        <div className="col-span-full flex items-center justify-between gap-4 rounded-2xl border p-3">
           <div>
             <p className="text-sm font-medium">{t('property.form.autoValuation')}</p>
             <p className="text-xs text-muted-foreground">{t('property.form.autoValuationHint')}</p>
@@ -334,7 +334,7 @@ function Toggle({ label, checked, onChange }: {
   label: string; checked: boolean; onChange: (v: boolean) => void
 }) {
   return (
-    <div className="flex items-center justify-between gap-3 rounded-lg border px-4 py-2">
+    <div className="flex items-center justify-between gap-3 rounded-xl border px-4 py-2">
       <span className="text-sm">{label}</span>
       <Switch checked={checked} onCheckedChange={onChange} aria-label={label} />
     </div>

--- a/frontend/src/components/property/PropertyValuationCard.tsx
+++ b/frontend/src/components/property/PropertyValuationCard.tsx
@@ -58,7 +58,7 @@ export function PropertyValuationCard({ accountId, metadata, currentValue }: Pro
         )}
 
         {result && result.status !== 'OK' && (
-          <div role="alert" className="flex gap-2 rounded-md bg-muted/50 p-3 text-sm">
+          <div role="alert" className="flex gap-2 rounded-xl bg-muted/50 p-3 text-sm">
             <Info className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
             <div>
               <p>{t(`property.valuation.status.${result.status}`)}</p>
@@ -77,7 +77,7 @@ export function PropertyValuationCard({ accountId, metadata, currentValue }: Pro
               <span className="text-sm text-muted-foreground">{t('property.valuation.estimate')}</span>
               <CurrencyDisplay value={result.estimatedValue ?? 0} className="text-lg font-semibold tabular-nums" />
               {result.confidence && (
-                <span className={`rounded px-2 py-0.5 text-xs font-medium ${CONFIDENCE_STYLES[result.confidence]}`}>
+                <span className={`rounded-full px-2 py-0.5 text-xs font-medium ${CONFIDENCE_STYLES[result.confidence]}`}>
                   {t(`property.valuation.confidence.${result.confidence}`)}
                 </span>
               )}
@@ -129,7 +129,7 @@ export function PropertyValuationCard({ accountId, metadata, currentValue }: Pro
                 </button>
 
                 {showMethod && (
-                  <div className="mt-2 space-y-2 rounded-md border p-3">
+                  <div className="mt-2 space-y-2 rounded-2xl border p-3">
                     {/* Stated plainly: these coefficients encode market intuition, not a
                         model fitted on the open data, which records none of these features. */}
                     <p className="text-xs text-muted-foreground">

--- a/frontend/src/components/shared/AccountCard.tsx
+++ b/frontend/src/components/shared/AccountCard.tsx
@@ -130,7 +130,7 @@ export function AccountCard({ account, onClick }: AccountCardProps) {
             <AccountTypeBadge type={account.type} />
             {/* Present only below 100%, so the balance above is knowingly a shared figure. */}
             {account.sharePercent != null && (
-              <span className="shrink-0 rounded bg-muted px-1.5 py-0.5 text-xs text-muted-foreground">
+              <span className="shrink-0 rounded-full bg-muted px-1.5 py-0.5 text-xs text-muted-foreground">
                 {Number(account.sharePercent).toFixed(0)} %
               </span>
             )}

--- a/frontend/src/components/shared/AccountForm.tsx
+++ b/frontend/src/components/shared/AccountForm.tsx
@@ -90,7 +90,7 @@ const EMPTY_DEFAULTS: AccountFormData = {
   endDate: '',
 }
 
-const selectControlClassName = "flex h-10 w-full rounded-xl border border-input bg-input/20 px-4 text-sm outline-none dark:bg-input/30"
+const selectControlClassName = "flex h-10 w-full rounded-lg border border-input bg-input/20 px-4 text-sm outline-none dark:bg-input/30"
 
 export function AccountForm({ open, onOpenChange, onSubmit, defaultValues, title, loading, accounts = [] }: AccountFormProps) {
   const { t } = useTranslation()
@@ -322,7 +322,7 @@ export function AccountForm({ open, onOpenChange, onSubmit, defaultValues, title
 
           {selectedType !== 'REAL_ESTATE' && selectedType !== 'LOAN' && (
             <div className="flex min-h-10 items-center gap-2">
-              <input id="isManual" type="checkbox" {...register('isManual')} className="h-5 w-5 rounded accent-primary" />
+              <input id="isManual" type="checkbox" {...register('isManual')} className="h-5 w-5 rounded-sm accent-primary" />
               <Label htmlFor="isManual">{t('accounts.manual')}</Label>
             </div>
           )}

--- a/frontend/src/components/shared/AddAccountModal.tsx
+++ b/frontend/src/components/shared/AddAccountModal.tsx
@@ -96,7 +96,7 @@ function MaskedOTPSlot({ index }: { index: number }) {
   return (
     <div
       data-active={isActive}
-      className="relative flex size-10 items-center justify-center border-y border-r border-input bg-input/20 text-sm transition-[border-color,box-shadow,background-color] outline-none first:rounded-l-xl first:border-l last:rounded-r-xl aria-invalid:border-destructive data-[active=true]:z-10 data-[active=true]:border-ring data-[active=true]:ring-2 data-[active=true]:ring-ring/30 dark:bg-input/30"
+      className="relative flex size-10 items-center justify-center border-y border-r border-input bg-input/20 text-sm transition-[border-color,box-shadow,background-color] outline-none first:rounded-l-lg first:border-l last:rounded-r-lg aria-invalid:border-destructive data-[active=true]:z-10 data-[active=true]:border-ring data-[active=true]:ring-2 data-[active=true]:ring-ring/30 dark:bg-input/30"
     >
       {hasChar ? '•' : null}
       {hasFakeCaret && (
@@ -364,7 +364,7 @@ function BankWizard({ onBack }: { onDone: () => void; onBack: () => void }) {
       <BackButton onClick={onBack} />
       <div className="space-y-4">
         {error && (
-          <div className="flex items-center gap-2 rounded-lg bg-destructive/10 px-3 py-2 text-sm text-destructive">
+          <div className="flex items-center gap-2 rounded-xl bg-destructive/10 px-3 py-2 text-sm text-destructive">
             <span className="flex-1">{error}</span>
             <Button variant="ghost" size="sm" onClick={() => setError(null)}>x</Button>
           </div>
@@ -391,7 +391,7 @@ function BankWizard({ onBack }: { onDone: () => void; onBack: () => void }) {
         )}
 
         {searchEnabled && searchFailed && !searchLoading && (
-          <div className="flex items-center gap-2 rounded-lg bg-destructive/10 px-3 py-2 text-sm text-destructive">
+          <div className="flex items-center gap-2 rounded-xl bg-destructive/10 px-3 py-2 text-sm text-destructive">
             <span className="flex-1">
               {extractErrorMessage(searchError, t('sync.banks.searchError'))}
             </span>
@@ -403,7 +403,7 @@ function BankWizard({ onBack }: { onDone: () => void; onBack: () => void }) {
             {institutions.map((inst) => (
               <div
                 key={inst.id}
-                className="grid grid-cols-[minmax(0,1fr)_2.5rem_auto] items-center gap-4 rounded-lg border px-3 py-2"
+                className="grid grid-cols-[minmax(0,1fr)_2.5rem_auto] items-center gap-4 rounded-xl border px-3 py-2"
               >
                 <div className="flex min-w-0 items-center gap-2">
                   <InstitutionLogo logoUrl={inst.logoUrl} />
@@ -491,7 +491,7 @@ function ExchangeWizard({ onBack }: { onDone: () => void; onBack: () => void }) 
     <>
       <BackButton onClick={onBack} />
       {error && (
-        <div className="flex items-center gap-2 rounded-lg bg-destructive/10 px-3 py-2 text-sm text-destructive">
+        <div className="flex items-center gap-2 rounded-xl bg-destructive/10 px-3 py-2 text-sm text-destructive">
           <span className="flex-1">{error}</span>
           <Button variant="ghost" size="sm" onClick={() => setError(null)}>x</Button>
         </div>
@@ -607,7 +607,7 @@ function WalletWizard({ onBack }: { onDone: () => void; onBack: () => void }) {
     <>
       <BackButton onClick={onBack} />
       {error && (
-        <div className="flex items-center gap-2 rounded-lg bg-destructive/10 px-3 py-2 text-sm text-destructive">
+        <div className="flex items-center gap-2 rounded-xl bg-destructive/10 px-3 py-2 text-sm text-destructive">
           <span className="flex-1">{error}</span>
           <Button variant="ghost" size="sm" onClick={() => setError(null)}>x</Button>
         </div>
@@ -748,7 +748,7 @@ function TradeRepublicWizard({ onBack }: { onDone: () => void; onBack: () => voi
       <BackButton onClick={onBack} />
       <div className="space-y-4">
         {errorMsg && (
-          <div className="flex flex-col gap-3 rounded-lg bg-destructive/10 px-4 py-3 text-sm text-destructive">
+          <div className="flex flex-col gap-3 rounded-xl bg-destructive/10 px-4 py-3 text-sm text-destructive">
             <span className="leading-6">{errorMsg}</span>
             <Button
               variant="ghost"
@@ -1077,7 +1077,7 @@ function FinaryWizard({ onDone, onBack }: { onDone: () => void; onBack: () => vo
 
       {/* Error banner */}
       {error && (
-        <div className="flex items-center gap-2 rounded-lg bg-destructive/10 px-3 py-2 text-sm text-destructive mb-4">
+        <div className="flex items-center gap-2 rounded-xl bg-destructive/10 px-3 py-2 text-sm text-destructive mb-4">
           <span className="flex-1">{error}</span>
           <Button variant="ghost" size="sm" onClick={() => setError(null)}>x</Button>
         </div>
@@ -1166,7 +1166,7 @@ function FinaryWizard({ onDone, onBack }: { onDone: () => void; onBack: () => vo
 
           {/* File upload zone */}
           <div
-            className={`flex flex-col items-center justify-center gap-3 rounded-xl border-2 border-dashed p-8 text-center transition-colors ${
+            className={`flex flex-col items-center justify-center gap-3 rounded-2xl border-2 border-dashed p-8 text-center transition-colors ${
               dragOver ? 'border-primary bg-primary/5' : 'border-muted-foreground/25 hover:border-muted-foreground/50'
             }`}
             onDragOver={(e) => { e.preventDefault(); setDragOver(true) }}
@@ -1203,7 +1203,7 @@ function FinaryWizard({ onDone, onBack }: { onDone: () => void; onBack: () => vo
 
           <div className="space-y-3 max-h-80 overflow-y-auto">
             {previewData.accounts.map((account, index) => (
-              <div key={account.finaryCategory + account.finaryId} className="rounded-lg border p-3 space-y-2">
+              <div key={account.finaryCategory + account.finaryId} className="rounded-2xl border p-3 space-y-2">
                 <div className="flex items-center justify-between">
                   <div className="min-w-0">
                     <p className="truncate text-sm font-medium">{account.finaryName}</p>
@@ -1230,7 +1230,7 @@ function FinaryWizard({ onDone, onBack }: { onDone: () => void; onBack: () => vo
 
                 {mappings[index]?.action === 'MAP_EXISTING' && (
                   <select
-                    className="h-10 w-full rounded-xl border border-input bg-input/20 px-4 text-sm outline-none dark:bg-input/30"
+                    className="h-10 w-full rounded-lg border border-input bg-input/20 px-4 text-sm outline-none dark:bg-input/30"
                     value={mappings[index].targetAccountId ?? ''}
                     onChange={(e) => {
                       const val = e.target.value
@@ -1258,7 +1258,7 @@ function FinaryWizard({ onDone, onBack }: { onDone: () => void; onBack: () => vo
                     <div className="space-y-1">
                       <Label>{t('sync.exchanges.type')}</Label>
                       <select
-                        className="h-10 w-full rounded-xl border border-input bg-input/20 px-4 text-sm outline-none dark:bg-input/30"
+                        className="h-10 w-full rounded-lg border border-input bg-input/20 px-4 text-sm outline-none dark:bg-input/30"
                         value={mappings[index].newAccount!.type}
                         onChange={(e) => updateNewAccountField(index, 'type', e.target.value)}
                       >
@@ -1321,7 +1321,7 @@ function FinaryWizard({ onDone, onBack }: { onDone: () => void; onBack: () => vo
           {importResult.importedAccounts.length > 0 && (
             <div className="space-y-2">
               {importResult.importedAccounts.map((account) => (
-                <div key={account.id} className="flex items-center gap-3 rounded-lg border px-3 py-2">
+                <div key={account.id} className="flex items-center gap-3 rounded-xl border px-3 py-2">
                   <div className="size-3 shrink-0 rounded-full" style={{ backgroundColor: account.color }} />
                   <div className="flex-1 min-w-0">
                     <p className="truncate text-sm font-medium">{account.name}</p>
@@ -1345,7 +1345,7 @@ function FinaryWizard({ onDone, onBack }: { onDone: () => void; onBack: () => vo
 
 function ResultStat({ label, value, color }: { label: string; value: number; color?: string }) {
   return (
-    <div className="rounded-xl bg-muted/50 p-3 text-center">
+    <div className="rounded-2xl bg-muted/50 p-3 text-center">
       <p className={`text-xl font-semibold ${color ?? ''}`}>{value}</p>
       <p className="text-xs text-muted-foreground">{label}</p>
     </div>

--- a/frontend/src/components/shared/BankCountrySelect.tsx
+++ b/frontend/src/components/shared/BankCountrySelect.tsx
@@ -56,7 +56,7 @@ export function BankCountrySelect({ value, onChange }: BankCountrySelectProps) {
         value={value}
         onChange={(e) => onChange(e.target.value)}
         aria-label={t('sync.banks.country')}
-        className="h-10 rounded-md border border-input bg-input/20 px-4 text-sm outline-none dark:bg-input/30"
+        className="h-10 rounded-lg border border-input bg-input/20 px-4 text-sm outline-none dark:bg-input/30"
       >
         {options.map((o) => (
           <option key={o.code} value={o.code}>{o.label}</option>

--- a/frontend/src/components/shared/ConfirmDialog.tsx
+++ b/frontend/src/components/shared/ConfirmDialog.tsx
@@ -84,7 +84,7 @@ export function ConfirmDialog({
         {error && (
           <p
             role="alert"
-            className="rounded-md border border-destructive/50 bg-destructive/10 px-3 py-2 text-sm text-destructive"
+            className="rounded-xl border border-destructive/50 bg-destructive/10 px-3 py-2 text-sm text-destructive"
           >
             {error}
           </p>

--- a/frontend/src/components/shared/DistributionPie.tsx
+++ b/frontend/src/components/shared/DistributionPie.tsx
@@ -122,10 +122,10 @@ function TooltipAnchor({ rect }: { rect: Rect }) {
       className="absolute z-30 flex flex-col items-center pointer-events-none"
       style={style}
     >
-      <span className="text-white font-semibold text-sm bg-black/60 backdrop-blur-sm px-2 py-0.5 rounded">
+      <span className="text-white font-semibold text-sm bg-black/60 backdrop-blur-sm px-2 py-0.5 rounded-md">
         {rect.item.name}
       </span>
-      <span className="text-white/80 text-xs bg-black/60 backdrop-blur-sm px-2 py-0.5 rounded mt-0.5">
+      <span className="text-white/80 text-xs bg-black/60 backdrop-blur-sm px-2 py-0.5 rounded-md mt-0.5">
         {rect.item.percentage}%
       </span>
     </div>

--- a/frontend/src/components/shared/EmptyChartState.tsx
+++ b/frontend/src/components/shared/EmptyChartState.tsx
@@ -10,7 +10,7 @@ export function EmptyChartState({ title, description }: EmptyChartStateProps) {
   const { t } = useTranslation()
 
   return (
-    <div className="flex h-[250px] flex-col items-center justify-center gap-3 rounded-lg border border-dashed border-border/50 bg-muted/20">
+    <div className="flex h-[250px] flex-col items-center justify-center gap-3 rounded-2xl border border-dashed border-border/50 bg-muted/20">
       <div className="flex size-12 items-center justify-center rounded-full bg-muted">
         <Moon className="size-5 text-muted-foreground" strokeWidth={1.5} />
       </div>

--- a/frontend/src/components/shared/HoldingDetailModal.tsx
+++ b/frontend/src/components/shared/HoldingDetailModal.tsx
@@ -153,7 +153,7 @@ export function HoldingDetailModal({ line, onClose }: HoldingDetailModalProps) {
 
               {/* Chart with mode toggle */}
               <div className="space-y-3">
-                <div className="inline-flex items-center rounded-2xl bg-muted p-1">
+                <div className="inline-flex items-center rounded-xl bg-muted p-1">
                   {([
                     { value: 'price' as ChartMode, label: t('holdings.assetPrice') },
                     { value: 'holding' as ChartMode, label: t('holdings.myPosition') },
@@ -161,7 +161,7 @@ export function HoldingDetailModal({ line, onClose }: HoldingDetailModalProps) {
                     <button
                       key={opt.value}
                       onClick={() => setMode(opt.value)}
-                      className={`inline-flex h-10 min-w-32 items-center justify-center rounded-xl px-6 text-sm font-medium transition-[background-color,color] ${
+                      className={`inline-flex h-10 min-w-32 items-center justify-center rounded-lg px-6 text-sm font-medium transition-[background-color,color] ${
                         mode === opt.value
                           ? 'bg-background text-foreground'
                           : 'text-muted-foreground hover:text-foreground'

--- a/frontend/src/components/shared/HoldingInsightSection.tsx
+++ b/frontend/src/components/shared/HoldingInsightSection.tsx
@@ -105,7 +105,7 @@ function CompositionViewToggle({ view, onChange, t }: CompositionViewToggleProps
     { value: 'line' as const, label: t('holdings.insight.viewLine'), Icon: AlignJustify },
   ]
   return (
-    <div className="inline-flex items-center rounded-2xl bg-muted p-1">
+    <div className="inline-flex items-center rounded-xl bg-muted p-1">
       {options.map(({ value, label, Icon }) => (
         <button
           key={value}
@@ -114,7 +114,7 @@ function CompositionViewToggle({ view, onChange, t }: CompositionViewToggleProps
           aria-pressed={view === value}
           title={label}
           className={cn(
-            'inline-flex h-10 min-w-32 items-center justify-center gap-2 rounded-xl px-6 text-sm font-medium transition-[background-color,color]',
+            'inline-flex h-10 min-w-32 items-center justify-center gap-2 rounded-lg px-6 text-sm font-medium transition-[background-color,color]',
             view === value
               ? 'bg-background text-foreground'
               : 'text-muted-foreground hover:text-foreground'
@@ -206,7 +206,7 @@ function LineView({ slices, others, labelOf, t }: ViewProps) {
           <PartitionBarSegment
             key={`${item.label}-${i}`}
             num={item.percent}
-            className={cn('min-h-2.5 rounded-sm px-0 py-0', item.color)}
+            className={cn('min-h-2.5 rounded-[2px] px-0 py-0', item.color)}
           />
         ))}
       </PartitionBar>

--- a/frontend/src/components/shared/HoldingsCard.tsx
+++ b/frontend/src/components/shared/HoldingsCard.tsx
@@ -184,7 +184,7 @@ export function HoldingsCard() {
                 key={tab.value}
                 onClick={() => setFilter(tab.value)}
                 className={cn(
-                  'inline-flex h-10 min-w-32 items-center justify-center whitespace-nowrap rounded-md border px-6 text-sm font-medium transition-[background-color,color,border-color]',
+                  'inline-flex h-10 min-w-32 items-center justify-center whitespace-nowrap rounded-lg border px-6 text-sm font-medium transition-[background-color,color,border-color]',
                   filter === tab.value
                     ? 'bg-primary text-primary-foreground'
                     : 'bg-background hover:bg-muted',

--- a/frontend/src/components/shared/ImportTransactionsModal.tsx
+++ b/frontend/src/components/shared/ImportTransactionsModal.tsx
@@ -34,7 +34,7 @@ const MAPPING_FIELDS: { key: MappingField; optional: boolean }[] = [
 ]
 
 const SELECT_CLASS =
-  'flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm focus:outline-none focus:ring-1 focus:ring-ring'
+  'flex h-9 w-full rounded-lg border border-input bg-transparent px-3 py-1 text-sm shadow-sm focus:outline-none focus:ring-1 focus:ring-ring'
 
 export function ImportTransactionsModal({ open, onOpenChange, accountId }: ImportTransactionsModalProps) {
   const { t } = useTranslation()
@@ -111,7 +111,7 @@ function ImportWizard({ accountId, onOpenChange }: { accountId: number; onOpenCh
               <AlertCircle className="size-5" />
               <span className="font-medium">{t('import.rowsSkipped', { count: result.skipped })}</span>
             </div>
-            <ul className="max-h-40 space-y-1 overflow-y-auto rounded-md border border-border bg-muted/40 p-2 text-sm">
+            <ul className="max-h-40 space-y-1 overflow-y-auto rounded-xl border border-border bg-muted/40 p-2 text-sm">
               {result.errors.map((e, i) => (
                 <li key={i} className="text-muted-foreground">
                   {t('import.rowLabel', { row: e.rowNumber })}: {e.message}
@@ -133,7 +133,7 @@ function ImportWizard({ accountId, onOpenChange }: { accountId: number; onOpenCh
       <div className="space-y-4">
         <div
           className={cn(
-            'flex flex-col items-center justify-center gap-2 rounded-lg border-2 border-dashed p-8 text-center transition-colors',
+            'flex flex-col items-center justify-center gap-2 rounded-2xl border-2 border-dashed p-8 text-center transition-colors',
             dragOver ? 'border-primary bg-primary/5' : 'border-border',
           )}
           onDragOver={e => { e.preventDefault(); setDragOver(true) }}
@@ -255,7 +255,7 @@ function ImportWizard({ accountId, onOpenChange }: { accountId: number; onOpenCh
       {/* Preview table */}
       <div>
         <p className="mb-2 text-sm font-medium">{t('import.preview')} ({t('import.rowsTotal', { count: preview.totalRows })})</p>
-        <div className="max-h-48 overflow-auto rounded-md border border-border">
+        <div className="max-h-48 overflow-auto rounded-xl border border-border">
           <table className="w-full text-xs">
             <thead className="sticky top-0 bg-muted">
               <tr>{columns.map((c, i) => <th key={i} className="px-2 py-1 text-left font-medium">{c}</th>)}</tr>

--- a/frontend/src/components/shared/LoadingSkeleton.tsx
+++ b/frontend/src/components/shared/LoadingSkeleton.tsx
@@ -22,7 +22,7 @@ export function LoadingSkeleton() {
             <Skeleton className="h-5 w-32" />
           </CardHeader>
           <CardContent>
-            <Skeleton className="h-[250px] w-full rounded-xl" />
+            <Skeleton className="h-[250px] w-full rounded-2xl" />
           </CardContent>
         </Card>
         <Card>
@@ -30,7 +30,7 @@ export function LoadingSkeleton() {
             <Skeleton className="h-5 w-32" />
           </CardHeader>
           <CardContent>
-            <Skeleton className="h-[250px] w-full rounded-xl" />
+            <Skeleton className="h-[250px] w-full rounded-2xl" />
           </CardContent>
         </Card>
       </div>

--- a/frontend/src/components/shared/PortfolioView.tsx
+++ b/frontend/src/components/shared/PortfolioView.tsx
@@ -200,7 +200,7 @@ export function PortfolioView() {
                 key={opt.value}
                 onClick={() => setSortBy(opt.value)}
                 className={cn(
-                  'inline-flex h-10 min-w-32 items-center justify-center whitespace-nowrap rounded-md border px-6 text-sm font-medium transition-[background-color,color,border-color]',
+                  'inline-flex h-10 min-w-32 items-center justify-center whitespace-nowrap rounded-lg border px-6 text-sm font-medium transition-[background-color,color,border-color]',
                   sortBy === opt.value
                     ? 'bg-primary text-primary-foreground'
                     : 'bg-background hover:bg-muted',

--- a/frontend/src/components/shared/TimeRangeSelector.tsx
+++ b/frontend/src/components/shared/TimeRangeSelector.tsx
@@ -20,7 +20,7 @@ export function TimeRangeSelector({ value, onChange }: TimeRangeSelectorProps) {
           key={range}
           onClick={() => onChange(range)}
           className={cn(
-            'inline-flex h-10 min-w-12 items-center justify-center rounded-md px-4 text-sm font-medium transition-[background-color,color]',
+            'inline-flex h-10 min-w-12 items-center justify-center rounded-lg px-4 text-sm font-medium transition-[background-color,color]',
             value === range
               ? 'bg-primary text-primary-foreground'
               : 'text-muted-foreground hover:bg-muted hover:text-foreground'

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -5,7 +5,7 @@ import { Slot } from "radix-ui"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "group/button inline-flex shrink-0 items-center justify-center rounded-md border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-[background-color,color,border-color,box-shadow,transform] outline-none select-none active:not-aria-[haspopup]:scale-[0.96] disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-2 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  "group/button inline-flex shrink-0 items-center justify-center rounded-lg border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-[background-color,color,border-color,box-shadow,transform] outline-none select-none active:not-aria-[haspopup]:scale-[0.96] disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-2 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
   {
     variants: {
       variant: {

--- a/frontend/src/components/ui/chart.tsx
+++ b/frontend/src/components/ui/chart.tsx
@@ -191,7 +191,7 @@ function ChartTooltipContent({
   return (
     <div
       className={cn(
-        "grid min-w-32 items-start gap-1.5 rounded-lg border border-border/50 bg-background px-2.5 py-1.5 text-xs/relaxed shadow-xl",
+        "grid min-w-32 items-start gap-1.5 rounded-xl border border-border/50 bg-background px-2.5 py-1.5 text-xs/relaxed shadow-xl",
         className
       )}
     >

--- a/frontend/src/components/ui/dialog.tsx
+++ b/frontend/src/components/ui/dialog.tsx
@@ -59,7 +59,7 @@ function DialogContent({
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(
-          "fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl bg-popover p-4 text-xs/relaxed text-popover-foreground ring-1 ring-foreground/10 duration-100 outline-none sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          "fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-4xl bg-popover p-4 text-xs/relaxed text-popover-foreground ring-1 ring-foreground/10 duration-100 outline-none sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
           className
         )}
         {...props}
@@ -69,7 +69,7 @@ function DialogContent({
           <DialogPrimitive.Close data-slot="dialog-close" asChild>
             <Button
               variant="ghost"
-              className="absolute top-2 right-2"
+              className="absolute top-3 right-3"
               size="icon-sm"
             >
               <X />

--- a/frontend/src/components/ui/dropdown-menu.tsx
+++ b/frontend/src/components/ui/dropdown-menu.tsx
@@ -42,7 +42,7 @@ function DropdownMenuContent({
         sideOffset={sideOffset}
         align={align}
         className={cn(
-          "z-50 max-h-(--radix-dropdown-menu-content-available-height) w-(--radix-dropdown-menu-trigger-width) min-w-56 origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-lg p-1.5 text-sm text-popover-foreground ring-1 ring-foreground/10 duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:overflow-hidden data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 animate-none! relative bg-popover/90 before:pointer-events-none before:absolute before:inset-0 before:-z-1 before:rounded-[inherit] before:backdrop-blur-2xl before:backdrop-saturate-150 **:data-[slot$=-item]:data-highlighted:bg-foreground/10 **:data-[slot$=-separator]:bg-foreground/5 **:data-[slot$=-trigger]:aria-expanded:bg-foreground/10! **:data-[variant=destructive]:text-accent-foreground! **:data-[variant=destructive]:**:text-accent-foreground!",
+          "z-50 max-h-(--radix-dropdown-menu-content-available-height) w-(--radix-dropdown-menu-trigger-width) min-w-56 origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-xl p-1.5 text-sm text-popover-foreground ring-1 ring-foreground/10 duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:overflow-hidden data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 animate-none! relative bg-popover/90 before:pointer-events-none before:absolute before:inset-0 before:-z-1 before:rounded-[inherit] before:backdrop-blur-2xl before:backdrop-saturate-150 **:data-[slot$=-item]:data-highlighted:bg-foreground/10 **:data-[slot$=-separator]:bg-foreground/5 **:data-[slot$=-trigger]:aria-expanded:bg-foreground/10! **:data-[variant=destructive]:text-accent-foreground! **:data-[variant=destructive]:**:text-accent-foreground!",
           className
         )}
         {...props}
@@ -74,7 +74,7 @@ function DropdownMenuItem({
       data-inset={inset}
       data-variant={variant}
       className={cn(
-        "group/dropdown-menu-item relative flex min-h-11 cursor-default items-center gap-3 rounded-md px-4 py-2 text-sm outline-hidden select-none data-inset:pl-10 data-[variant=destructive]:text-destructive data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-5 data-[variant=destructive]:*:[svg]:text-destructive",
+        "group/dropdown-menu-item relative flex min-h-11 cursor-default items-center gap-3 rounded-lg px-4 py-2 text-sm outline-hidden select-none data-inset:pl-10 data-[variant=destructive]:text-destructive data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-5 data-[variant=destructive]:*:[svg]:text-destructive",
         className
       )}
       {...props}
@@ -96,7 +96,7 @@ function DropdownMenuCheckboxItem({
       data-slot="dropdown-menu-checkbox-item"
       data-inset={inset}
       className={cn(
-        "relative flex min-h-11 cursor-default items-center gap-3 rounded-md py-2 pr-10 pl-4 text-sm outline-hidden select-none data-inset:pl-10 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-5",
+        "relative flex min-h-11 cursor-default items-center gap-3 rounded-lg py-2 pr-10 pl-4 text-sm outline-hidden select-none data-inset:pl-10 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-5",
         className
       )}
       checked={checked}
@@ -139,7 +139,7 @@ function DropdownMenuRadioItem({
       data-slot="dropdown-menu-radio-item"
       data-inset={inset}
       className={cn(
-        "relative flex min-h-11 cursor-default items-center gap-3 rounded-md py-2 pr-10 pl-4 text-sm outline-hidden select-none data-inset:pl-10 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-5",
+        "relative flex min-h-11 cursor-default items-center gap-3 rounded-lg py-2 pr-10 pl-4 text-sm outline-hidden select-none data-inset:pl-10 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-5",
         className
       )}
       {...props}
@@ -225,7 +225,7 @@ function DropdownMenuSubTrigger({
       data-slot="dropdown-menu-sub-trigger"
       data-inset={inset}
       className={cn(
-        "flex min-h-11 cursor-default items-center gap-3 rounded-md px-4 py-2 text-sm outline-hidden select-none data-inset:pl-10 data-open:bg-accent data-open:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-5",
+        "flex min-h-11 cursor-default items-center gap-3 rounded-lg px-4 py-2 text-sm outline-hidden select-none data-inset:pl-10 data-open:bg-accent data-open:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-5",
         className
       )}
       {...props}
@@ -244,7 +244,7 @@ function DropdownMenuSubContent({
     <DropdownMenuPrimitive.SubContent
       data-slot="dropdown-menu-sub-content"
       className={cn(
-        "z-50 min-w-56 origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-lg p-1.5 text-sm text-popover-foreground ring-1 ring-foreground/10 duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 animate-none! relative bg-popover/90 before:pointer-events-none before:absolute before:inset-0 before:-z-1 before:rounded-[inherit] before:backdrop-blur-2xl before:backdrop-saturate-150 **:data-[slot$=-item]:data-highlighted:bg-foreground/10 **:data-[slot$=-separator]:bg-foreground/5 **:data-[slot$=-trigger]:aria-expanded:bg-foreground/10! **:data-[variant=destructive]:text-accent-foreground! **:data-[variant=destructive]:**:text-accent-foreground!",
+        "z-50 min-w-56 origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-xl p-1.5 text-sm text-popover-foreground ring-1 ring-foreground/10 duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 animate-none! relative bg-popover/90 before:pointer-events-none before:absolute before:inset-0 before:-z-1 before:rounded-[inherit] before:backdrop-blur-2xl before:backdrop-saturate-150 **:data-[slot$=-item]:data-highlighted:bg-foreground/10 **:data-[slot$=-separator]:bg-foreground/5 **:data-[slot$=-trigger]:aria-expanded:bg-foreground/10! **:data-[variant=destructive]:text-accent-foreground! **:data-[variant=destructive]:**:text-accent-foreground!",
         className
       )}
       {...props}

--- a/frontend/src/components/ui/empty.tsx
+++ b/frontend/src/components/ui/empty.tsx
@@ -7,7 +7,7 @@ function Empty({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="empty"
       className={cn(
-        "flex w-full min-w-0 flex-1 flex-col items-center justify-center gap-4 rounded-xl border-dashed p-6 text-center text-balance",
+        "flex w-full min-w-0 flex-1 flex-col items-center justify-center gap-4 rounded-2xl border-dashed p-6 text-center text-balance",
         className
       )}
       {...props}
@@ -31,7 +31,7 @@ const emptyMediaVariants = cva(
     variants: {
       variant: {
         default: "bg-transparent",
-        icon: "flex size-8 shrink-0 items-center justify-center rounded-md bg-muted text-foreground [&_svg:not([class*='size-'])]:size-4",
+        icon: "flex size-8 shrink-0 items-center justify-center rounded-lg bg-muted text-foreground [&_svg:not([class*='size-'])]:size-4",
       },
     },
     defaultVariants: {

--- a/frontend/src/components/ui/input-otp.tsx
+++ b/frontend/src/components/ui/input-otp.tsx
@@ -30,7 +30,7 @@ function InputOTPGroup({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="input-otp-group"
       className={cn(
-        "flex items-center rounded-md has-aria-invalid:border-destructive has-aria-invalid:ring-2 has-aria-invalid:ring-destructive/20 dark:has-aria-invalid:ring-destructive/40",
+        "flex items-center rounded-lg has-aria-invalid:border-destructive has-aria-invalid:ring-2 has-aria-invalid:ring-destructive/20 dark:has-aria-invalid:ring-destructive/40",
         className
       )}
       {...props}
@@ -53,7 +53,7 @@ function InputOTPSlot({
       data-slot="input-otp-slot"
       data-active={isActive}
       className={cn(
-        "relative flex size-10 items-center justify-center border-y border-r border-input bg-input/20 text-sm transition-[border-color,box-shadow,background-color] outline-none first:rounded-l-md first:border-l last:rounded-r-md aria-invalid:border-destructive data-[active=true]:z-10 data-[active=true]:border-ring data-[active=true]:ring-2 data-[active=true]:ring-ring/30 data-[active=true]:aria-invalid:border-destructive data-[active=true]:aria-invalid:ring-destructive/20 dark:bg-input/30 dark:data-[active=true]:aria-invalid:ring-destructive/40",
+        "relative flex size-10 items-center justify-center border-y border-r border-input bg-input/20 text-sm transition-[border-color,box-shadow,background-color] outline-none first:rounded-l-lg first:border-l last:rounded-r-lg aria-invalid:border-destructive data-[active=true]:z-10 data-[active=true]:border-ring data-[active=true]:ring-2 data-[active=true]:ring-ring/30 data-[active=true]:aria-invalid:border-destructive data-[active=true]:aria-invalid:ring-destructive/20 dark:bg-input/30 dark:data-[active=true]:aria-invalid:ring-destructive/40",
         className
       )}
       {...props}

--- a/frontend/src/components/ui/input.tsx
+++ b/frontend/src/components/ui/input.tsx
@@ -8,7 +8,7 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
       type={type}
       data-slot="input"
       className={cn(
-        "h-10 w-full min-w-0 rounded-md border border-input bg-input/20 px-4 py-2 text-sm transition-[border-color,box-shadow,background-color] outline-none file:inline-flex file:h-8 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground/80 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-2 aria-invalid:ring-destructive/20 dark:bg-input/30 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
+        "h-10 w-full min-w-0 rounded-lg border border-input bg-input/20 px-4 py-2 text-sm transition-[border-color,box-shadow,background-color] outline-none file:inline-flex file:h-8 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground/80 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-2 aria-invalid:ring-destructive/20 dark:bg-input/30 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
         className
       )}
       {...props}

--- a/frontend/src/components/ui/item.tsx
+++ b/frontend/src/components/ui/item.tsx
@@ -34,7 +34,7 @@ function ItemSeparator({
 }
 
 const itemVariants = cva(
-  "group/item flex w-full flex-wrap items-center rounded-md border text-xs/relaxed transition-colors duration-100 [a]:transition-colors [a]:hover:bg-muted",
+  "group/item flex w-full flex-wrap items-center rounded-xl border text-xs/relaxed transition-colors duration-100 [a]:transition-colors [a]:hover:bg-muted",
   {
     variants: {
       variant: {
@@ -83,7 +83,7 @@ const itemMediaVariants = cva(
         default: "bg-transparent",
         icon: "[&_svg:not([class*='size-'])]:size-4",
         image:
-          "size-8 overflow-hidden rounded-sm group-data-[size=sm]/item:size-8 group-data-[size=xs]/item:size-6 [&_img]:size-full [&_img]:object-cover",
+          "size-8 overflow-hidden rounded-lg group-data-[size=sm]/item:size-8 group-data-[size=xs]/item:size-6 group-data-[size=xs]/item:rounded-md [&_img]:size-full [&_img]:object-cover",
       },
     },
     defaultVariants: {

--- a/frontend/src/components/ui/partition-bar.tsx
+++ b/frontend/src/components/ui/partition-bar.tsx
@@ -40,7 +40,7 @@ function PartitionBar({
 }
 
 const segmentVariants = cva(
-  "flex min-w-0 flex-col justify-center overflow-hidden rounded-md px-2 py-1.5",
+  "flex min-w-0 flex-col justify-center overflow-hidden rounded-lg px-2 py-1.5",
   {
     variants: {
       variant: {

--- a/frontend/src/components/ui/progress.tsx
+++ b/frontend/src/components/ui/progress.tsx
@@ -14,7 +14,7 @@ function Progress({
     <ProgressPrimitive.Root
       data-slot="progress"
       className={cn(
-        "relative flex h-1 w-full items-center overflow-x-hidden rounded-md bg-muted",
+        "relative flex h-1 w-full items-center overflow-x-hidden rounded-full bg-muted",
         className
       )}
       {...props}

--- a/frontend/src/components/ui/progress.tsx
+++ b/frontend/src/components/ui/progress.tsx
@@ -21,7 +21,7 @@ function Progress({
     >
       <ProgressPrimitive.Indicator
         data-slot="progress-indicator"
-        className="size-full flex-1 bg-primary transition-all"
+        className="size-full flex-1 rounded-full bg-primary transition-all"
         style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
       />
     </ProgressPrimitive.Root>

--- a/frontend/src/components/ui/tabs.tsx
+++ b/frontend/src/components/ui/tabs.tsx
@@ -25,7 +25,7 @@ function Tabs({
 }
 
 const tabsListVariants = cva(
-  "group/tabs-list inline-flex w-fit flex-wrap items-center justify-center gap-1 rounded-lg p-1 text-muted-foreground group-data-horizontal/tabs:min-h-12 group-data-vertical/tabs:h-fit group-data-vertical/tabs:flex-col data-[variant=line]:rounded-none",
+  "group/tabs-list inline-flex w-fit flex-wrap items-center justify-center gap-1 rounded-xl p-1 text-muted-foreground group-data-horizontal/tabs:min-h-12 group-data-vertical/tabs:h-fit group-data-vertical/tabs:flex-col data-[variant=line]:rounded-none",
   {
     variants: {
       variant: {
@@ -63,7 +63,7 @@ function TabsTrigger({
     <TabsPrimitive.Trigger
       data-slot="tabs-trigger"
       className={cn(
-        "relative inline-flex h-10 min-w-24 flex-1 items-center justify-center gap-2 rounded-md border border-transparent px-6 text-sm font-medium whitespace-nowrap text-foreground/60 transition-[background-color,color,border-color,box-shadow] group-data-vertical/tabs:w-full group-data-vertical/tabs:justify-start hover:text-foreground disabled:pointer-events-none disabled:opacity-50 has-data-[icon=inline-end]:pr-5 has-data-[icon=inline-start]:pl-5 dark:text-muted-foreground dark:hover:text-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "relative inline-flex h-10 min-w-24 flex-1 items-center justify-center gap-2 rounded-lg border border-transparent px-6 text-sm font-medium whitespace-nowrap text-foreground/60 transition-[background-color,color,border-color,box-shadow] group-data-vertical/tabs:w-full group-data-vertical/tabs:justify-start hover:text-foreground disabled:pointer-events-none disabled:opacity-50 has-data-[icon=inline-end]:pr-5 has-data-[icon=inline-start]:pl-5 dark:text-muted-foreground dark:hover:text-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         "group-data-[variant=line]/tabs-list:bg-transparent group-data-[variant=line]/tabs-list:data-active:bg-transparent dark:group-data-[variant=line]/tabs-list:data-active:border-transparent dark:group-data-[variant=line]/tabs-list:data-active:bg-transparent",
         "data-active:bg-background data-active:text-foreground dark:data-active:border-input dark:data-active:bg-input/30 dark:data-active:text-foreground",
         "after:absolute after:bg-foreground after:opacity-0 after:transition-opacity group-data-horizontal/tabs:after:inset-x-0 group-data-horizontal/tabs:after:bottom-[-5px] group-data-horizontal/tabs:after:h-0.5 group-data-vertical/tabs:after:inset-y-0 group-data-vertical/tabs:after:-right-1 group-data-vertical/tabs:after:w-0.5 group-data-[variant=line]/tabs-list:data-active:after:opacity-100",

--- a/frontend/src/components/ui/tooltip.tsx
+++ b/frontend/src/components/ui/tooltip.tsx
@@ -42,7 +42,7 @@ function TooltipContent({
         data-slot="tooltip-content"
         sideOffset={sideOffset}
         className={cn(
-          "z-50 inline-flex w-fit max-w-xs origin-(--radix-tooltip-content-transform-origin) items-center gap-1.5 rounded-md bg-foreground px-3 py-1.5 text-xs text-background has-data-[slot=kbd]:pr-1.5 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 **:data-[slot=kbd]:relative **:data-[slot=kbd]:isolate **:data-[slot=kbd]:z-50 **:data-[slot=kbd]:rounded-sm data-[state=delayed-open]:animate-in data-[state=delayed-open]:fade-in-0 data-[state=delayed-open]:zoom-in-95 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          "z-50 inline-flex w-fit max-w-xs origin-(--radix-tooltip-content-transform-origin) items-center gap-1.5 rounded-lg bg-foreground px-3 py-1.5 text-xs text-background has-data-[slot=kbd]:pr-1.5 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 **:data-[slot=kbd]:relative **:data-[slot=kbd]:isolate **:data-[slot=kbd]:z-50 **:data-[slot=kbd]:rounded-sm data-[state=delayed-open]:animate-in data-[state=delayed-open]:fade-in-0 data-[state=delayed-open]:zoom-in-95 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
           className
         )}
         {...props}

--- a/frontend/src/demo/data/accounts.ts
+++ b/frontend/src/demo/data/accounts.ts
@@ -128,6 +128,7 @@ export const mockAccounts: Account[] = [
     color: '#a855f7',
     ticker: null,
     logoUrl: null,
+    logoKey: null,
     createdAt: '2023-06-01T08:00:00Z',
     realEstate: {
       purchasePrice: 320000,

--- a/frontend/src/pages/accounts/AccountsPage.tsx
+++ b/frontend/src/pages/accounts/AccountsPage.tsx
@@ -322,7 +322,7 @@ export function AccountsPage() {
                 key={f}
                 onClick={() => setFilter(f)}
                 className={cn(
-                  'inline-flex h-10 min-w-32 items-center justify-center rounded-md px-6 text-sm font-medium transition-[background-color,color]',
+                  'inline-flex h-10 min-w-32 items-center justify-center rounded-lg px-6 text-sm font-medium transition-[background-color,color]',
                   filter === f
                     ? 'bg-primary text-primary-foreground'
                     : 'text-muted-foreground hover:bg-muted hover:text-foreground'
@@ -365,7 +365,7 @@ export function AccountsPage() {
               </CardHeader>
               <CardContent>
                 {isHistoryLoading ? (
-                  <Skeleton className="h-[250px] w-full rounded-xl" />
+                  <Skeleton className="h-[250px] w-full rounded-2xl" />
                 ) : (
                   <AccountsStackedChart accounts={chartAccounts} data={chartPnlData} />
                 )}
@@ -378,7 +378,7 @@ export function AccountsPage() {
       {isLoading ? (
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
           {Array.from({ length: 6 }).map((_, i) => (
-            <Skeleton key={i} className="h-32 w-full rounded-xl" />
+            <Skeleton key={i} className="h-32 w-full rounded-4xl" />
           ))}
         </div>
       ) : filteredAccounts.length === 0 ? (

--- a/frontend/src/pages/activation/ActivationPage.tsx
+++ b/frontend/src/pages/activation/ActivationPage.tsx
@@ -72,7 +72,7 @@ export function ActivationPage() {
         </CardHeader>
         <CardContent>
           {/* Warning */}
-          <div className="mb-6 rounded-lg border border-yellow-500/30 bg-yellow-500/10 p-4 text-sm text-yellow-200">
+          <div className="mb-6 rounded-2xl border border-yellow-500/30 bg-yellow-500/10 p-4 text-sm text-yellow-200">
             <p className="font-semibold mb-1">Data access notice</p>
             <p>
               The administrator of this Picsou instance has technical access to all data stored

--- a/frontend/src/pages/admin/sections/EnableBankingSection.tsx
+++ b/frontend/src/pages/admin/sections/EnableBankingSection.tsx
@@ -69,7 +69,7 @@ export function EnableBankingSection({ settings }: { settings: AdminEnableBankin
   if (!settings.privateKeyPresent) missing.push(t('admin.enableBanking.privateKey'))
 
   return (
-    <Card className="rounded-4xl bg-card">
+    <Card className="bg-card">
       <CardHeader>
         <CardTitle className="flex items-center gap-2 text-lg">
           <Landmark className="size-5 text-muted-foreground" />
@@ -220,13 +220,13 @@ function KeypairPanel({ privateKeyPresent }: { privateKeyPresent: boolean }) {
       </div>
 
       {/* Mode toggle */}
-      <div className="flex gap-1 rounded-2xl bg-muted p-1">
+      <div className="flex gap-1 rounded-xl bg-muted p-1">
         {(['generate', 'import'] as Mode[]).map((m) => (
           <button
             key={m}
             type="button"
             onClick={() => switchMode(m)}
-            className={`flex-1 rounded-xl px-6 py-2 text-sm font-medium transition-colors ${
+            className={`flex-1 rounded-lg px-6 py-2 text-sm font-medium transition-colors ${
               mode === m
                 ? 'bg-primary text-primary-foreground'
                 : 'text-muted-foreground hover:text-foreground'
@@ -280,7 +280,7 @@ function KeypairPanel({ privateKeyPresent }: { privateKeyPresent: boolean }) {
             value={privatePem}
             onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => setPrivatePem(e.target.value)}
             placeholder={'-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----'}
-            className="min-h-[140px] w-full resize-none rounded-xl border border-input bg-input/20 p-3 font-mono text-sm leading-snug placeholder:text-muted-foreground/80 dark:bg-input/30"
+            className="min-h-[140px] w-full resize-none rounded-lg border border-input bg-input/20 p-3 font-mono text-sm leading-snug placeholder:text-muted-foreground/80 dark:bg-input/30"
           />
           {importError && <p role="alert" className="text-sm text-destructive">{importError}</p>}
           <Button
@@ -301,7 +301,7 @@ function KeypairPanel({ privateKeyPresent }: { privateKeyPresent: boolean }) {
       {publicPem && (
         <div className="space-y-3">
           <p className="text-sm text-muted-foreground">{t('admin.enableBanking.keypair.uploadInstruction')}</p>
-          <pre className="max-h-64 overflow-auto rounded-xl border border-border/60 bg-muted/40 p-4 font-mono text-[11px] leading-snug whitespace-pre-wrap break-all">
+          <pre className="max-h-64 overflow-auto rounded-2xl border border-border/60 bg-muted/40 p-4 font-mono text-[11px] leading-snug whitespace-pre-wrap break-all">
             {publicPem}
           </pre>
           <div className="flex flex-col gap-2 sm:flex-row">

--- a/frontend/src/pages/admin/sections/IntegrationsSection.tsx
+++ b/frontend/src/pages/admin/sections/IntegrationsSection.tsx
@@ -18,7 +18,7 @@ export function IntegrationsSection({ integrations }: { integrations: Record<str
   const toggle = useToggleIntegration()
 
   return (
-    <Card className="rounded-4xl bg-card">
+    <Card className="bg-card">
       <CardHeader>
         <CardTitle className="flex items-center gap-2 text-lg">
           <Plug className="size-5 text-muted-foreground" />

--- a/frontend/src/pages/admin/sections/MembersSection.tsx
+++ b/frontend/src/pages/admin/sections/MembersSection.tsx
@@ -117,7 +117,7 @@ export function MembersSection() {
         ) : !members || members.length === 0 ? (
           <p className="text-sm text-muted-foreground">{t('admin.members.noMembers')}</p>
         ) : (
-          <ul className="divide-y rounded-lg border">
+          <ul className="divide-y rounded-xl border">
             {members.map((m) => {
               const isSelf = m.id === currentUser?.memberId
               const isAdminMember = !m.managed
@@ -238,10 +238,10 @@ export function MembersSection() {
         )}
 
         {link && (
-          <div className="rounded-lg border bg-muted p-3 space-y-2">
+          <div className="rounded-2xl border bg-muted p-3 space-y-2">
             <p className="text-sm font-medium">{t('admin.members.linkLabel')}</p>
             <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
-              <code className="flex-1 break-all rounded-xl bg-background px-3 py-2 text-sm">
+              <code className="flex-1 break-all rounded-lg bg-background px-3 py-2 text-sm">
                 {link.url}
               </code>
               <Button size="sm" variant="outline" onClick={handleCopy}>

--- a/frontend/src/pages/admin/sections/SecuritySection.tsx
+++ b/frontend/src/pages/admin/sections/SecuritySection.tsx
@@ -48,7 +48,7 @@ export function SecuritySection({ settings }: { settings: AdminSecuritySettings 
   })
 
   return (
-    <Card className="rounded-4xl bg-card">
+    <Card className="bg-card">
       <CardHeader>
         <CardTitle className="flex items-center gap-2 text-lg">
           <ShieldCheck className="size-5 text-muted-foreground" />

--- a/frontend/src/pages/dashboard/DashboardPage.tsx
+++ b/frontend/src/pages/dashboard/DashboardPage.tsx
@@ -276,7 +276,7 @@ export function DashboardPage() {
                 <Item
                   key={goal.id}
                   variant="muted"
-                  className="flex-col items-stretch rounded-4xl px-4 py-3 gap-4 cursor-pointer"
+                  className="flex-col items-stretch rounded-2xl px-4 py-3 gap-4 cursor-pointer"
                   onClick={() => setDetailGoalId(goal.id)}
                 >
                   <ItemContent className="gap-3">

--- a/frontend/src/pages/goals/GoalCalendarPage.tsx
+++ b/frontend/src/pages/goals/GoalCalendarPage.tsx
@@ -163,7 +163,7 @@ function YearGridView({ months, selectedYm, onSelect, onAddPreviousMonth, isAddi
                     disabled={isAddingMonth}
                     title={t('goals.addPreviousMonth')}
                     aria-label={t('goals.addPreviousMonth')}
-                    className="flex flex-col items-center justify-center gap-[9px] rounded-xl border border-dashed border-border px-2 py-3 transition-colors cursor-pointer min-w-[90px] text-muted-foreground hover:bg-accent/50 hover:text-foreground disabled:opacity-50 disabled:cursor-not-allowed"
+                    className="flex flex-col items-center justify-center gap-[9px] rounded-2xl border border-dashed border-border px-2 py-3 transition-colors cursor-pointer min-w-[90px] text-muted-foreground hover:bg-accent/50 hover:text-foreground disabled:opacity-50 disabled:cursor-not-allowed"
                   >
                     {isAddingMonth
                       ? <Loader2 className="size-5 animate-spin" />
@@ -187,7 +187,7 @@ function YearGridView({ months, selectedYm, onSelect, onAddPreviousMonth, isAddi
                     <button
                       key={entry.yearMonth}
                       onClick={() => onSelect(entry.yearMonth)}
-                      className={`flex flex-col items-center gap-[9px] rounded-xl border px-2 py-3 transition-colors cursor-pointer min-w-[90px] ${
+                      className={`flex flex-col items-center gap-[9px] rounded-2xl border px-2 py-3 transition-colors cursor-pointer min-w-[90px] ${
                         isSelected ? 'border-primary bg-accent' : 'border-border hover:bg-accent/50'
                       }`}
                     >
@@ -262,7 +262,7 @@ function TimelineView({ months, selectedYm, onSelect }: {
             <button
               key={entry.yearMonth}
               onClick={() => onSelect(entry.yearMonth)}
-              className={`w-full flex items-center gap-3 rounded-md px-3 py-2.5 text-left transition-colors ${isSelected ? 'bg-accent' : 'hover:bg-accent/50'}`}
+              className={`w-full flex items-center gap-3 rounded-xl px-3 py-2.5 text-left transition-colors ${isSelected ? 'bg-accent' : 'hover:bg-accent/50'}`}
             >
               <span className="w-28 shrink-0 text-sm font-medium">{fullMonthName(entry.yearMonth, locale)}</span>
               <div className="flex-1 h-2 rounded-full bg-muted overflow-hidden">
@@ -317,7 +317,7 @@ function CalendarGridView({ months, selectedYm, onSelect }: {
                   <button
                     key={entry.yearMonth}
                     onClick={() => onSelect(entry.yearMonth)}
-                    className={`rounded-lg border p-3 text-left transition-colors ${isSelected ? 'border-primary bg-accent' : 'border-border hover:bg-accent/50'}`}
+                    className={`rounded-2xl border p-3 text-left transition-colors ${isSelected ? 'border-primary bg-accent' : 'border-border hover:bg-accent/50'}`}
                   >
                     <div className="flex items-center justify-between mb-1">
                       <span className="text-sm font-medium">{monthAbbr(entry.yearMonth, locale)}</span>
@@ -544,7 +544,7 @@ export function GoalCalendarPage() {
             <div className="overflow-x-auto">
               <div className="flex gap-3 min-w-max">
                 {Array.from({ length: 12 }).map((_, i) => (
-                  <div key={i} className="flex flex-col items-center gap-[9px] rounded-xl border border-border px-2 py-3 min-w-[90px]">
+                  <div key={i} className="flex flex-col items-center gap-[9px] rounded-2xl border border-border px-2 py-3 min-w-[90px]">
                     <Skeleton className="h-2.5 w-8" />
                     <Skeleton className="size-[80px] rounded-full" />
                     <Skeleton className="h-2.5 w-14" />
@@ -669,7 +669,7 @@ export function GoalCalendarPage() {
         <SheetContent
           side="bottom"
           showCloseButton={false}
-          className="max-h-[85vh] overflow-y-auto rounded-t-2xl p-4"
+          className="max-h-[85vh] overflow-y-auto rounded-t-4xl p-4"
         >
           <SheetHeader className="sr-only">
             <SheetTitle>{selectedEntry ? fullMonthName(selectedEntry.yearMonth, locale) : ''}</SheetTitle>

--- a/frontend/src/pages/goals/GoalsPage.tsx
+++ b/frontend/src/pages/goals/GoalsPage.tsx
@@ -213,7 +213,7 @@ export function GoalsPage() {
                       type="checkbox"
                       checked={form.accountIds.includes(a.id)}
                       onChange={() => toggleAccount(a.id)}
-                      className="rounded accent-primary"
+                      className="rounded-sm accent-primary"
                     />
                     <span
                       className="w-2.5 h-2.5 rounded-full shrink-0"

--- a/frontend/src/pages/login/LoginPage.tsx
+++ b/frontend/src/pages/login/LoginPage.tsx
@@ -81,7 +81,7 @@ export function LoginPage() {
                   autoComplete="username"
                   required
                   placeholder="admin"
-                  className="h-12 rounded-xl px-4 text-base md:text-base"
+                  className="h-12 px-4 text-base md:text-base"
                 />
               </div>
 
@@ -98,12 +98,12 @@ export function LoginPage() {
                     autoComplete="current-password"
                     required
                     placeholder="••••••••"
-                    className="h-12 rounded-xl px-4 pr-14 text-base md:text-base"
+                    className="h-12 px-4 pr-14 text-base md:text-base"
                   />
                   <button
                     type="button"
                     onClick={() => setShowPw(v => !v)}
-                    className="absolute right-2 top-1/2 inline-flex h-10 w-10 -translate-y-1/2 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                    className="absolute right-2 top-1/2 inline-flex h-10 w-10 -translate-y-1/2 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
                     aria-label={showPw ? t('auth.hidePassword') : t('auth.showPassword')}
                     aria-pressed={showPw}
                   >
@@ -116,13 +116,13 @@ export function LoginPage() {
                 </div>
               </div>
 
-              <div className="flex items-start gap-3 rounded-xl py-1">
+              <div className="flex items-start gap-3 py-1">
                 <input
                   id="rememberMe"
                   type="checkbox"
                   checked={rememberMe}
                   onChange={e => setRememberMe(e.target.checked)}
-                  className="mt-1 h-5 w-5 shrink-0 rounded-md accent-primary"
+                  className="mt-1 h-5 w-5 shrink-0 rounded-sm accent-primary"
                 />
                 <div className="flex flex-col">
                   <Label htmlFor="rememberMe" className="cursor-pointer text-base font-semibold">
@@ -141,7 +141,7 @@ export function LoginPage() {
               <Button
                 type="submit"
                 disabled={loginMutation.isPending}
-                className="mt-2 h-12 w-full rounded-full px-8 text-base transition-transform active:scale-[0.96]"
+                className="mt-2 h-12 w-full px-8 text-base transition-transform active:scale-[0.96]"
               >
                 {loginMutation.isPending && (
                   <Loader2 className="size-5 animate-spin" />

--- a/frontend/src/pages/login/MfaChallengePage.tsx
+++ b/frontend/src/pages/login/MfaChallengePage.tsx
@@ -92,7 +92,7 @@ export function MfaChallengePage() {
                   autoFocus
                   required
                   placeholder={isRecoveryCode ? '12345678' : '123456'}
-                  className="h-12 rounded-xl px-4 text-center font-mono text-lg md:text-lg"
+                  className="h-12 px-4 text-center font-mono text-lg md:text-lg"
                 />
               </div>
 
@@ -108,13 +108,13 @@ export function MfaChallengePage() {
                 {isRecoveryCode ? t('auth.mfaUseTotp') : t('auth.mfaUseRecovery')}
               </button>
 
-              <div className="flex items-start gap-3 rounded-xl py-1">
+              <div className="flex items-start gap-3 py-1">
                 <input
                   id="trustDevice"
                   type="checkbox"
                   checked={trustDevice}
                   onChange={e => setTrustDevice(e.target.checked)}
-                  className="mt-1 h-5 w-5 shrink-0 rounded-md accent-primary"
+                  className="mt-1 h-5 w-5 shrink-0 rounded-sm accent-primary"
                 />
                 <div className="flex flex-col">
                   <Label htmlFor="trustDevice" className="cursor-pointer text-base font-semibold">
@@ -133,7 +133,7 @@ export function MfaChallengePage() {
               <Button
                 type="submit"
                 disabled={verify.isPending || code.length === 0}
-                className="mt-2 h-12 w-full rounded-full px-8 text-base transition-transform active:scale-[0.96]"
+                className="mt-2 h-12 w-full px-8 text-base transition-transform active:scale-[0.96]"
               >
                 {verify.isPending && <Loader2 className="size-5 animate-spin" />}
                 {verify.isPending ? t('auth.mfaVerifying') : t('auth.mfaVerifyButton')}

--- a/frontend/src/pages/settings/FamilySettingsPage.tsx
+++ b/frontend/src/pages/settings/FamilySettingsPage.tsx
@@ -72,7 +72,7 @@ function MemberManagement() {
             const isIndependent = member.managed && member.hasLogin && member.activated
 
             return (
-              <div key={member.id} className="flex items-center justify-between rounded-lg border p-3">
+              <div key={member.id} className="flex items-center justify-between rounded-xl border p-3">
                 <div>
                   <div className="flex items-center gap-2">
                     <p className="font-medium">{member.displayName}</p>
@@ -142,7 +142,7 @@ function MemberManagement() {
 
         {/* Activation link display */}
         {activationLink && (
-          <div className="rounded-lg border bg-muted p-3">
+          <div className="rounded-2xl border bg-muted p-3">
             <p className="text-sm font-medium mb-1">{t('family.settings.activationLink')}</p>
             <code className="text-xs break-all">{window.location.origin}{activationLink}</code>
           </div>

--- a/frontend/src/pages/settings/SettingsPage.tsx
+++ b/frontend/src/pages/settings/SettingsPage.tsx
@@ -57,13 +57,13 @@ function ToggleGroup({
   onChange: (value: string) => void
 }) {
   return (
-    <div className="inline-flex items-center rounded-2xl bg-muted p-1">
+    <div className="inline-flex items-center rounded-xl bg-muted p-1">
       {options.map((opt) => (
         <button
           key={opt.value}
           type="button"
           onClick={() => onChange(opt.value)}
-          className={`inline-flex h-10 min-w-24 items-center justify-center rounded-xl px-8 text-sm font-medium transition-[background-color,color] ${
+          className={`inline-flex h-10 min-w-24 items-center justify-center rounded-lg px-8 text-sm font-medium transition-[background-color,color] ${
             value === opt.value
               ? 'bg-primary text-primary-foreground'
               : 'text-muted-foreground hover:text-foreground'
@@ -92,7 +92,7 @@ function SectionCard({
   children: React.ReactNode
 }) {
   return (
-    <Card className="rounded-4xl bg-card">
+    <Card className="bg-card">
       <CardHeader>
         <CardTitle className="flex items-center gap-2 text-lg">
           {React.createElement(icon, { className: "size-5 text-muted-foreground" })}
@@ -377,7 +377,7 @@ export function SettingsPage() {
               href="https://github.com/zoeille/picsou-finance"
               target="_blank"
               rel="noreferrer"
-              className="inline-flex min-h-10 max-w-full items-center gap-2 rounded-xl font-medium text-foreground transition-colors hover:text-muted-foreground"
+              className="inline-flex min-h-10 max-w-full items-center gap-2 rounded-lg font-medium text-foreground transition-colors hover:text-muted-foreground"
             >
               <span className="truncate">github.com/zoeille/picsou-finance</span>
               <ExternalLink className="size-4 text-muted-foreground" />

--- a/frontend/src/pages/settings/sections/AccessKeysSection.tsx
+++ b/frontend/src/pages/settings/sections/AccessKeysSection.tsx
@@ -48,14 +48,14 @@ function ScopeToggle({
       aria-checked={checked}
       onClick={onToggle}
       className={cn(
-        'flex w-full flex-col items-start gap-0.5 rounded-lg border p-3 text-left transition-colors',
+        'flex w-full flex-col items-start gap-0.5 rounded-2xl border p-3 text-left transition-colors',
         checked ? 'border-primary bg-primary/5' : 'border-border hover:bg-muted',
       )}
     >
       <span className="flex items-center gap-2 text-sm font-medium">
         <span
           className={cn(
-            'flex size-4 shrink-0 items-center justify-center rounded border',
+            'flex size-4 shrink-0 items-center justify-center rounded-sm border',
             checked ? 'border-primary bg-primary text-primary-foreground' : 'border-muted-foreground/40',
           )}
           aria-hidden
@@ -173,7 +173,7 @@ export function AccessKeysSection() {
       ) : !keys || keys.length === 0 ? (
         <p className="text-sm text-muted-foreground">{t('accessKeys.empty')}</p>
       ) : (
-        <ul className="divide-y rounded-lg border">
+        <ul className="divide-y rounded-xl border">
           {keys.map((k) => {
             const status = keyStatus(k)
             const badge = STATUS_BADGE[status]
@@ -233,7 +233,7 @@ export function AccessKeysSection() {
         <div className="space-y-2">
           <Label className="text-muted-foreground">{t('accessKeys.connectEndpointLabel')}</Label>
           <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
-            <code className="flex min-h-10 flex-1 items-center break-all rounded-xl bg-background px-4 py-2 font-mono text-sm">
+            <code className="flex min-h-10 flex-1 items-center break-all rounded-lg bg-background px-4 py-2 font-mono text-sm">
               {endpoint}
             </code>
             <Button
@@ -250,7 +250,7 @@ export function AccessKeysSection() {
         <div className="space-y-2">
           <Label className="text-muted-foreground">{t('accessKeys.connectSnippetLabel')}</Label>
           <div className="relative space-y-2 sm:space-y-0">
-            <pre className="min-h-10 overflow-x-auto rounded-xl bg-background p-4 font-mono text-sm leading-relaxed sm:pr-40">
+            <pre className="min-h-10 overflow-x-auto rounded-2xl bg-background p-4 font-mono text-sm leading-relaxed sm:pr-40">
               {snippet}
             </pre>
             <Button
@@ -280,9 +280,9 @@ export function AccessKeysSection() {
                 <DialogDescription>{t('accessKeys.secretWarning')}</DialogDescription>
               </DialogHeader>
               <div className="min-h-0 overflow-y-auto px-5 py-4">
-                <div className="space-y-2 rounded-lg border border-amber-500/40 bg-amber-50 p-3 dark:bg-amber-950/30">
+                <div className="space-y-2 rounded-2xl border border-amber-500/40 bg-amber-50 p-3 dark:bg-amber-950/30">
                   <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
-                    <code className="flex min-h-10 flex-1 items-center break-all rounded-xl bg-background px-4 py-2 font-mono text-sm">
+                    <code className="flex min-h-10 flex-1 items-center break-all rounded-lg bg-background px-4 py-2 font-mono text-sm">
                       {created.secret}
                     </code>
                     <Button
@@ -365,7 +365,7 @@ export function AccessKeysSection() {
                   {createKey.isError && (
                     <p
                       role="alert"
-                      className="rounded-md border border-destructive/50 bg-destructive/10 px-3 py-2 text-sm text-destructive"
+                      className="rounded-xl border border-destructive/50 bg-destructive/10 px-3 py-2 text-sm text-destructive"
                     >
                       {formatApiError(createKey.error, t, 'accessKeys.error')}
                     </p>

--- a/frontend/src/pages/settings/security/ExportDataDialog.tsx
+++ b/frontend/src/pages/settings/security/ExportDataDialog.tsx
@@ -117,7 +117,7 @@ export function ExportDataDialog({
             </div>
           )}
 
-          <div className="flex items-start gap-3 rounded-md border p-3">
+          <div className="flex items-start gap-3 rounded-2xl border p-3">
             <Switch
               id="export-snapshots"
               checked={includeBalanceSnapshots}

--- a/frontend/src/pages/settings/security/MfaEnrollDialog.tsx
+++ b/frontend/src/pages/settings/security/MfaEnrollDialog.tsx
@@ -137,12 +137,12 @@ export function MfaEnrollDialog({
               <img
                 src={qrUri}
                 alt="2FA QR code"
-                className="size-48 sm:size-56 border rounded-lg bg-white p-2"
+                className="size-48 sm:size-56 border rounded-2xl bg-white p-2"
               />
             </div>
             <div className="space-y-1.5">
               <p className="text-xs text-muted-foreground">{t('settings.mfaEnrollSecretManual')}</p>
-              <code className="block w-full font-mono text-xs sm:text-sm break-all rounded border bg-muted/40 p-2 text-center">
+              <code className="block w-full font-mono text-xs sm:text-sm break-all rounded-lg border bg-muted/40 p-2 text-center">
                 {secret}
               </code>
             </div>

--- a/frontend/src/pages/settings/security/RecoveryCodesView.tsx
+++ b/frontend/src/pages/settings/security/RecoveryCodesView.tsx
@@ -43,11 +43,11 @@ export function RecoveryCodesView({
 
   return (
     <div className="space-y-4">
-      <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 rounded-lg border bg-muted/30 p-3">
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 rounded-2xl border bg-muted/30 p-3">
         {codes.map(code => (
           <code
             key={code}
-            className="font-mono text-sm tracking-wider text-center py-1.5 px-2 rounded bg-background border"
+            className="font-mono text-sm tracking-wider text-center py-1.5 px-2 rounded-md bg-background border"
           >
             {code}
           </code>
@@ -70,7 +70,7 @@ export function RecoveryCodesView({
           type="checkbox"
           checked={acknowledged}
           onChange={e => setAcknowledged(e.target.checked)}
-          className="mt-0.5 h-4 w-4 rounded"
+          className="mt-0.5 h-4 w-4 rounded-sm"
         />
         <span className="text-sm">{t('settings.mfaEnrollStep4Confirm')}</span>
       </label>

--- a/frontend/src/pages/settings/security/SessionsList.tsx
+++ b/frontend/src/pages/settings/security/SessionsList.tsx
@@ -33,7 +33,7 @@ export function SessionsList() {
 
   return (
     <div className="space-y-3">
-      <ul className="divide-y rounded-lg border">
+      <ul className="divide-y rounded-xl border">
         {sessions.map(s => (
           <SessionRow
             key={s.id}

--- a/frontend/src/pages/setup/SetupLayout.tsx
+++ b/frontend/src/pages/setup/SetupLayout.tsx
@@ -69,7 +69,7 @@ export function SetupLayout() {
         <div
           role="radiogroup"
           aria-label={t('setup.intro.language')}
-          className="inline-flex min-h-12 shrink-0 items-center rounded-2xl border border-border/60 bg-background/80 p-1 backdrop-blur-md"
+          className="inline-flex min-h-12 shrink-0 items-center rounded-xl border border-border/60 bg-background/80 p-1 backdrop-blur-md"
         >
           {SUPPORTED_LOCALES.map((locale) => (
             <button
@@ -79,7 +79,7 @@ export function SetupLayout() {
               aria-checked={activeLanguage === locale.code}
               onClick={() => switchLang(locale.code)}
               className={cn(
-                'inline-flex h-10 min-w-12 items-center justify-center rounded-xl px-4 text-sm font-medium transition-[background-color,color] sm:min-w-14 sm:px-5',
+                'inline-flex h-10 min-w-12 items-center justify-center rounded-lg px-4 text-sm font-medium transition-[background-color,color] sm:min-w-14 sm:px-5',
                 activeLanguage === locale.code
                   ? 'bg-primary text-primary-foreground'
                   : 'text-muted-foreground hover:text-foreground'
@@ -92,7 +92,7 @@ export function SetupLayout() {
 
         <span
           className={cn(
-            'inline-flex h-10 min-w-0 items-center rounded-full border border-border/60',
+            'inline-flex h-10 min-w-0 items-center rounded-lg border border-border/60',
             'bg-background/80 px-4 text-xs font-medium text-muted-foreground',
             'backdrop-blur-md'
           )}
@@ -110,7 +110,7 @@ export function SetupLayout() {
       >
         <a
           href="#setup-main"
-          className="sr-only focus:not-sr-only focus:fixed focus:left-4 focus:top-20 focus:z-[60] focus:inline-flex focus:h-10 focus:items-center focus:rounded-full focus:bg-primary focus:px-6 focus:text-sm focus:font-medium focus:text-primary-foreground"
+          className="sr-only focus:not-sr-only focus:fixed focus:left-4 focus:top-20 focus:z-[60] focus:inline-flex focus:h-10 focus:items-center focus:rounded-lg focus:bg-primary focus:px-6 focus:text-sm focus:font-medium focus:text-primary-foreground"
         >
           {t('setup.a11y.skipToContent')}
         </a>

--- a/frontend/src/pages/setup/SetupStepAdmin.tsx
+++ b/frontend/src/pages/setup/SetupStepAdmin.tsx
@@ -145,7 +145,7 @@ export function SetupStepAdmin() {
               onClick={() => setShowPassword((value) => !value)}
               className={cn(
                 'absolute right-2 top-1/2 inline-flex h-10 w-10 -translate-y-1/2',
-                'items-center justify-center rounded-full text-muted-foreground',
+                'items-center justify-center rounded-lg text-muted-foreground',
                 'transition-colors hover:bg-muted hover:text-foreground'
               )}
             >
@@ -225,7 +225,7 @@ export function SetupStepAdmin() {
           <Button
             type="submit"
             disabled={submitAdmin.isPending || !formState.isValid}
-            className="w-full rounded-full"
+            className="w-full"
           >
             {submitAdmin.isPending ? t('setup.admin.creating') : t('setup.admin.cta')}
           </Button>

--- a/frontend/src/pages/setup/SetupStepComplete.tsx
+++ b/frontend/src/pages/setup/SetupStepComplete.tsx
@@ -111,7 +111,7 @@ export function SetupStepComplete() {
       <div className="relative space-y-8">
         <div className="text-center space-y-2">
           <div className="flex justify-center">
-            <span className="rounded-2xl bg-emerald-500/10 p-3 text-emerald-500">
+            <span className="rounded-lg bg-emerald-500/10 p-3 text-emerald-500">
               <CheckCircle2 className="h-8 w-8" />
             </span>
           </div>
@@ -163,14 +163,14 @@ export function SetupStepComplete() {
           {autoLogin === 'success' ? (
             <Button
               onClick={goToDashboard}
-              className="w-full rounded-full"
+              className="w-full"
             >
               {t('setup.complete.cta')}
             </Button>
           ) : autoLogin === 'failed' ? (
             <Button
               onClick={goToLogin}
-              className="w-full rounded-full"
+              className="w-full"
             >
               {t('setup.complete.loginFallback')}
             </Button>

--- a/frontend/src/pages/setup/SetupStepIntegrations.tsx
+++ b/frontend/src/pages/setup/SetupStepIntegrations.tsx
@@ -97,14 +97,14 @@ export function SetupStepIntegrations() {
         {count === 0 ? (
           <Button
             onClick={handleContinue}
-            className="w-full rounded-full"
+            className="w-full"
           >
             {t('setup.integrations.skipAll')}
           </Button>
         ) : (
           <Button
             onClick={handleContinue}
-            className="w-full rounded-full"
+            className="w-full"
           >
             {t('setup.integrations.continue')}
           </Button>

--- a/frontend/src/pages/setup/SetupStepIntro.tsx
+++ b/frontend/src/pages/setup/SetupStepIntro.tsx
@@ -26,7 +26,7 @@ export function SetupStepIntro() {
               type="button"
               onClick={() => setPhase('content')}
               aria-label={t('setup.intro.skipAria')}
-              className="rounded-full px-3 py-1 text-xs text-muted-foreground underline-offset-4 hover:text-foreground hover:underline"
+              className="rounded-lg px-3 py-1 text-xs text-muted-foreground underline-offset-4 hover:text-foreground hover:underline"
             >
               {t('setup.intro.skip')}
             </button>

--- a/frontend/src/pages/setup/SetupStepSecurity.tsx
+++ b/frontend/src/pages/setup/SetupStepSecurity.tsx
@@ -89,7 +89,7 @@ export function SetupStepSecurity() {
                         size="icon"
                         onClick={() => remove(idx)}
                         aria-label={t('setup.security.originRemove')}
-                        className="h-10 w-10 rounded-xl"
+                        className="h-10 w-10"
                       >
                         <X className="size-4" />
                       </Button>
@@ -114,7 +114,7 @@ export function SetupStepSecurity() {
               type="button"
               variant="outline"
               onClick={() => append('')}
-              className="rounded-xl px-4"
+              className="px-4"
             >
               <PlusCircle className="mr-2 size-4" />
               {t('setup.security.originAdd')}
@@ -122,7 +122,7 @@ export function SetupStepSecurity() {
           </div>
         </div>
 
-        <div className="flex items-center justify-between gap-4 rounded-xl border border-border/60 p-5">
+        <div className="flex items-center justify-between gap-4 rounded-2xl border border-border/60 p-5">
           <div className="space-y-1">
             <Label htmlFor="setup-secure-cookies" className="text-sm font-semibold">
               {t('setup.security.secureCookiesLabel')}
@@ -155,7 +155,7 @@ export function SetupStepSecurity() {
           <Button
             type="submit"
             disabled={submit.isPending}
-            className="w-full rounded-full"
+            className="w-full"
           >
             {submit.isPending ? t('setup.security.saving') : t('setup.security.cta')}
           </Button>

--- a/frontend/src/pages/setup/components/IntegrationCard.tsx
+++ b/frontend/src/pages/setup/components/IntegrationCard.tsx
@@ -46,7 +46,7 @@ export function IntegrationCard({
     >
       <span
         className={cn(
-          'shrink-0 rounded-xl p-2 transition-colors',
+          'shrink-0 rounded-lg p-2 transition-colors',
           checked ? 'bg-primary/10 text-primary' : 'bg-muted text-muted-foreground'
         )}
         aria-hidden="true"
@@ -59,7 +59,7 @@ export function IntegrationCard({
       </div>
       <span
         className={cn(
-          'mt-0.5 h-5 w-5 shrink-0 rounded-md border-2 flex items-center justify-center transition-colors',
+          'mt-0.5 h-5 w-5 shrink-0 rounded-sm border-2 flex items-center justify-center transition-colors',
           checked
             ? 'bg-primary border-primary text-primary-foreground'
             : 'border-muted-foreground/40'

--- a/frontend/src/pages/setup/integrations/SetupStepBourseDirect.tsx
+++ b/frontend/src/pages/setup/integrations/SetupStepBourseDirect.tsx
@@ -29,7 +29,7 @@ export function SetupStepBourseDirect() {
     <div className="space-y-8">
       <div className="text-center space-y-2">
         <div className="flex justify-center">
-          <span className="rounded-xl bg-primary/10 p-3 text-primary">
+          <span className="rounded-lg bg-primary/10 p-3 text-primary">
             <BriefcaseBusiness className="h-6 w-6" />
           </span>
         </div>
@@ -48,14 +48,14 @@ export function SetupStepBourseDirect() {
           type="button"
           variant="outline"
           onClick={skip}
-          className="w-full rounded-full"
+          className="w-full"
         >
           {t('setup.bourseDirect.skip')}
         </Button>
         <Button
           onClick={proceed}
           disabled={ack.isPending}
-          className="w-full rounded-full"
+          className="w-full"
         >
           {t('setup.bourseDirect.cta')}
         </Button>

--- a/frontend/src/pages/setup/integrations/SetupStepBoursoBank.tsx
+++ b/frontend/src/pages/setup/integrations/SetupStepBoursoBank.tsx
@@ -66,7 +66,7 @@ export function SetupStepBoursoBank() {
     <div className="space-y-8">
       <div className="text-center space-y-2">
         <div className="flex justify-center">
-          <span className="rounded-xl bg-primary/10 p-3 text-primary">
+          <span className="rounded-lg bg-primary/10 p-3 text-primary">
             <Boxes className="h-6 w-6" />
           </span>
         </div>
@@ -122,7 +122,7 @@ export function SetupStepBoursoBank() {
           <Button
             onClick={run}
             disabled={health.isPending}
-            className="w-full rounded-full"
+            className="w-full"
           >
             {t('setup.bourso.retry')}
           </Button>
@@ -130,7 +130,7 @@ export function SetupStepBoursoBank() {
           <Button
             onClick={proceed}
             disabled={phase === 'checking'}
-            className="w-full rounded-full"
+            className="w-full"
           >
             {t('setup.bourso.continue')}
           </Button>

--- a/frontend/src/pages/setup/integrations/SetupStepCrypto.tsx
+++ b/frontend/src/pages/setup/integrations/SetupStepCrypto.tsx
@@ -75,7 +75,7 @@ export function SetupStepCrypto() {
     <div className="space-y-8">
       <div className="text-center space-y-2">
         <div className="flex justify-center">
-          <span className="rounded-xl bg-primary/10 p-3 text-primary">
+          <span className="rounded-lg bg-primary/10 p-3 text-primary">
             <Bitcoin className="h-6 w-6" />
           </span>
         </div>
@@ -122,7 +122,7 @@ export function SetupStepCrypto() {
           type="button"
           variant="outline"
           onClick={skip}
-          className="w-full rounded-full"
+          className="w-full"
         >
           {t('setup.crypto.skip')}
         </Button>
@@ -130,7 +130,7 @@ export function SetupStepCrypto() {
           <Button
             onClick={run}
             disabled={gen.isPending}
-            className="w-full rounded-full"
+            className="w-full"
           >
             {t('setup.crypto.generateCta')}
           </Button>
@@ -138,7 +138,7 @@ export function SetupStepCrypto() {
           <Button
             onClick={proceed}
             disabled={phase === 'running'}
-            className="w-full rounded-full"
+            className="w-full"
           >
             {t('setup.crypto.continue')}
           </Button>

--- a/frontend/src/pages/setup/integrations/SetupStepFinary.tsx
+++ b/frontend/src/pages/setup/integrations/SetupStepFinary.tsx
@@ -29,7 +29,7 @@ export function SetupStepFinary() {
     <div className="space-y-8">
       <div className="text-center space-y-2">
         <div className="flex justify-center">
-          <span className="rounded-xl bg-primary/10 p-3 text-primary">
+          <span className="rounded-lg bg-primary/10 p-3 text-primary">
             <PiggyBank className="h-6 w-6" />
           </span>
         </div>
@@ -50,14 +50,14 @@ export function SetupStepFinary() {
           type="button"
           variant="outline"
           onClick={skip}
-          className="w-full rounded-full"
+          className="w-full"
         >
           {t('setup.finary.skip')}
         </Button>
         <Button
           onClick={proceed}
           disabled={ack.isPending}
-          className="w-full rounded-full"
+          className="w-full"
         >
           {t('setup.finary.cta')}
         </Button>

--- a/frontend/src/pages/setup/integrations/SetupStepTradeRepublic.tsx
+++ b/frontend/src/pages/setup/integrations/SetupStepTradeRepublic.tsx
@@ -29,7 +29,7 @@ export function SetupStepTradeRepublic() {
     <div className="space-y-8">
       <div className="text-center space-y-2">
         <div className="flex justify-center">
-          <span className="rounded-xl bg-primary/10 p-3 text-primary">
+          <span className="rounded-lg bg-primary/10 p-3 text-primary">
             <LineChart className="h-6 w-6" />
           </span>
         </div>
@@ -50,14 +50,14 @@ export function SetupStepTradeRepublic() {
           type="button"
           variant="outline"
           onClick={skip}
-          className="w-full rounded-full"
+          className="w-full"
         >
           {t('setup.tr.skip')}
         </Button>
         <Button
           onClick={proceed}
           disabled={ack.isPending}
-          className="w-full rounded-full"
+          className="w-full"
         >
           {t('setup.tr.cta')}
         </Button>

--- a/frontend/src/pages/setup/integrations/enablebanking/EBStep1Explain.tsx
+++ b/frontend/src/pages/setup/integrations/enablebanking/EBStep1Explain.tsx
@@ -24,11 +24,11 @@ export function EBStep1Explain({ onNext }: Props) {
     <EBSubstepShell current={1} total={5}>
       <div className="space-y-6">
         <div className="flex items-center justify-center gap-3 text-primary">
-          <span className="rounded-xl bg-primary/10 p-3">
+          <span className="rounded-lg bg-primary/10 p-3">
             <Landmark className="h-6 w-6" />
           </span>
           <span className="text-muted-foreground" aria-hidden="true">+</span>
-          <span className="rounded-xl bg-primary/10 p-3">
+          <span className="rounded-lg bg-primary/10 p-3">
             <Lock className="h-6 w-6" />
           </span>
         </div>
@@ -55,12 +55,12 @@ export function EBStep1Explain({ onNext }: Props) {
         </div>
 
         {psd2Open && (
-          <div className="rounded-xl border border-border/60 bg-muted/40 p-4 text-xs text-muted-foreground">
+          <div className="rounded-2xl border border-border/60 bg-muted/40 p-4 text-xs text-muted-foreground">
             {t('setup.enablebanking.explain.psd2Body')}
           </div>
         )}
 
-        <div className="flex items-start gap-3 rounded-xl border border-amber-500/40 bg-amber-500/10 p-4 text-left">
+        <div className="flex items-start gap-3 rounded-2xl border border-amber-500/40 bg-amber-500/10 p-4 text-left">
           <AlertTriangle className="mt-0.5 h-4 w-4 flex-shrink-0 text-amber-600 dark:text-amber-400" />
           <div className="space-y-1 text-xs sm:text-sm">
             <p className="font-medium text-amber-900 dark:text-amber-100">
@@ -72,7 +72,7 @@ export function EBStep1Explain({ onNext }: Props) {
           </div>
         </div>
 
-        <div className="flex items-start gap-3 rounded-xl border border-border/60 bg-muted/40 p-4 text-left">
+        <div className="flex items-start gap-3 rounded-2xl border border-border/60 bg-muted/40 p-4 text-left">
           <Info className="mt-0.5 h-4 w-4 flex-shrink-0 text-muted-foreground" />
           <p className="text-xs sm:text-sm text-muted-foreground">
             {t('setup.enablebanking.explain.psd2ScopeNote')}
@@ -84,25 +84,25 @@ export function EBStep1Explain({ onNext }: Props) {
             <Button
               variant="outline"
               onClick={handleCreateAccount}
-              className="w-full rounded-full"
+              className="w-full"
             >
               {t('setup.enablebanking.explain.needAccount')}
             </Button>
             <Button
               onClick={handleHaveAccount}
-              className="w-full rounded-full"
+              className="w-full"
             >
               {t('setup.enablebanking.explain.haveAccount')}
             </Button>
           </div>
         ) : (
-          <div className="space-y-3 rounded-xl border border-border/60 bg-card p-4 text-center">
+          <div className="space-y-3 rounded-2xl border border-border/60 bg-card p-4 text-center">
             <p className="text-sm text-muted-foreground">
               {t('setup.enablebanking.explain.signupOpened')}
             </p>
             <Button
               onClick={onNext}
-              className="w-full rounded-full"
+              className="w-full"
             >
               {t('setup.enablebanking.explain.continueAfterSignup')}
             </Button>

--- a/frontend/src/pages/setup/integrations/enablebanking/EBStep2Credentials.tsx
+++ b/frontend/src/pages/setup/integrations/enablebanking/EBStep2Credentials.tsx
@@ -126,12 +126,12 @@ export function EBStep2Credentials({ onNext, onBack }: Props) {
             prior substep displays it for the user to register in EB. */}
         <input type="hidden" {...register('redirectUri')} />
 
-        <label className="flex items-start gap-3 rounded-xl border border-border/60 bg-muted/30 p-3 text-left cursor-pointer">
+        <label className="flex items-start gap-3 rounded-2xl border border-border/60 bg-muted/30 p-3 text-left cursor-pointer">
           <input
             type="checkbox"
             checked={prodAcknowledged}
             onChange={(e) => setProdAcknowledged(e.target.checked)}
-            className="mt-0.5 h-4 w-4 flex-shrink-0 cursor-pointer rounded border-border accent-primary"
+            className="mt-0.5 h-4 w-4 flex-shrink-0 cursor-pointer rounded-sm border-border accent-primary"
             aria-describedby="eb-prod-ack-desc"
           />
           <span id="eb-prod-ack-desc" className="text-xs sm:text-sm">
@@ -157,7 +157,7 @@ export function EBStep2Credentials({ onNext, onBack }: Props) {
           <Button
             type="submit"
             disabled={writeConfig.isPending || !formState.isValid || !prodAcknowledged}
-            className="w-full rounded-full sm:w-auto"
+            className="w-full sm:w-auto"
           >
             {t('setup.enablebanking.continue')}
           </Button>

--- a/frontend/src/pages/setup/integrations/enablebanking/EBStep3Keypair.tsx
+++ b/frontend/src/pages/setup/integrations/enablebanking/EBStep3Keypair.tsx
@@ -116,17 +116,17 @@ export function EBStep3Keypair({ onNext, onBack }: Props) {
     <EBSubstepShell current={4} total={5}>
       <div className="space-y-6">
         <div className="flex justify-center">
-          <span className="rounded-xl bg-primary/10 p-3 text-primary">
+          <span className="rounded-lg bg-primary/10 p-3 text-primary">
             <KeyRound className="h-6 w-6" />
           </span>
         </div>
 
         {/* Mode toggle */}
-        <div className="flex rounded-lg border border-border/60 p-1 gap-1">
+        <div className="flex rounded-xl border border-border/60 p-1 gap-1">
           <button
             type="button"
             onClick={() => handleSwitchMode('generate')}
-            className={`flex-1 rounded-md px-3 py-2 text-sm font-medium transition-colors ${
+            className={`flex-1 rounded-lg px-3 py-2 text-sm font-medium transition-colors ${
               mode === 'generate'
                 ? 'bg-primary text-primary-foreground'
                 : 'text-muted-foreground hover:text-foreground'
@@ -137,7 +137,7 @@ export function EBStep3Keypair({ onNext, onBack }: Props) {
           <button
             type="button"
             onClick={() => handleSwitchMode('import')}
-            className={`flex-1 rounded-md px-3 py-2 text-sm font-medium transition-colors ${
+            className={`flex-1 rounded-lg px-3 py-2 text-sm font-medium transition-colors ${
               mode === 'import'
                 ? 'bg-primary text-primary-foreground'
                 : 'text-muted-foreground hover:text-foreground'
@@ -167,7 +167,7 @@ export function EBStep3Keypair({ onNext, onBack }: Props) {
             )}
 
             {generate.isError && !pem && (
-              <div className="space-y-3 rounded-xl border border-destructive/40 bg-destructive/5 p-4 text-center">
+              <div className="space-y-3 rounded-2xl border border-destructive/40 bg-destructive/5 p-4 text-center">
                 <p className="text-sm text-destructive">
                   {t('setup.enablebanking.keypair.error')}
                 </p>
@@ -181,7 +181,7 @@ export function EBStep3Keypair({ onNext, onBack }: Props) {
               <>
                 <pre
                   id="eb-public-pem"
-                  className="max-h-64 overflow-auto rounded-xl border border-border/60 bg-muted/40 p-4 text-[11px] leading-snug font-mono whitespace-pre-wrap break-all"
+                  className="max-h-64 overflow-auto rounded-2xl border border-border/60 bg-muted/40 p-4 text-[11px] leading-snug font-mono whitespace-pre-wrap break-all"
                 >
                   {pem}
                 </pre>
@@ -246,7 +246,7 @@ export function EBStep3Keypair({ onNext, onBack }: Props) {
                   value={privatePem}
                   onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => setPrivatePem(e.target.value)}
                   placeholder={"-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----"}
-                  className="w-full rounded-xl border border-border/60 bg-muted/40 p-3 font-mono text-[11px] leading-snug min-h-[140px] resize-none"
+                  className="w-full rounded-lg border border-border/60 bg-muted/40 p-3 font-mono text-[11px] leading-snug min-h-[140px] resize-none"
                 />
 
                 {importError && (
@@ -254,7 +254,7 @@ export function EBStep3Keypair({ onNext, onBack }: Props) {
                 )}
 
                 <Button
-                  className="w-full rounded-full"
+                  className="w-full"
                   disabled={!privatePem.trim() || importKey.isPending}
                   onClick={handleImport}
                 >
@@ -274,7 +274,7 @@ export function EBStep3Keypair({ onNext, onBack }: Props) {
                 </p>
                 <pre
                   id="eb-public-pem"
-                  className="max-h-64 overflow-auto rounded-xl border border-border/60 bg-muted/40 p-4 text-[11px] leading-snug font-mono whitespace-pre-wrap break-all"
+                  className="max-h-64 overflow-auto rounded-2xl border border-border/60 bg-muted/40 p-4 text-[11px] leading-snug font-mono whitespace-pre-wrap break-all"
                 >
                   {pem}
                 </pre>
@@ -291,7 +291,7 @@ export function EBStep3Keypair({ onNext, onBack }: Props) {
           <Button
             onClick={onNext}
             disabled={!pem}
-            className="w-full rounded-full sm:w-auto"
+            className="w-full sm:w-auto"
           >
             {t('setup.enablebanking.keypair.uploadedCta')}
           </Button>

--- a/frontend/src/pages/setup/integrations/enablebanking/EBStep4Redirect.tsx
+++ b/frontend/src/pages/setup/integrations/enablebanking/EBStep4Redirect.tsx
@@ -34,7 +34,7 @@ export function EBStep4Redirect({ onNext, onBack }: Props) {
     <EBSubstepShell current={2} total={5}>
       <div className="space-y-6">
         <div className="flex justify-center">
-          <span className="rounded-xl bg-primary/10 p-3 text-primary">
+          <span className="rounded-lg bg-primary/10 p-3 text-primary">
             <ExternalLink className="h-6 w-6" />
           </span>
         </div>
@@ -85,7 +85,7 @@ export function EBStep4Redirect({ onNext, onBack }: Props) {
           </Button>
           <Button
             onClick={onNext}
-            className="w-full rounded-full sm:w-auto"
+            className="w-full sm:w-auto"
           >
             {t('setup.enablebanking.redirect.addedCta')}
           </Button>

--- a/frontend/src/pages/setup/integrations/enablebanking/EBStep5Test.tsx
+++ b/frontend/src/pages/setup/integrations/enablebanking/EBStep5Test.tsx
@@ -70,7 +70,7 @@ export function EBStep5Test({ onBack }: Props) {
     <EBSubstepShell current={5} total={5}>
       <div className="space-y-6">
         <div className="flex justify-center">
-          <span className="rounded-xl bg-primary/10 p-3 text-primary">
+          <span className="rounded-lg bg-primary/10 p-3 text-primary">
             <Zap className="h-6 w-6" />
           </span>
         </div>
@@ -95,7 +95,7 @@ export function EBStep5Test({ onBack }: Props) {
             <div className="flex justify-center">
               <Button
                 onClick={run}
-                className="w-full rounded-full"
+                className="w-full"
               >
                 {t('setup.enablebanking.test.run')}
               </Button>
@@ -116,7 +116,7 @@ export function EBStep5Test({ onBack }: Props) {
             <p className="text-lg font-medium">{t('setup.enablebanking.test.success')}</p>
             <Button
               onClick={proceed}
-              className="w-full rounded-full"
+              className="w-full"
             >
               {t('setup.enablebanking.continue')}
             </Button>
@@ -144,7 +144,7 @@ export function EBStep5Test({ onBack }: Props) {
               <Button
                 type="button"
                 onClick={run}
-                className="w-full rounded-full sm:w-auto"
+                className="w-full sm:w-auto"
               >
                 {t('setup.enablebanking.test.retry')}
               </Button>

--- a/frontend/src/pages/sync/BankSyncTab.tsx
+++ b/frontend/src/pages/sync/BankSyncTab.tsx
@@ -241,7 +241,7 @@ export function BankSyncTab() {
         {searchLoading && <p className="text-sm text-muted-foreground">{t('common.loading')}</p>}
 
         {searchEnabled && searchFailed && !searchLoading && (
-          <div className="flex items-center gap-2 rounded-lg bg-destructive/10 px-3 py-2 text-sm text-destructive">
+          <div className="flex items-center gap-2 rounded-xl bg-destructive/10 px-3 py-2 text-sm text-destructive">
             <span className="flex-1">{formatApiError(searchError, t, 'sync.banks.searchError')}</span>
           </div>
         )}

--- a/frontend/src/pages/sync/CryptoExchangeTab.tsx
+++ b/frontend/src/pages/sync/CryptoExchangeTab.tsx
@@ -127,7 +127,7 @@ export function CryptoExchangeTab() {
         <Card size="sm">
           <CardContent className="space-y-4 p-4">
             {addError && (
-              <p role="alert" className="rounded-lg bg-destructive/10 px-3 py-2 text-sm text-destructive">
+              <p role="alert" className="rounded-xl bg-destructive/10 px-3 py-2 text-sm text-destructive">
                 {addError}
               </p>
             )}

--- a/frontend/src/pages/sync/FinaryTab.tsx
+++ b/frontend/src/pages/sync/FinaryTab.tsx
@@ -383,7 +383,7 @@ export function FinaryTab() {
 
       {/* Error banner */}
       {error && (
-        <div className="flex items-center gap-2 rounded-lg bg-destructive/10 px-4 py-3 text-sm text-destructive">
+        <div className="flex items-center gap-2 rounded-xl bg-destructive/10 px-4 py-3 text-sm text-destructive">
           <X className="size-4 shrink-0" />
           <span className="flex-1">{error}</span>
           <Button variant="ghost" size="icon-xs" onClick={() => setError(null)}>
@@ -580,7 +580,7 @@ export function FinaryTab() {
             <Card size="sm">
               <CardContent className="space-y-2 pt-0">
                 {importResult.importedAccounts.map((account) => (
-                  <div key={account.id} className="flex items-center gap-3 rounded-lg px-3 py-2">
+                  <div key={account.id} className="flex items-center gap-3 rounded-xl px-3 py-2">
                     <div className="size-3 shrink-0 rounded-full" style={{ backgroundColor: account.color }} />
                     <div className="flex-1 min-w-0">
                       <p className="truncate text-sm font-medium">{account.name}</p>
@@ -667,7 +667,7 @@ function MappingCard({
 
         {mapping.action === 'MAP_EXISTING' && (
           <select
-            className="h-10 w-full rounded-xl border border-input bg-input/20 px-4 text-sm outline-none dark:bg-input/30"
+            className="h-10 w-full rounded-lg border border-input bg-input/20 px-4 text-sm outline-none dark:bg-input/30"
             value={mapping.targetAccountId ?? ''}
             onChange={(e) => {
               const val = e.target.value
@@ -698,7 +698,7 @@ function MappingCard({
             <div className="space-y-1">
               <Label>{t('sync.exchanges.type')}</Label>
               <select
-                className="h-10 w-full rounded-xl border border-input bg-input/20 px-4 text-sm outline-none dark:bg-input/30"
+                className="h-10 w-full rounded-lg border border-input bg-input/20 px-4 text-sm outline-none dark:bg-input/30"
                 value={mapping.newAccount.type}
                 onChange={(e) => onNewAccountField('type', e.target.value)}
               >
@@ -751,7 +751,7 @@ function MappingCard({
 
 function ResultStat({ label, value, color }: { label: string; value: number; color: string }) {
   return (
-    <div className="rounded-xl bg-muted/50 p-4 text-center">
+    <div className="rounded-2xl bg-muted/50 p-4 text-center">
       <p className={`text-2xl font-semibold ${color}`}>{value}</p>
       <p className="mt-1 text-xs text-muted-foreground">{label}</p>
     </div>


### PR DESCRIPTION
> **Rebuilt as a code-only PR.** Devin flagged that the original diff amended `CODING_RULES.md` and the conventions alongside the twelve `components/ui/` edits those amendments legitimise — the exact pattern rule 0 says to reject. The prescription is to split, so the rule change now lands on its own in **#89** and this PR carries only the code that conforms to it. Zero convention edits here.
>
> **Merge order:** #88 (build fix) → #89 (ratification) → this. Stacked on #88 so CI is green; that commit disappears from this diff once #88 merges.

## Problem

Reported visually: on one screen a 26px card sits next to an 8px button, a 10px segmented control and a 14px code row — four unrelated corner radii. The audit found the same *kind* of element rendered at three or four different radii across `frontend/src`:

| Element | Radii found |
|---|---|
| Inline alert strip | `md` (8), `lg` (10), `xl` (14) |
| Segmented control wrapper + item | `2xl`+`xl`, `lg`+`md`, or bare `md` with no wrapper |
| Select / text input | `md` (8) from the primitive, `xl` (14) hand-written |
| Code-copy value row | `rounded` (4), `lg` (10), `xl` (14) |
| Checkbox | `rounded` (4), `sm` (6), `md` (8) |
| Buttons | **34 `rounded-full` overrides** — 27 setup-wizard buttons, both login/MFA submits, both password eye toggles, the setup status chip, the skip link, the setup intro text button |

## Change

Applies the ladder ratified in #89. The `--radius` token and the derived scale (6/8/10/14/18/22/26 px) are **untouched** — only the tier assignment changes:

| Tier | Class | ≈px | Applies to |
|---|---|---|---|
| Surface | `rounded-4xl` | 26 | `Card`, `DialogContent`, bottom sheet, desktop sidebar shell |
| Panel | `rounded-2xl` | 18 | callouts, `<pre>` blocks, dropzones, empty states, sub-panels, mobile nav bar |
| Row / container | `rounded-xl` | 14 | list rows & containers, nav rows, alert strips, segment wrappers, dropdowns, chart tooltips |
| Control | `rounded-lg` | 10 | button, input, select, textarea, segment item, menu item, OTP slot, icon tile |
| Micro | `rounded-md` | 8 | skeleton, `size-6` tile, treemap cell |
| Hairline | `rounded-sm` | 6 | checkbox, `size-4` logo |
| Circular | `rounded-full` | — | avatar, switch, badge, dot, progress, step bubble, swatch |

Two visible consequences:

1. **Controls move one rung up** (`md`→`lg`, containers `lg`→`xl`). This makes the segmented control concentric — a `p-1` (4px) wrapper at 14px holding a 10px item, where 10 holding 8 was not — and narrows the gap to the 26px cards controls sit beside.
2. **`DialogContent` `xl`→`4xl`**, so a modal matches the cards behind it instead of reading as a large panel. Its close button moves `top-2 right-2` → `top-3 right-3` to sit properly inside the bigger corner.

Cards keep `rounded-4xl` — ADR 2026-07-12 records that as deliberate, so the controls moved up to meet them, not the reverse.

The ladder lives in the shadcn primitives, so app code inherits it: the 34 overrides and every restated radius (`<Card className="rounded-4xl">`, `<Item className="rounded-xl">`) are **removed** rather than rewritten.

**The property flow from #82 is included.** Rebasing brought it in, and it had reproduced the drift verbatim — a bare `rounded` on two chips, `rounded-md` selects and callouts, `rounded-lg` on rows and a popover container. It is exactly the "a new screen inherits the deviation by copying the form next to it" case the feature note already named. No bare `rounded` is left anywhere in `src`.

`components/ui/sidebar.tsx` is deliberately **not** updated — vendor file, no import anywhere in the app.

## Verification

`bun run typecheck` · `bun run lint` (zero warnings) · `bunx vitest run` (34 files, 217 tests) · `bun run build` — all pass.

No test asserts on a `rounded-*` class, so the suite could not have caught this drift; #89's feature note records that, along with the grep that can.

**Not visually verified in a browser** — the local Vite dev server runs HTTPS with a self-signed cert the automated browser can't accept. Verified by static audit + build/tests. Worth an eyeball on: modals (biggest change, 14→26px), the desktop sidebar shell (14→26px), the mobile nav bar (14→18px), and the setup wizard buttons losing their pill shape.

Styling only — no behavior change.

---

## Review responses (CodeRabbit)

Nine findings; seven were documentation and moved with the docs to #89. The two code findings:

**✅ `progress.tsx` — round the indicator.** Applied. The ladder moved the track to `rounded-full`, but the fill kept square ends, so the trailing edge — the one that moves — was a hard cut against a pill track. Rounding it also matches what the app already does by hand: the goal and family progress bars build their fill as `h-full rounded-full`.

**❌ `AccountCard` share badge + `PropertyValuationCard` confidence badge — "replace `rounded-full` with `rounded`".** Not applied. Bare `rounded` (4px) is not a rung on the ladder at all, so this would introduce the exact off-scale value the PR removes — it is the last remaining bare `rounded` pattern and there are now zero in `src`. Both elements are `px-1.5`/`px-2 py-0.5 text-xs` chips, which is the `Badge` primitive's own shape (`rounded-full`), and matches the existing status chips in `SessionsList` (`rounded-full bg-primary/10 px-2 py-0.5 text-xs`). `rounded-full` is the consistent classification; the "micro" rung is `rounded-md`, not `rounded`.
