### PR TITLE
fix(demo): restore the frontend build broken by a semantic merge on main

### DIFF
--- a/frontend/src/demo/data/accounts.ts
+++ b/frontend/src/demo/data/accounts.ts
@@ -128,6 +128,7 @@ export const mockAccounts: Account[] = [
     color: '#a855f7',
     ticker: null,
     logoUrl: null,
+    logoKey: null,
     createdAt: '2023-06-01T08:00:00Z',
     realEstate: {
       purchasePrice: 320000,


### PR DESCRIPTION
## `main` does not build

```
src/demo/data/accounts.ts(116,3): error TS2741:
Property 'logoKey' is missing in type '{ ... type: "REAL_ESTATE" ... }'
but required in type 'Account'
```

Reproduced on a clean `main` worktree, so this is not introduced by any open branch.

**Semantic merge, no textual conflict.** #83 made `logoKey` a required field on `Account`; #82 added the demo property account without it. Neither PR touched the other's file, so git merged both cleanly and the break exists only in the combination — the class of bug that per-PR CI cannot catch, because each branch was green against the `main` it was cut from.

**Why it survived CI:** `bun run typecheck` (`tsc --noEmit`) passes while `bun run build` (`tsc -b`) fails. The two resolve different project configs, so the cheaper check is not a proxy for the real one. Worth knowing when verifying frontend work locally — `typecheck` alone will keep missing this.

## Fix

One field, `logoKey: null`, matching every other demo account.

Filed on its own because it blocks the build for everyone and is unrelated to whatever else is in flight.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the demo real-estate account data to include the missing logo setting, improving consistency in account display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->