### PR TITLE
docs(design): ratify the radius ladder and add the design system

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,8 @@ bun run test:e2e     # Playwright E2E tests
 
 ## Code conventions
 
+**Touching the UI? Read [`docs/conventions/design-system.md`](docs/conventions/design-system.md) first** — it is the single authority for shape, color, typography, spacing, elevation, motion, which component to reach for, and the four data states. Compose the shadcn primitives and inherit; never restyle them per page.
+
 See [`docs/conventions/`](docs/conventions/) and module-specific instruction files (`backend/CLAUDE.md`, `frontend/CLAUDE.md`).
 
 ## Project architecture

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,8 @@ bun run test:e2e     # Playwright E2E tests
 
 ## Code conventions
 
+**Touching the UI? Read [`docs/conventions/design-system.md`](docs/conventions/design-system.md) first** — it is the single authority for shape, color, typography, spacing, elevation, motion, which component to reach for, and the four data states. Compose the shadcn primitives and inherit; never restyle them per page.
+
 See [`docs/conventions/`](docs/conventions/) and module-specific CLAUDE.md files (`backend/CLAUDE.md`, `frontend/CLAUDE.md`).
 
 ## Project architecture

--- a/docs/CODING_RULES.md
+++ b/docs/CODING_RULES.md
@@ -1,6 +1,6 @@
 # Coding Rules — non-negotiable charter
 
-> Last updated: 2026-07-12
+> Last updated: 2026-08-10
 
 The **conventions** in [`docs/conventions/`](./conventions/) describe *how* we write code in each
 area. This file is shorter and stricter: it holds the **non-negotiables** — the rules whose
@@ -35,15 +35,21 @@ In review, this is a hard gate:
 
 shadcn/ui primitives are generated. Customize via **theme tokens** (`--radius`, color tokens in
 `index.css`) or the shadcn CLI — never by editing the primitive off its scale. In particular, never
-inflate a control's radius (e.g. `rounded-md` → `rounded-full` on `Button`). See
+inflate a control's radius (e.g. `rounded-lg` → `rounded-full` on `Button`). The one sanctioned
+exception is an **app-wide, on-scale** standard that is ratified in an ADR and written down in the
+convention — the radius ladder is the only current instance; a one-screen tweak never qualifies. See
 [`docs/features/ui-control-shape-system.md`](./features/ui-control-shape-system.md) and
-[`docs/conventions/frontend.md`](./conventions/frontend.md).
+[`docs/conventions/design-system.md`](./conventions/design-system.md).
 
 ## 2. Follow the theme, not per-component styling
 
-Radius, color, and control sizing come from `--radius` and the semantic color tokens. Never hardcode
-`rounded-full`/`rounded-xl` on interactive text controls, and never use raw palette classes
-(`text-gray-*` — they render blue here). Detail: [`docs/conventions/frontend.md`](./conventions/frontend.md).
+Radius, color, and control sizing come from `--radius` and the semantic color tokens. Radius follows
+the [ladder](./conventions/design-system.md#1-shape--the-radius-ladder) — surface `4xl` / panel `2xl` / row `xl` /
+control `lg` — so never hardcode `rounded-full` or `rounded-2xl` on an interactive text control, and
+never restate a radius a primitive already provides. Never use raw palette classes
+(`text-gray-*` — they render blue here). **Every visual decision — shape, color, type, spacing,
+elevation, motion, which component to reach for — is settled in
+[`docs/conventions/design-system.md`](./conventions/design-system.md). Read it before writing UI.**
 
 ## 3. Layers stay separated
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -119,6 +119,7 @@
 
 | Topic | File |
 |-------|------|
+| **Design system** (shape, color, type, spacing, components, states) | [design-system.md](./conventions/design-system.md) |
 | REST API | [api-rest.md](./conventions/api-rest.md) |
 | Error handling | [error-handling.md](./conventions/error-handling.md) |
 | Testing | [testing.md](./conventions/testing.md) |

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -9,6 +9,7 @@
 ## Coding rules
 
 - [CODING_RULES.md](./CODING_RULES.md) -- Non-negotiable charter (convention integrity, theme, layers). Read before a large refactor or review.
+- [conventions/design-system.md](./conventions/design-system.md) -- **The design system.** Shape, color, type, spacing, elevation, motion, component catalogue, states, a11y, conformance greps. Read before writing any UI.
 
 ## Architecture
 
@@ -43,7 +44,7 @@
 | 2026-06-01 | [ETF composition via Boursorama (single source)](./decisions/2026-06-01-etf-composition-via-boursorama.md) | Active |
 | 2026-06-05 | [Access-key auth + embedded MCP server](./decisions/2026-06-05-access-key-auth-and-embedded-mcp.md) | Active |
 | 2026-07-11 | [Realized P&L: average-cost, computed on the fly](./decisions/2026-07-11-realized-pnl-average-cost-on-the-fly.md) | Active |
-| 2026-07-12 | [UI controls follow the shadcn theme radius, not a pill shape](./decisions/2026-07-12-ui-controls-follow-shadcn-theme-radius.md) | Active |
+| 2026-07-12 | [UI controls follow the shadcn theme radius, not a pill shape](./decisions/2026-07-12-ui-controls-follow-shadcn-theme-radius.md) | ⚠️ Superseded |
 | 2026-07-17 | [EVM multichain wallets — one address, many chains](./decisions/2026-07-17-evm-multichain-wallets.md) | Active |
 | 2026-07-19 | [Caddy as an opt-in TLS terminator for the Docker stack](./decisions/2026-07-19-caddy-opt-in-tls-profile.md) | Active |
 | 2026-07-21 | [Bourse Direct isolated browser sidecar and atomic complete snapshots](./decisions/2026-07-21-bourse-direct-isolated-atomic-sync.md) | Active |
@@ -54,6 +55,7 @@
 | 2026-08-01 | [Estimate property value from French open data](./decisions/2026-08-01-open-data-property-valuation.md) | Active |
 | 2026-08-01 | [Per-member ownership shares on properties and loans](./decisions/2026-08-01-account-ownership-shares.md) | Active |
 | 2026-08-10 | [Verify an ISIN's ticker against Yahoo instead of predicting it](./decisions/2026-08-10-yahoo-verified-isin-tickers.md) | Active |
+| 2026-08-10 | [One radius ladder for every surface, not just controls](./decisions/2026-08-10-ui-radius-ladder.md) | Active |
 
 ## Feature notes
 
@@ -91,7 +93,7 @@
 | Add Account modal (unified sync + manual) | 2026-07-07 | [add-account-modal.md](./features/add-account-modal.md) |
 | Docker deployment | 2026-07-19 | [docker-deployment.md](./features/docker-deployment.md) |
 | Navigation (sidebar + mobile bottom nav) | 2026-07-12 | [sidebar-navigation.md](./features/sidebar-navigation.md) |
-| UI control shape (shadcn theme radius) | 2026-08-10 | [ui-control-shape-system.md](./features/ui-control-shape-system.md) |
+| UI radius ladder (shadcn theme radius) | 2026-08-10 | [ui-control-shape-system.md](./features/ui-control-shape-system.md) |
 | Multi-account family system | 2026-07-07 | [multi-account-family.md](./features/multi-account-family.md) |
 | CORS & cookie security | 2026-06-02 | [security-cors-cookies.md](./features/security-cors-cookies.md) |
 | 24H Intraday net worth chart | 2026-04-18 | [intraday-chart.md](./features/intraday-chart.md) |

--- a/docs/conventions/design-system.md
+++ b/docs/conventions/design-system.md
@@ -259,7 +259,10 @@ delete.
 - **Focus is centralized.** `index.css` applies a `:focus-visible` outline + ring to every
   interactive role. Do **not** add one-off `focus:*` / `focus-visible:*` / `focus-within:*` classes —
   the only sanctioned exception is an element that must *appear* on focus, like the setup skip link.
-- Hit targets follow the control rhythm (`h-10`, icon buttons ≥ `size-9`).
+- Hit targets follow the control rhythm: `h-10` for text controls, and for icon buttons any rung of
+  the `Button` `size="icon"` family (`icon-xs` 32px … `icon-lg` 44px). All of them clear the 24px
+  WCAG 2.1 AA minimum (2.5.8); reserve `icon-xs` for dense toolbars and prefer `icon` (40px) for
+  anything a user hits often or on touch.
 - Icon-only buttons need `aria-label` **and** `title`. Decorative icons need `aria-hidden="true"`.
 - Toggles use `aria-pressed`; segmented radio groups use `role="radiogroup"` + `role="radio"` +
   `aria-checked`; live regions use `aria-live="polite"`; errors use `role="alert"`.

--- a/docs/conventions/design-system.md
+++ b/docs/conventions/design-system.md
@@ -55,8 +55,20 @@ its own, ratified for its own sake, or drop the deviation.
 | **Control** | `rounded-lg` | 10 | button, input, select, textarea, segment item, menu item, OTP slot, icon tile (`size-8`…`size-12`), single-line code-copy value |
 | **Micro** | `rounded-md` | 8 | skeleton default, `size-6` tile, treemap cell, small overlay chip |
 | **Hairline** | `rounded-sm` | 6 | checkbox, `size-4` logo |
-| **Circular** | `rounded-full` | — | avatar, switch, badge, status dot, progress bar, step bubble, color swatch, decorative empty-state icon bubble |
+| **Circular** | `rounded-full` | — | *identity* avatar (see below), switch, badge, status dot, progress bar, step bubble, color swatch, decorative empty-state icon bubble |
 | **Chart mark** | `rounded-[2px]` | 2 | chart swatches, legend squares, thin bar segments, tooltip arrow (≤ 10px marks) |
+
+**Two clarifications on that table.**
+
+*Chart marks are the one sanctioned arbitrary value.* `rounded-[2px]` is deliberate, not drift:
+below ~10px every rung on the scale reads as a circle, so a mark that small needs a value off it.
+It is the only `rounded-[…]` allowed in app code.
+
+*Avatars split by what they hold.* An avatar standing for a **person** is circular — that is the
+`Avatar` primitive's default, so inherit it. An avatar used as a **brand or logo tile** takes the
+icon-tile rung instead (`rounded-sm` at `size-4`, `rounded-md` at `size-6`, `rounded-lg` at
+`size-8`…`size-12`), because a logo clipped to a circle loses its mark. The codebase does not apply
+this split consistently yet — see §11.
 
 **The ladder is concentric.** At every nesting step, the parent's radius = the child's radius + the
 padding between them. `TabsList` is `p-1` (4px) at `rounded-xl` (14) holding a `rounded-lg` (10)
@@ -326,6 +338,12 @@ Documented so the next agent doesn't propagate them as if they were the rule:
   appear (18). New work uses `emerald`.
 - **`components/ui/sidebar.tsx` is dead** — no import anywhere in the app, still on stock shadcn
   radii. Apply the ladder only if it is ever wired up.
+- **Avatar shape is split and not yet reconciled.** Person avatars are circular in `MembersSection`
+  (`size-9 rounded-full`) but square in `AppSidebar`'s profile rows (`size-10`/`size-8 rounded-lg`,
+  `size-6 rounded-md`) — deliberate there, since they sit beside nav icon tiles of the same size.
+  Conversely `AccountCard` renders *bank logos* through a circular `Avatar` while `AddAccountModal`
+  renders the same logos square (`size-4 rounded-sm`). Follow §1 for new work; normalising the four
+  existing sites is a visible design change, not a radius fix, so it is deliberately out of scope.
 - **`ErrorState` ships hardcoded English defaults** (`'Error'`, `'Retry'`). Pass translated props
   until it is fixed.
 - **There is no shared `Select` component.** Native `<select>` elements are styled with the control
@@ -333,7 +351,7 @@ Documented so the next agent doesn't propagate them as if they were the rule:
   `PropertyMetadataForm` hold it as a module-local `selectControlClassName`/`selectClassName`, while
   `AddAccountModal` ×2, `FinaryTab` ×2 and `AddPropertyModal` repeat it literally:
 
-  ```
+  ```text
   h-10 w-full rounded-lg border border-input bg-input/20 px-4 text-sm outline-none dark:bg-input/30
   ```
 
@@ -360,8 +378,9 @@ grep -rnE "(text|bg|border)-(gray|slate|zinc|neutral|stone)-[0-9]" src --include
 # Unbounded transitions in app code (should be empty)
 grep -rn "transition-all" src/pages src/components/shared src/components/layout --include='*.tsx'
 
-# Pilled text controls (each hit must be an avatar/switch/badge/dot/swatch)
-grep -rn "rounded-full" src/pages src/components/shared --include='*.tsx'
+# Pilled text controls (each hit must be an avatar/switch/badge/dot/swatch).
+# Scan all of src except the generated primitives, which own the sanctioned pills.
+grep -rn "rounded-full" src --include='*.tsx' | grep -v "^src/components/ui/"
 
 # Inline style objects (each hit must be a genuinely dynamic value)
 grep -rn "style={{" src/pages src/components/shared --include='*.tsx'

--- a/docs/conventions/design-system.md
+++ b/docs/conventions/design-system.md
@@ -1,0 +1,380 @@
+# Convention: Design system
+
+> The single authority for **how Picsou looks**. Read this before writing or reviewing any UI.
+>
+> Scope split — this file owns *visual* decisions (shape, color, type, spacing, elevation, motion,
+> component choice, states). [`frontend.md`](./frontend.md) owns *code* decisions (state management,
+> hooks, API layer, routing, i18n wiring, types). When they overlap, this file wins on looks and
+> `frontend.md` wins on structure. Do not restate a rule from here into another file — link to it.
+>
+> **Status:** this file states the standard. The radius ladder in §1 is ratified by
+> [ADR 2026-08-10](../decisions/2026-08-10-ui-radius-ladder.md) and applied to the codebase by the
+> follow-up sweep — until that lands, the §12 radius grep still reports pre-ladder values in app
+> code. Everything else here describes what the codebase already does.
+
+## 0. The one rule
+
+**Compose the primitives and inherit. Never restyle.**
+
+Picsou's look is carried by `frontend/src/components/ui/` (shadcn primitives) and
+`frontend/src/index.css` (theme tokens). A page's job is to *pick the right component*, not to
+re-describe what it should look like.
+
+```tsx
+// ✅ inherits shape, height, padding, focus ring, dark mode
+<Button variant="outline">{t('accounts.add')}</Button>
+
+// ❌ every class here is either a duplicate of the primitive or a deviation from it
+<button className="h-9 rounded-full border px-3 text-xs hover:bg-gray-100">…</button>
+```
+
+If a class in app code sets **radius, height, font-size, or color** on something a primitive already
+renders, it is a finding until proven otherwise. Adding a class the primitive does not provide
+(layout, width, margin, grid placement) is normal and fine.
+
+**Why so strict:** commit `716228e` (PR #29) restyled controls page-by-page *and* rewrote the
+convention to bless it, so review passed and a human found the regression weeks later. That is the
+origin of [`CODING_RULES.md`](../CODING_RULES.md) rule 0 — a PR that changes the code and the rule
+together to make a deviation look compliant gets **rejected**, not merged. Land the rule change on
+its own, ratified for its own sake, or drop the deviation.
+
+---
+
+## 1. Shape — the radius ladder
+
+`--radius: 0.625rem` (10px) in `index.css` derives the whole scale:
+`sm` 6 · `md` 8 · `lg` 10 · `xl` 14 · `2xl` 18 · `3xl` 22 · `4xl` 26 px.
+
+**Every box picks a rung by what it is** — never by taste, never a hardcoded pixel value:
+
+| Tier | Class | ≈ px | Applies to |
+|------|-------|------|-----------|
+| **Surface** | `rounded-4xl` | 26 | `Card`, `DialogContent`, bottom sheet, desktop sidebar shell |
+| **Panel** | `rounded-2xl` | 18 | boxes inside a surface: callouts, `<pre>` code blocks, dropzones, empty states, bordered sub-panels, stat blocks, mobile nav bar |
+| **Row / control container** | `rounded-xl` | 14 | list containers and rows, nav rows, inline alert strips, segmented-control wrappers, dropdown/popover content, chart tooltips |
+| **Control** | `rounded-lg` | 10 | button, input, select, textarea, segment item, menu item, OTP slot, icon tile (`size-8`…`size-12`), single-line code-copy value |
+| **Micro** | `rounded-md` | 8 | skeleton default, `size-6` tile, treemap cell, small overlay chip |
+| **Hairline** | `rounded-sm` | 6 | checkbox, `size-4` logo |
+| **Circular** | `rounded-full` | — | avatar, switch, badge, status dot, progress bar, step bubble, color swatch, decorative empty-state icon bubble |
+| **Chart mark** | `rounded-[2px]` | 2 | chart swatches, legend squares, thin bar segments, tooltip arrow (≤ 10px marks) |
+
+**The ladder is concentric.** At every nesting step, the parent's radius = the child's radius + the
+padding between them. `TabsList` is `p-1` (4px) at `rounded-xl` (14) holding a `rounded-lg` (10)
+trigger. Picking a rung off the ladder breaks that alignment visibly.
+
+**Row vs panel** is decided by height: one control tall (≈40–56px) is a *row*; a multi-line block
+with `p-4`+ is a *panel*.
+
+**Cards stay `rounded-4xl` on purpose.** Do not "fix" the card radius down to match controls — the
+round card is the app's shape signature. Controls were moved *up* to meet it.
+
+Rationale, gotchas, and the audit that produced this:
+[`features/ui-control-shape-system.md`](../features/ui-control-shape-system.md) ·
+ADR [2026-08-10](../decisions/2026-08-10-ui-radius-ladder.md).
+
+---
+
+## 2. Color
+
+### Semantic tokens only
+
+All tokens live in the `@theme` / `:root` / `.dark` blocks of `frontend/src/index.css`, in oklch,
+with a light and a dark value each. **Never use a raw palette class** (`text-gray-*`, `bg-gray-*`) —
+they bypass the theme and do not adapt to dark mode. In this project the gray palette is remapped to
+blue, so `text-gray-500` renders *blue*, which is how the mistake gets caught late.
+
+| Intent | Token |
+|--------|-------|
+| Page background | `bg-background` |
+| Primary text | `text-foreground` |
+| Muted / secondary text | `text-muted-foreground` |
+| Subtle fill | `bg-muted` |
+| Card / surface fill | `bg-card` (+ `text-card-foreground`) |
+| Floating surface fill | `bg-popover` (+ `text-popover-foreground`) |
+| Primary action | `bg-primary` / `text-primary` (+ `text-primary-foreground`) |
+| Secondary action | `bg-secondary` (+ `text-secondary-foreground`) |
+| Destructive | `text-destructive`, `bg-destructive/10` |
+| Hairline / divider | `border-border`, `ring-border` |
+| Field fill | `bg-input/20` (`dark:bg-input/30`) |
+| Focus ring | `ring` (applied centrally — see §7) |
+| Chart series | `--chart-1` … `--chart-5` |
+| Sidebar surfaces | `--sidebar*` family |
+
+### Status colors — the one sanctioned exception
+
+Financial and status signals may use literal palette colors, because green/red carry meaning that no
+semantic token expresses: gain/loss, sync success/failure, staleness warnings. When you do:
+
+- Always ship a dark-mode variant (`text-emerald-500 dark:text-emerald-400`) or pick a shade that
+  reads on both.
+- **Gain is `emerald`, loss is `red`.** Use `emerald-500` / `red-500` as the default pair — that is
+  what the portfolio, holdings, and P&L surfaces already use.
+- Warning is `amber`, informational is `blue`, on-chain/violet accents belong to goals.
+
+Never use a status color for a neutral UI element. A gray button is `variant="ghost"`, not
+`text-slate-400`.
+
+---
+
+## 3. Typography
+
+One family: **Geist Variable**, loaded via `@fontsource-variable/geist`, applied on `html` as
+`font-sans`. `--font-heading` maps to the same family — there is no second typeface, so a "heading
+font" change means weight and size, never family.
+
+| Role | Class | Notes |
+|------|-------|-------|
+| Page title | `PageHeader` | Don't hand-roll — see §5 |
+| Card title | `CardTitle` (`cn-card-title`: `text-sm`, weight 700) | Small and bold by design, not a bug |
+| Section / card description | `CardDescription` (`text-sm`) | Do **not** shrink to `text-xs` locally |
+| Body, controls, labels | `text-sm` | The workhorse — 339 uses |
+| Hero figures (net worth, goal totals) | `text-2xl` … `text-4xl` + `tabular-nums` | |
+| Dense metadata, chart labels, badges | `text-xs` | |
+| Form `Label` | `Label` (`text-sm`) | Do **not** shrink locally |
+
+**Numbers always get `tabular-nums`.** Any figure that can change or sits in a column — balances,
+percentages, quantities, dates in tables — must not jitter as digits change.
+
+**Money goes through `CurrencyDisplay`**, never `toFixed()` + a hardcoded `€`. It resolves the active
+locale and handles the sign. Same for dates and numbers: use the `lib/utils.ts` helpers
+(`formatCurrency`, `formatDate`, `getLocale`) so FR/EN/DE/ES all format correctly.
+
+Do not use arbitrary sizes (`text-[15px]`) for new work — pick a rung. See §11 for the two existing
+off-scale values and why they are grandfathered rather than copied.
+
+---
+
+## 4. Spacing, sizing, elevation, motion
+
+### Control rhythm
+
+Text inputs, buttons, tabs, menus, segmented controls and pill filters share one CTA rhythm:
+
+- Height `h-10` · font `text-sm`
+- Padding: `px-8` buttons · `px-4` inputs/selects · `px-6` dense segmented items
+- Radius: the **control** rung (§1)
+
+Avoid local `h-6`/`h-7`/`h-8`/`h-9`, `text-xs`, or narrow `px-2` on a text control. Smaller sizing is
+for pure icon buttons, badges, dense table cells, chart labels, and non-interactive metadata.
+
+Icon buttons use the `Button` `size="icon"` family (`icon-xs` 32 · `icon-sm` 36 · `icon` 40 ·
+`icon-lg` 44) — never a hand-built `h-8 w-8` div with an onClick.
+
+### Spacing scale
+
+Stay on the 4px grid. In practice the codebase uses a narrow band, and new work should too:
+
+| Context | Value |
+|---------|-------|
+| Icon ↔ label inside a control | `gap-2` |
+| Related items in a row | `gap-3` |
+| Card / grid gutters | `gap-4` |
+| Tight stacks (label + field) | `space-y-2` |
+| Form field groups | `space-y-4` |
+| Page sections | `space-y-6` |
+| Card padding | `px-4` (from `Card` — don't restate) |
+| Panel padding | `p-4`, dense variants `p-3` |
+
+### Icon sizes
+
+`lucide-react` only, as direct JSX (`<Pencil className="size-4" />`). No other icon library.
+
+`size-4` is the default (inside controls, inline with `text-sm`) · `size-5` for nav and emphasis ·
+`size-3`/`size-3.5` for dense metadata · `size-10`/`size-12` for empty-state and hero illustrations.
+
+### Elevation — rings, not shadows
+
+Picsou separates surfaces with a **hairline ring**, not a drop shadow: `ring-1 ring-foreground/10`
+(cards, dialogs), `ring-1 ring-border` (nav shells). Reserve `shadow-lg`/`shadow-xl` for genuinely
+floating, transient things — chart tooltips and popovers. Do not add a shadow to a card.
+
+### Motion
+
+**Name the animated properties.** `transition-all` is banned in app code: it animates layout
+properties you didn't intend and costs paint. Use bounded values:
+
+```tsx
+transition-[background-color,color,border-color]   // hover/active states
+transition-[border-color,box-shadow]                // selection rings
+transition-[width]                                  // progress bars
+transition-transform                                // press feedback
+transition-colors                                   // the common shorthand, fine
+```
+
+Press feedback on buttons is already in the primitive (`active:scale-[0.96]`) — don't re-add it.
+Avoid `scale-*` on selected swatches or cards: dialogs and cards clip overflow, so scaled round
+elements look cut off.
+
+---
+
+## 5. Layout
+
+- **Pages start flush with the main content column.** No `mx-auto` centering wrapper on a top-level
+  app page — `AppLayout` already owns the gutters (`md:p-4 md:gap-4`).
+- **Every page opens with `PageHeader`** (`components/shared/PageHeader.tsx`), which supplies the
+  date surtitle, the title, and right-aligned actions. Don't hand-roll an `<h1>`.
+- **Cards are the unit of content.** Group with `Card` / `CardHeader` / `CardTitle` /
+  `CardDescription` / `CardContent`. Card padding comes from the primitive.
+- **Responsive grids** step `grid-cols-1 sm:grid-cols-2 lg:grid-cols-3` with `gap-4`. The breakpoint
+  for mobile/desktop chrome is `md` (768px), matching `useIsMobile` and the nav split.
+- **Mobile:** the bottom nav is fixed, so scrollable content carries `pb-20 md:pb-0`. If the nav's
+  height changes, update that value.
+
+Shell shapes: the desktop sidebar is a floating **surface** (`rounded-4xl`), the mobile dock is a
+compact **panel** (`rounded-2xl`). See [`features/sidebar-navigation.md`](../features/sidebar-navigation.md).
+
+---
+
+## 6. The four states — every data surface needs all of them
+
+A screen that only handles the happy path is incomplete. TanStack Query gives you the flags; render
+all four:
+
+| State | Component | Rule |
+|-------|-----------|------|
+| **Loading** | `Skeleton` / `LoadingSkeleton` | Skeletons mirror the *shape* of what they replace — a row placeholder is `h-16 rounded-xl`, a chart is `h-[250px] rounded-2xl`, a card is `rounded-4xl` |
+| **Empty** | `EmptyState` (page) · `EmptyChartState` (chart) | A page-level empty state centers in the remaining viewport height; one nested in a card or modal stays compact |
+| **Error** | `ErrorState` with `onRetry` | **Render it, never hide it.** An empty card reads as "nothing to show", which is the wrong conclusion when the fetch failed. Format via `formatApiError` |
+| **Degraded** | `DegradedModeBanner` | For partial backend availability |
+
+Destructive actions go through `ConfirmDialog` — never a bare `window.confirm`, never a one-click
+delete.
+
+---
+
+## 7. Accessibility
+
+- **Focus is centralized.** `index.css` applies a `:focus-visible` outline + ring to every
+  interactive role. Do **not** add one-off `focus:*` / `focus-visible:*` / `focus-within:*` classes —
+  the only sanctioned exception is an element that must *appear* on focus, like the setup skip link.
+- Hit targets follow the control rhythm (`h-10`, icon buttons ≥ `size-9`).
+- Icon-only buttons need `aria-label` **and** `title`. Decorative icons need `aria-hidden="true"`.
+- Toggles use `aria-pressed`; segmented radio groups use `role="radiogroup"` + `role="radio"` +
+  `aria-checked`; live regions use `aria-live="polite"`; errors use `role="alert"`.
+- Never signal state with color alone — pair it with an icon, a label, or a ring.
+- **All user-visible text goes through `useTranslation()`**, in all four locales (FR/EN/DE/ES). A
+  hardcoded string is a bug even if the app is currently in French.
+
+---
+
+## 8. Charts
+
+Recharts v3 only. Series colors come from `--chart-1` … `--chart-5` — never hand-picked hex. Chart
+tooltips are the **row** rung (`rounded-xl`) and are the one place `shadow-lg`/`shadow-xl` is
+correct. Legend swatches and thin bar segments use the **chart mark** rung (`rounded-[2px]`); at
+≤10px a "proper" radius reads as a circle.
+
+Every chart needs an `EmptyChartState` fallback, axis labels in the active locale, and
+`tabular-nums` on any rendered figure.
+
+---
+
+## 9. "I need to build X" — pick, don't invent
+
+| You need | Use | Never |
+|----------|-----|-------|
+| Any button | `Button` (+ `variant`, `size`) | a styled `<button>` |
+| Text field | `Input` · numbers `NumericInput` · dates `DateInput` | a styled `<input>` |
+| Dropdown of options | native `<select>` on the control rhythm (see §11), or `DropdownMenu` for actions | a custom popover |
+| Tabs / segmented control | `Tabs` + `TabsList` + `TabsTrigger` | a hand-built wrapper + buttons |
+| Modal | `Dialog` family | a fixed-position div |
+| Confirm a destructive action | `ConfirmDialog` | `window.confirm` |
+| List row | `Item` + `ItemMedia`/`ItemContent`/`ItemTitle` | a flex div with a radius |
+| Content grouping | `Card` family | a bordered div |
+| Status pill | `Badge` · `AccountTypeBadge` | a `rounded-full` span |
+| Money | `CurrencyDisplay` | `toFixed()` + `€` |
+| Progress | `Progress` · `GoalProgressBar` | a div pair with widths |
+| Page title | `PageHeader` | an `<h1>` |
+| Empty / error / loading | §6 | a bare `null` |
+| Toast | `sonner` (`toast.*`) | an inline banner |
+| Color / logo choice | `ColorPicker` · `LogoPicker` | a swatch grid |
+
+Before building a new shared component, grep `components/shared/` — there are ~40 of them.
+
+---
+
+## 10. Don'ts (grep-able)
+
+- **Never edit `components/ui/`** except for an app-wide, on-scale standard that is ratified in an
+  ADR and written down here. A one-screen tweak never qualifies.
+- **Never restate a radius/height/color a primitive already provides** (`<Card className="rounded-4xl">`,
+  `<Button className="rounded-lg">`). It is noise, and it hides the real overrides during an audit.
+- **Never `rounded-full` on a text control**, and never override a primitive's radius via className —
+  tailwind-merge keeps the *last* radius class, so the page silently wins over the primitive.
+- **Never a raw palette class** for a neutral (`text-gray-*`, `bg-slate-*`).
+- **Never `transition-all`** in app code.
+- **Never inline `style={{…}}` objects, CSS modules, or styled-components.** Tailwind only. (Dynamic
+  values that genuinely can't be a class — a chart series color, a computed bar width — are the
+  exception, via `style={{ backgroundColor: item.color }}`.)
+- **Never a hardcoded user-visible string** — `useTranslation()`, four locales.
+- **Never a one-off `focus:*` ring.**
+- **Never hide an error state.**
+- **Never `scale-*` on a swatch or card** (overflow clipping).
+
+---
+
+## 11. Known deviations
+
+Documented so the next agent doesn't propagate them as if they were the rule:
+
+- **`PageHeader` uses `text-[28px]` / `text-[13px]` and inline `style={{ fontWeight }}`.** Off the
+  type scale and against the no-inline-style rule. It is the only page title in the app, so it is
+  visually consistent by construction — but do **not** copy the pattern into a new component.
+- **`transition-all` survives in four `components/ui/` files** (`progress`, `switch`, `badge`, and
+  the unused `sidebar`). Vendor-generated; app code is clean. Don't add more.
+- **Gain green is not fully uniform** — `emerald-500` dominates (28 uses) but `green-600`/`green-400`
+  appear (18). New work uses `emerald`.
+- **`components/ui/sidebar.tsx` is dead** — no import anywhere in the app, still on stock shadcn
+  radii. Apply the ladder only if it is ever wired up.
+- **`ErrorState` ships hardcoded English defaults** (`'Error'`, `'Retry'`). Pass translated props
+  until it is fixed.
+- **There is no shared `Select` component.** Native `<select>` elements are styled with the control
+  class inline, and the same string is now copy-pasted in **7** places — `AccountForm` and
+  `PropertyMetadataForm` hold it as a module-local `selectControlClassName`/`selectClassName`, while
+  `AddAccountModal` ×2, `FinaryTab` ×2 and `AddPropertyModal` repeat it literally:
+
+  ```
+  h-10 w-full rounded-lg border border-input bg-input/20 px-4 text-sm outline-none dark:bg-input/30
+  ```
+
+  This is the clearest instance of the copy-the-neighbouring-file failure mode in the codebase.
+  Reuse that exact string for now, but **extracting it into a shared export is the next change this
+  file is asking for** — do not add an eighth copy.
+
+---
+
+## 12. Conformance checks
+
+Run these before opening a UI PR. Each should return only values named in this file:
+
+```bash
+cd frontend
+
+# Radius — every result must be a rung from §1
+grep -rhoE "rounded(-[a-z0-9]+)*(-\[[^]]+\])?" src --include='*.tsx' --include='*.ts' \
+  | sort | uniq -c | sort -rn
+
+# Raw palette leaks (should be empty)
+grep -rnE "(text|bg|border)-(gray|slate|zinc|neutral|stone)-[0-9]" src --include='*.tsx'
+
+# Unbounded transitions in app code (should be empty)
+grep -rn "transition-all" src/pages src/components/shared src/components/layout --include='*.tsx'
+
+# Pilled text controls (each hit must be an avatar/switch/badge/dot/swatch)
+grep -rn "rounded-full" src/pages src/components/shared --include='*.tsx'
+
+# Inline style objects (each hit must be a genuinely dynamic value)
+grep -rn "style={{" src/pages src/components/shared --include='*.tsx'
+```
+
+---
+
+## Links
+
+- Charter: [`CODING_RULES.md`](../CODING_RULES.md) — rules 0–2 are the enforcement teeth for this file
+- Code conventions: [`frontend.md`](./frontend.md) — state, hooks, API, routing, i18n wiring, types
+- Radius detail: [`features/ui-control-shape-system.md`](../features/ui-control-shape-system.md)
+- ADR: [2026-08-10 radius ladder](../decisions/2026-08-10-ui-radius-ladder.md) (supersedes
+  [2026-07-12](../decisions/2026-07-12-ui-controls-follow-shadcn-theme-radius.md))
+- Theme tokens: [`features/theme-persistence.md`](../features/theme-persistence.md)
+- Navigation shells: [`features/sidebar-navigation.md`](../features/sidebar-navigation.md)

--- a/docs/conventions/frontend.md
+++ b/docs/conventions/frontend.md
@@ -165,74 +165,28 @@ const DashboardPage = lazy(() =>
 
 ## Styling
 
+**All visual rules live in [`design-system.md`](./design-system.md)** — the radius ladder, color
+tokens, typography, spacing, elevation, motion, icons, layout, the four data states, accessibility,
+the component-picking table, and the grep-able conformance checks. Read it before writing any UI.
+Do not restate its rules here; a second copy is how the shape convention drifted in the first place
+(see [`CODING_RULES.md`](../CODING_RULES.md) rule 0).
+
+The code-level facts that belong to *this* file:
+
 ### Tailwind CSS v4
 
 - Imported via `@import "tailwindcss"` in `index.css`.
 - oklch color tokens for both light and dark themes (defined in `:root` and `.dark`).
 - Font: **Geist Variable** (`@fontsource-variable/geist`).
-- Radius scale from `--radius` base.
+- Radius scale derived from the `--radius` base in the `@theme inline` block.
 
 ### shadcn/ui
 
-Components in `components/ui/` are **generated** — avoid one-off product styling inside them. App-wide primitive standards such as button or tab sizing may live there when the change deliberately applies across the whole application; document those standards in this file.
-
-#### Controls — input, button, menu, and segment sizing
-
-Text inputs, text buttons, tabs, dropdown menus, segmented controls, and pill filters should use the same readable CTA rhythm as the setup wizard:
-
-- Height: `h-10`
-- Horizontal padding: `px-8` for normal buttons, `px-4` for inputs/selects, `px-6` for dense segmented controls
-- Font size: `text-sm`
-- Shape: **follow the shadcn theme radius, all derived from `--radius` in `index.css`.** Interactive text controls are `rounded-md` (buttons, filter chips, tabs/segmented items, menu items); their containers (segmented control, dropdown menu, popover) are `rounded-lg`. Never hardcode `rounded-full`, `rounded-xl`, or `rounded-2xl` on a text control or its container — a pill button next to `rounded-lg` cards reads as a foreign design system. `rounded-full` is reserved for avatars, switches, badges, and status dots; larger radii (`rounded-xl`/`rounded-2xl`/`rounded-4xl`) belong to cards and large surfaces only.
-
-Avoid local `h-6`, `h-7`, `h-8`, `h-9`, `text-xs`, or narrow `px-2` overrides for text controls, and never re-pill a control with a `rounded-full` className that overrides the shadcn `Button`/`Tabs` primitive. OTP slots should follow the same readable `h-10` control rhythm unless a dense, space-constrained surface has a documented reason to shrink them. Reserve smaller sizing for pure icon buttons, badges, dense table data, chart labels, and non-interactive metadata.
-
-`Label` and `CardDescription` are app-wide readable primitives (`text-sm`). Do not shrink form labels or section descriptions locally unless the element is truly dense metadata rather than an input label.
-
-Color swatches should use a stable visible size and selection ring. Avoid
-`scale-*` transforms on selected or hovered swatches because cards and dialogs
-often clip overflow, which makes round swatches look cut off.
-
-Code-copy rows and settings navigation rows follow the same readable scale:
-their visible value container should be at least `min-h-10`, use `rounded-xl`
-and `px-4`, and the associated action button should be full-width on mobile
-then at least `min-w-36` on desktop. Avoid local `p-2`, `px-2 py-1.5`, and
-`text-xs` on these rows.
-
-Transitions must name the animated properties explicitly. Do not use
-`transition-all`; prefer bounded values such as
-`transition-[border-color,background-color,color]`, `transition-[width]`, or
-`transition-transform`.
-
-#### Focus styling
-
-Picsou uses a centralized `:focus-visible` ring in `index.css` for keyboard focus
-on interactive elements. Avoid one-off `focus:*`, `focus-visible:*`,
-`group-focus:*`, or `focus-within:*` Tailwind classes on normal controls unless a
-component needs to become visible only when focused, such as a skip link.
-
-#### Page layout
-
-Top-level app pages should start flush with the main content column, not centered inside `mx-auto` wrappers. Use `PageHeader` so every page title carries the same date surtitle and action alignment as the dashboard. Empty pages that are the primary page state should center their `EmptyState` in the remaining viewport height; nested empty states inside cards or modals should stay compact.
-
-#### Color tokens — always semantic, never raw palette
-
-All theme color tokens are defined in the `@theme` block of `frontend/src/index.css`. **Never use raw palette classes** (`text-gray-*`, `bg-gray-*`, etc.) — they bypass the theme tokens and do not adapt to dark mode.
-
-| Intent | Use |
-|--------|-----|
-| Primary text | `text-foreground` |
-| Muted / secondary text | `text-muted-foreground` |
-| Subtle background | `bg-muted` |
-| Card background | `bg-card` |
-| Primary action color | `text-primary` / `bg-primary` |
-| Destructive / error | `text-destructive` |
-
-**Exception:** intentional status colors (`text-green-*`, `text-red-*`, `text-amber-*`, etc.) are fine when used as semantic UI signals (sync status badges, financial gain/loss indicators). Always include dark-mode variants or use the `dark:` prefix for those.
-
-### Icons
-
-Use icons from `lucide-react` as direct JSX components (e.g., `<Pencil className="size-4" />`). No other icon libraries.
+Components in `components/ui/` are **generated** — avoid one-off product styling inside them.
+App-wide primitive standards (control sizing, the radius ladder) may live there when the change
+deliberately applies across the whole application and is ratified in an ADR; document those
+standards in [`design-system.md`](./design-system.md). `shadcn add <component>` resets them, so
+re-apply the standard after regenerating a primitive.
 
 ## Internationalization
 
@@ -250,7 +204,9 @@ Use icons from `lucide-react` as direct JSX components (e.g., `<Pencil className
 
 ## Charts
 
-Recharts v3 for all data visualizations. Chart color tokens (`--chart-1` through `--chart-5`) are defined in the Tailwind theme.
+Recharts v3 for all data visualizations. Chart color tokens (`--chart-1` through `--chart-5`) are
+defined in the Tailwind theme. Visual rules (tooltip shape, legend marks, empty state, locale-aware
+labels): [`design-system.md`](./design-system.md) § Charts.
 
 ## Scripts
 
@@ -270,15 +226,17 @@ e2e specs (which need a browser) and fail. Keep unit tests under `src/`, e2e und
 
 ## Don'ts
 
-- **Never use raw palette classes** (`text-gray-*`, `bg-gray-*`) — always semantic tokens (`text-foreground`, `bg-muted`). The gray palette is remapped to blue.
+Visual don'ts (raw palette classes, pilled controls, restated radii, `transition-all`, inline
+styles, icon libraries, one-off focus rings) live in
+[`design-system.md`](./design-system.md) § Don'ts, with the greps that catch them.
+
+Code-level don'ts:
+
 - **Never create API functions in components** — all API calls go in `features/*/api.ts`.
 - **Never create hooks outside `features/`** — domain hooks live in `features/*/hooks.ts`. Only generic UI hooks (like `use-mobile`) go in `hooks/`.
 - **Never use Redux, Context, or global state for server data** — TanStack Query only.
-- **Never edit files in `components/ui/`** — these are shadcn/ui generated. Customize via theme tokens or the shadcn CLI. In particular, never inflate a primitive's radius away from the shadcn scale (e.g. `rounded-md`→`rounded-full` on `Button`, `rounded-lg`→`rounded-2xl` on `DropdownMenu`).
-- **Never hardcode `rounded-full` / `rounded-xl` / `rounded-2xl` on interactive text controls** (buttons, filter chips, tabs, segmented items, menu items) or use a `rounded-full` className to override a shadcn primitive. Shape follows the `--radius` theme: `rounded-md` for controls, `rounded-lg` for their containers. `rounded-full` is only for avatars, switches, badges, and status dots.
-- **Never use icon libraries other than `lucide-react`.**
+- **Never edit files in `components/ui/`** — these are shadcn/ui generated. Customize via theme tokens or the shadcn CLI. The only sanctioned exception is an app-wide, on-scale standard ratified in an ADR and documented in [`design-system.md`](./design-system.md).
 - **Never hardcode user-visible strings** — always use `useTranslation()`.
-- **Never use CSS modules, styled-components, or inline style objects** — Tailwind only.
 - **Never call `Math.random()`/`Date.now()` in render** — lazy `useState(() => …)` initializer (React Compiler `purity`).
 - **Never seed/reset form state in a `useEffect(…, [open])`** — use the key-remount + lazy-init pattern (`set-state-in-effect`).
 - **Never use RHF `watch('x')`** — use `useWatch({ control, name: 'x' })` (`incompatible-library`).

--- a/docs/decisions/2026-07-12-ui-controls-follow-shadcn-theme-radius.md
+++ b/docs/decisions/2026-07-12-ui-controls-follow-shadcn-theme-radius.md
@@ -1,7 +1,13 @@
 # ADR: UI controls follow the shadcn theme radius, not a pill shape
 
 > Date: 2026-07-12
-> Status: ✅ Active
+> Status: ❌ Superseded by [2026-08-10 — One radius ladder for every surface](./2026-08-10-ui-radius-ladder.md)
+
+> **What changed:** the principle below still stands — shape derives from `--radius`, `rounded-full`
+> is reserved for naturally circular elements, and app code never re-shapes a control. Only the
+> specific rungs changed: controls are now `rounded-lg` (not `rounded-md`) and their containers
+> `rounded-xl` (not `rounded-lg`), and the ladder now assigns a tier to panels, rows, and micro
+> elements too. Read the superseding ADR for the current table.
 
 ## Context
 

--- a/docs/decisions/2026-07-12-ui-controls-follow-shadcn-theme-radius.md
+++ b/docs/decisions/2026-07-12-ui-controls-follow-shadcn-theme-radius.md
@@ -2,7 +2,7 @@
 
 > Date: 2026-07-12
 > Status: ❌ Superseded by [2026-08-10 — One radius ladder for every surface](./2026-08-10-ui-radius-ladder.md)
-
+>
 > **What changed:** the principle below still stands — shape derives from `--radius`, `rounded-full`
 > is reserved for naturally circular elements, and app code never re-shapes a control. Only the
 > specific rungs changed: controls are now `rounded-lg` (not `rounded-md`) and their containers

--- a/docs/decisions/2026-08-10-ui-radius-ladder.md
+++ b/docs/decisions/2026-08-10-ui-radius-ladder.md
@@ -1,0 +1,170 @@
+# ADR: One radius ladder for every surface, not just controls
+
+> Date: 2026-08-10
+> Status: ✅ Active
+
+## Context
+
+[ADR 2026-07-12](./2026-07-12-ui-controls-follow-shadcn-theme-radius.md) settled the *shape question
+for interactive controls*: no pills, follow the `--radius` scale, `rounded-md` for controls and
+`rounded-lg` for their containers. That decision held and is not being reopened.
+
+What it did **not** cover is everything between a control and a card: callout boxes, code blocks,
+list containers, list rows, dropzones, stat tiles, icon tiles, skeletons, checkboxes, chart
+tooltips. Those had no assigned rung, so each page picked one. An audit of `frontend/src` on
+2026-08-10 found the same kind of element rendered at three or four different radii:
+
+| Element | Radii found in the codebase |
+|---------|-----------------------------|
+| Inline error/alert strip | `rounded-md` (8), `rounded-lg` (10), `rounded-xl` (14) |
+| Segmented control wrapper / item | `2xl`+`xl` (18/14), `lg`+`md` (10/8), bare `md` with no wrapper |
+| Select / text input | `rounded-md` (8) from the primitive, `rounded-xl` (14) hand-written |
+| Code-copy value row | `rounded` (4), `rounded-lg` (10), `rounded-xl` (14) |
+| Checkbox | `rounded` (4), `rounded-sm` (6), `rounded-md` (8) |
+| Buttons | `rounded-md` (8) — plus 29 overriding to `rounded-full`, and 5 more pilled controls |
+
+The 2026-07-12 ADR predicted this failure mode ("Override vigilance … we accept relying on the
+convention Don'ts and review to catch these"). It did not hold: 29 `rounded-full` button overrides
+(27 in the setup wizard, 2 on the login/MFA submits) plus 5 other pilled controls — both password
+eye toggles, the setup status chip, the skip link, and the setup intro text button — survived, and the unassigned tiers drifted freely because
+no rule covered them.
+
+The visible symptom, reported by the maintainer with screenshots: on one screen a 26px card sits
+next to an 8px button, a 10px segmented control, and a 14px code row — four different corner radii
+with no relationship between them.
+
+## Decision
+
+**Every box in the UI takes its radius from one ladder, keyed on what the box *is*.** The `--radius`
+token and the derived scale in `index.css` are unchanged (6 / 8 / 10 / 14 / 18 / 22 / 26 px); only
+the tier assignment is now defined for the whole app rather than for controls alone.
+
+| Tier | Token | ≈ px | What |
+|------|-------|------|------|
+| **Surface** | `rounded-4xl` | 26 | `Card`, `DialogContent`, bottom sheet, desktop sidebar shell |
+| **Panel** | `rounded-2xl` | 18 | boxes inside a surface: callouts, `<pre>` code blocks, dropzones, empty states, bordered sub-panels, stat blocks, the mobile nav bar |
+| **Row / control container** | `rounded-xl` | 14 | list containers and list rows, nav rows, inline alert strips, segmented-control wrappers, dropdown/popover content, chart tooltips |
+| **Control** | `rounded-lg` | 10 | button, input, select, textarea, segment item, menu item, OTP slot, icon tile (`size-8`…`size-12`), single-line code-copy value |
+| **Micro** | `rounded-md` | 8 | skeleton default, `size-6` tile, treemap cell, small overlay chip |
+| **Hairline** | `rounded-sm` | 6 | checkbox, `size-4` logo |
+| **Circular** | `rounded-full` | — | avatar, switch, badge, status dot, progress bar, step bubble, color swatch, decorative empty-state icon bubble |
+| **Chart mark** | `rounded-[2px]` | 2 | chart swatches, legend squares, thin bar segments, tooltip arrow (≤ 10px marks) |
+
+Two consequences change previously-documented values:
+
+1. **Controls move one rung up**, `rounded-md` → `rounded-lg`, and their containers `rounded-lg` →
+   `rounded-xl`. This makes the segmented control concentric — a `p-1` (4px) wrapper at 14px holding
+   a 10px item is exactly right, where 10px holding 8px was not — and narrows the gap to the 26px
+   cards the controls sit next to.
+2. **`DialogContent` moves `rounded-xl` → `rounded-4xl`.** A modal is a surface; it now matches the
+   cards behind it instead of reading as a large panel.
+
+Tier assignment is owned by the shadcn `ui/` primitives. App code composes `<Button>` / `<Tabs>` /
+`<Card>` / `<Item>` and inherits; it must not restate or override a radius that the primitive
+already provides.
+
+## Alternatives considered
+
+### A. Leave the primitives alone; only fix app-level overrides
+
+- **Pros**:
+  - Zero edits under `components/ui/`, fully aligned with [`CODING_RULES.md`](../CODING_RULES.md) rule 1
+  - Smallest diff; `shadcn add` regenerations stay clean
+- **Cons**:
+  - Leaves controls at 8px next to 26px cards — the exact mismatch that was reported
+  - Leaves the segmented control non-concentric (10px wrapper, 8px item, 4px padding)
+  - Fixes the drift but not the underlying complaint
+
+### B. Lower the card tier instead (26 → 18 or 22) to meet the controls
+
+- **Pros**:
+  - Also closes the gap, without touching a single control
+  - Yields an evenly spaced 10 / 14 / 18 / 22 ladder
+- **Cons**:
+  - Restyles every screen in the app; the round card is Picsou's most visible shape signature
+  - [ADR 2026-07-12](./2026-07-12-ui-controls-follow-shadcn-theme-radius.md) explicitly records
+    `rounded-4xl` cards as intentional and warns against "fixing" them
+  - The request was harmonisation, not a redesign
+
+### C. Raise `--radius` so every rung grows
+
+- **Pros**:
+  - One-line change, no primitive edits
+- **Cons**:
+  - Scales the whole ladder uniformly — the *relative* mismatch between a control and a card is
+    unchanged, which is the actual problem
+  - Inflates cards past 26px as a side effect
+
+### D. Full ladder with controls one rung up — **chosen**
+
+- **Pros**:
+  - Assigns a tier to every element, so there is nothing left to drift into
+  - Concentric by construction: container radius = item radius + padding at each nesting step
+  - Keeps the card signature and the no-pills principle from the previous ADR intact
+- **Cons**:
+  - Requires on-scale edits to eight `components/ui/` primitives
+  - Diverges from stock shadcn defaults, so a future `shadcn add` will reset those files
+
+## Reasoning
+
+Options A and C do not solve the reported problem — one fixes the wrong half, the other scales the
+mismatch instead of removing it. That leaves a choice between moving the cards down (B) or the
+controls up (D), and the previous ADR already ruled on that: cards are deliberately rounder and are
+not to be "fixed" to match controls. Moving controls up is the only direction left, and it happens
+to be the one that makes the nesting math work — 10 inside 14 inside 18 inside 26, each step
+matching the padding that separates it from its parent.
+
+Extending the ladder to *every* tier, rather than only to controls, is what actually prevents
+recurrence. The 2026-07-12 ADR relied on review vigilance for the tiers it left unspecified, and the
+audit above is the measurement of how well that worked. A rung for every element turns "what radius
+should this box have?" from a judgment call into a lookup.
+
+## Trade-offs accepted
+
+- **`components/ui/` is hand-edited.** [`CODING_RULES.md`](../CODING_RULES.md) rule 1 forbids editing
+  primitives *off their scale*; these edits stay on the `--radius`-derived scale and are an app-wide
+  standard, which [`conventions/frontend.md`](../conventions/frontend.md) already sanctions
+  ("App-wide primitive standards … may live there when the change deliberately applies across the
+  whole application; document those standards in this file"). The cost is that
+  `shadcn add button` will reset `button.tsx` to `rounded-md` and the tier must be re-applied.
+- **Divergence from stock shadcn.** The previous ADR counted "matches the shadcn defaults" as a pro.
+  We give that up for eight files. The theme already diverges (custom `--radius` multipliers,
+  `rounded-4xl` cards, `h-10`/`px-8` control sizing), so the marginal cost is small.
+- **14 vs 18 on a nested box is a judgment call.** The row/panel split is keyed on whether the box
+  is one control tall (row) or a multi-line block (panel). Borderline cases exist; a 4px difference
+  on a nested box is not worth re-litigating per PR.
+- **Still no lint rule.** Conformance remains review-enforced, but is now grep-able: any
+  `rounded-*` in app code that is not in the table above is a finding.
+
+## Consequences
+
+This ADR ratifies the ladder; the sweep that applies it to the codebase lands as a separate
+follow-up change, per [`CODING_RULES.md`](../CODING_RULES.md) rule 0 — a convention may not be
+relaxed in the same diff as the deviation it legitimises. What the sweep will do:
+
+- `frontend/src/components/ui/`: `button.tsx`, `input.tsx`, `input-otp.tsx`, `item.tsx`, `tabs.tsx`,
+  `dropdown-menu.tsx`, `tooltip.tsx`, `chart.tsx`, `empty.tsx`, `partition-bar.tsx`, `progress.tsx`
+  and `dialog.tsx` take the tier assignment. `card.tsx` stays unchanged (`rounded-4xl`).
+- 34 `rounded-full` overrides are removed (29 on `<Button>`, 5 on other controls), along with every
+  `rounded-xl` override on an `<Input>`, `<select>`, `<textarea>` or segmented item; these inherit
+  from the primitive instead.
+- `components/ui/sidebar.tsx` is **not** updated: it is a vendor file with no import anywhere in the
+  app. If it is ever wired up, apply the ladder then.
+- New rule for reviewers: a `rounded-*` class in app code is only correct if it names a tier from the
+  table, and only if the primitive does not already provide it.
+- Enforced by [`conventions/design-system.md`](../conventions/design-system.md) (§ 1 Shape, § 10 Don'ts) and
+  [`CODING_RULES.md`](../CODING_RULES.md) rules 1–2.
+
+## Supersedes
+
+[ADR 2026-07-12 — UI controls follow the shadcn theme radius, not a pill shape](./2026-07-12-ui-controls-follow-shadcn-theme-radius.md).
+
+Its core ruling is **retained**: shape derives from `--radius`, `rounded-full` is reserved for
+naturally circular elements, and app code never re-shapes a control. Only the specific rungs
+(`rounded-md` control / `rounded-lg` container) are replaced by the ladder above, and the scope is
+widened from controls to every surface.
+
+## Related features
+
+- [UI radius ladder](../features/ui-control-shape-system.md) — the implementation detail and gotchas
+- [Theme (dark / light / system)](../features/theme-persistence.md) — the theme tokens these radii derive from

--- a/docs/decisions/2026-08-10-ui-radius-ladder.md
+++ b/docs/decisions/2026-08-10-ui-radius-ladder.md
@@ -123,9 +123,10 @@ should this box have?" from a judgment call into a lookup.
 
 - **`components/ui/` is hand-edited.** [`CODING_RULES.md`](../CODING_RULES.md) rule 1 forbids editing
   primitives *off their scale*; these edits stay on the `--radius`-derived scale and are an app-wide
-  standard, which [`conventions/frontend.md`](../conventions/frontend.md) already sanctions
-  ("App-wide primitive standards … may live there when the change deliberately applies across the
-  whole application; document those standards in this file"). The cost is that
+  standard, which [`conventions/frontend.md`](../conventions/frontend.md) sanctions — "App-wide
+  primitive standards (control sizing, the radius ladder) may live there when the change
+  deliberately applies across the whole application and is ratified in an ADR; document those
+  standards in `design-system.md`" — a sentence this ADR is the ratification for. The cost is that
   `shadcn add button` will reset `button.tsx` to `rounded-md` and the tier must be re-applied.
 - **Divergence from stock shadcn.** The previous ADR counted "matches the shadcn defaults" as a pro.
   We give that up for twelve files. The theme already diverges (custom `--radius` multipliers,

--- a/docs/decisions/2026-08-10-ui-radius-ladder.md
+++ b/docs/decisions/2026-08-10-ui-radius-ladder.md
@@ -102,7 +102,7 @@ already provides.
   - Concentric by construction: container radius = item radius + padding at each nesting step
   - Keeps the card signature and the no-pills principle from the previous ADR intact
 - **Cons**:
-  - Requires on-scale edits to eight `components/ui/` primitives
+  - Requires on-scale edits to twelve `components/ui/` primitives
   - Diverges from stock shadcn defaults, so a future `shadcn add` will reset those files
 
 ## Reasoning
@@ -128,7 +128,7 @@ should this box have?" from a judgment call into a lookup.
   whole application; document those standards in this file"). The cost is that
   `shadcn add button` will reset `button.tsx` to `rounded-md` and the tier must be re-applied.
 - **Divergence from stock shadcn.** The previous ADR counted "matches the shadcn defaults" as a pro.
-  We give that up for eight files. The theme already diverges (custom `--radius` multipliers,
+  We give that up for twelve files. The theme already diverges (custom `--radius` multipliers,
   `rounded-4xl` cards, `h-10`/`px-8` control sizing), so the marginal cost is small.
 - **14 vs 18 on a nested box is a judgment call.** The row/panel split is keyed on whether the box
   is one control tall (row) or a multi-line block (panel). Borderline cases exist; a 4px difference

--- a/docs/features/sidebar-navigation.md
+++ b/docs/features/sidebar-navigation.md
@@ -53,7 +53,9 @@ Active nav items keep Lucide icons stroke-only. The item gets `ring-1 ring-borde
 - `frontend/src/components/layout/AppSidebar.tsx` — desktop sidebar with `NavItem`, admin profile switcher, and bottom-pinned account/settings access
 - `frontend/src/components/layout/MobileBottomNav.tsx` — mobile bottom navbar
 - `frontend/src/components/layout/AppLayout.tsx` — renders sidebar (desktop) + bottom nav (mobile)
-- `frontend/src/components/ui/item.tsx` — `Item` / `ItemMedia` / `ItemContent` primitives (do not edit)
+- `frontend/src/components/ui/item.tsx` — `Item` / `ItemMedia` / `ItemContent` primitives. Generated:
+  don't edit, except for the app-wide radius ladder ratified in
+  [ADR 2026-08-10](../decisions/2026-08-10-ui-radius-ladder.md), which sets `Item` to the row rung
 - `frontend/src/i18n/locales/{fr,en}.json` — `nav.*` keys for labels
 - `frontend/src/assets/horizontal-white-picsou.svg` — horizontal wordmark logo used at the top of the desktop sidebar
 - `frontend/src/assets/picsou_logo_white.svg` — icon-only logo used in mobile nav

--- a/docs/features/sidebar-navigation.md
+++ b/docs/features/sidebar-navigation.md
@@ -1,6 +1,6 @@
 # Feature: Navigation (Sidebar + Mobile Bottom Nav)
 
-> Last updated: 2026-07-12
+> Last updated: 2026-08-10
 
 ## Context
 
@@ -35,6 +35,14 @@ A fixed bottom bar with the Picsou logo centered and 2 nav items on each side:
 - Active state: `ring-1 ring-border` + foreground icon color
 - Safe area padding for iOS notch: `env(safe-area-inset-bottom)`
 - `AppLayout` adds `pb-20 md:pb-0` on main content to avoid overlap
+
+### Shell shape
+
+Both shells follow the [radius ladder](../conventions/design-system.md#1-shape--the-radius-ladder). The desktop
+`<nav>` is a full-height floating surface, so it takes the **surface** rung (`rounded-4xl`) and
+matches the cards beside it; the mobile bar is a compact 64px dock, so it takes the **panel** rung
+(`rounded-2xl`). Nav rows inherit the **row** rung from the `Item` primitive — don't restate
+`rounded-xl` on them.
 
 ### Active state (shared pattern)
 

--- a/docs/features/ui-control-shape-system.md
+++ b/docs/features/ui-control-shape-system.md
@@ -1,6 +1,13 @@
 # Feature: UI radius ladder (shadcn theme radius)
 
 > Last updated: 2026-08-10
+>
+> **Status:** the ladder below is ratified by
+> [ADR 2026-08-10](../decisions/2026-08-10-ui-radius-ladder.md) and applied to the codebase by a
+> separate sweep (split out per [`CODING_RULES.md`](../CODING_RULES.md) rule 0). Until that sweep
+> lands, the primitives named under *Key files* still carry their pre-ladder radii — `button.tsx` is
+> `rounded-md`, `dialog.tsx` is `rounded-xl` — so read this note as the target, not as a description
+> of `main`.
 
 ## Context
 

--- a/docs/features/ui-control-shape-system.md
+++ b/docs/features/ui-control-shape-system.md
@@ -1,39 +1,60 @@
-# Feature: UI control shape (shadcn theme radius)
+# Feature: UI radius ladder (shadcn theme radius)
 
 > Last updated: 2026-08-10
 
 ## Context
 
-Every interactive control in the app (buttons, filter chips, tabs, segmented controls, dropdown
-menus, inputs) must read as one design system. Their corner radius is not chosen per component — it
-derives from a single theme token, `--radius`, so cards, controls, and menus stay visually
-consistent. This note exists because a large frontend rewrite once broke that consistency and the
-breakage was hard to trace (see Gotchas).
+Every box in the app — from a 26px card down to a 6px checkbox — must read as one design system.
+Corner radius is not chosen per component: it derives from a single theme token, `--radius`, and
+each kind of element is assigned a fixed rung of the derived scale. This note exists because the
+consistency has broken twice: once when a rewrite turned every control into a pill (2026-07-12), and
+once because only *controls* had an assigned rung, so everything between a control and a card drifted
+(2026-08-10).
 
 ## How it works
 
 `--radius: 0.625rem` (10px) is defined once in `frontend/src/index.css`. Tailwind v4 derives the
-whole scale from it (`--radius-sm/md/lg/xl/2xl/...` as multiples). Controls pick a rung of that
-scale; they never hardcode a pixel radius or a pill shape:
+whole scale from it as multiples, which lands on an evenly-spaced ladder:
 
-| Surface | Radius class | ≈ px |
-|---------|-------------|------|
-| Interactive text control (button, filter chip, tab/segment item, menu item) | `rounded-md` | 8 |
-| Control container (segmented control, dropdown/popover) | `rounded-lg` | 10 |
-| Cards / large surfaces | `rounded-xl` … `rounded-4xl` | 14+ |
-| Circular by nature (avatar, switch thumb, badge, status dot, scrollbar) | `rounded-full` | — |
+| Token | `rounded-sm` | `rounded-md` | `rounded-lg` | `rounded-xl` | `rounded-2xl` | `rounded-3xl` | `rounded-4xl` |
+|-------|----|----|----|----|----|----|----|
+| px    | 6  | 8  | 10 | 14 | 18 | 22 | 26 |
 
-Shape lives in the shadcn primitives (`frontend/src/components/ui/button.tsx`, `tabs.tsx`,
-`dropdown-menu.tsx`), so a page composes `<Button>` / `<Tabs>` and inherits the correct radius. App
-code must not re-shape a control with a local `rounded-*` className.
+Elements pick a rung by **what they are**; they never hardcode a pixel radius or a pill shape:
+
+| Tier | Class | ≈ px | Applies to |
+|------|-------|------|-----------|
+| **Surface** | `rounded-4xl` | 26 | `Card`, `DialogContent`, bottom sheet, desktop sidebar shell |
+| **Panel** | `rounded-2xl` | 18 | boxes inside a surface: callouts, `<pre>` code blocks, dropzones, empty states, bordered sub-panels, stat blocks, mobile nav bar |
+| **Row / control container** | `rounded-xl` | 14 | list containers and rows, nav rows, inline alert strips, segmented-control wrappers, dropdown/popover content, chart tooltips |
+| **Control** | `rounded-lg` | 10 | button, input, select, textarea, segment item, menu item, OTP slot, icon tile (`size-8`…`size-12`), single-line code-copy value |
+| **Micro** | `rounded-md` | 8 | skeleton default, `size-6` tile, treemap cell, small overlay chip |
+| **Hairline** | `rounded-sm` | 6 | checkbox, `size-4` logo |
+| **Circular** | `rounded-full` | — | avatar, switch, badge, status dot, progress bar, step bubble, color swatch, decorative empty-state icon bubble |
+| **Chart mark** | `rounded-[2px]` | 2 | chart swatches, legend squares, thin bar segments, tooltip arrow (≤ 10px marks) |
+
+The ladder is **concentric**: at every nesting step, the parent's radius equals the child's radius
+plus the padding between them. A `TabsList` is `p-1` (4px) at `rounded-xl` (14) holding a
+`rounded-lg` (10) trigger; a card is `px-4` (16px) at `rounded-4xl` (26) holding a `rounded-lg` (10)
+control. Picking a rung off the ladder breaks that alignment visibly.
+
+Shape lives in the shadcn primitives, so a page composes `<Button>` / `<Tabs>` / `<Card>` / `<Item>`
+and inherits the correct radius. App code must not restate or override a radius the primitive
+already provides.
 
 ### Key files
 
-- `frontend/src/index.css` — `--radius` base token and the derived radius scale
-- `frontend/src/components/ui/button.tsx` — `rounded-md` base (do not edit off-scale)
-- `frontend/src/components/ui/tabs.tsx` — list `rounded-lg`, trigger `rounded-md`
-- `frontend/src/components/ui/dropdown-menu.tsx` — container `rounded-lg`, items `rounded-md`
-- `docs/conventions/frontend.md` — the enforced rule + Don'ts (§ Controls, § Don'ts)
+- `frontend/src/index.css` — `--radius` base token and the derived scale (`@theme inline`)
+- `frontend/src/components/ui/card.tsx` — `rounded-4xl` surface (unchanged since 2026-07-12)
+- `frontend/src/components/ui/dialog.tsx` — `rounded-4xl`; a modal is a surface, it matches the cards behind it
+- `frontend/src/components/ui/button.tsx` — `rounded-lg` control base
+- `frontend/src/components/ui/input.tsx`, `input-otp.tsx` — `rounded-lg` control
+- `frontend/src/components/ui/tabs.tsx` — list `rounded-xl`, trigger `rounded-lg`
+- `frontend/src/components/ui/dropdown-menu.tsx` — container `rounded-xl`, items `rounded-lg`
+- `frontend/src/components/ui/item.tsx` — row `rounded-xl`; `ItemMedia` image `rounded-lg` (`rounded-md` at `size=xs`)
+- `frontend/src/components/ui/chart.tsx`, `tooltip.tsx` — chart tooltip `rounded-xl`, text tooltip `rounded-lg`
+- `frontend/src/components/ui/progress.tsx` — `rounded-full` track
+- `docs/conventions/design-system.md` — the enforced rule + Don'ts (§ 1 Shape, § 10 Don'ts)
 - `docs/CODING_RULES.md` — the non-negotiable charter this rule belongs to
 
 ## Technical choices
@@ -41,7 +62,9 @@ code must not re-shape a control with a local `rounded-*` className.
 | Choice | Why | Rejected alternative |
 |--------|-----|----------------------|
 | Single `--radius` token, scale derived | One knob re-shapes the whole app coherently | Per-component hardcoded radii — drift, no single source of truth |
-| Controls at `rounded-md`, not `rounded-full` | Pills next to `rounded-lg` cards read as a foreign design system in a data-dense finance UI | Full-pill controls (would require pilling inputs/badges too to stay coherent) |
+| A rung for **every** element, not just controls | Unassigned tiers are where drift happens; a lookup beats a judgment call | Controls-only rule (2026-07-12) — panels/rows/chips drifted across 3–4 radii |
+| Controls at `rounded-lg`, not `rounded-full` | Pills next to `rounded-4xl` cards read as a foreign design system in a data-dense finance UI | Full-pill controls (would require pilling inputs/badges too to stay coherent) |
+| Cards stay `rounded-4xl` | The round card is the app's shape signature; lowering it restyles every screen | Dropping cards to 18/22 to meet the controls |
 | Radius owned by shadcn `ui/` primitives | Compose-and-inherit; pages never restyle shape | Per-page `rounded-*` overrides — the exact drift #29 introduced |
 
 ## Gotchas / Pitfalls
@@ -49,37 +72,50 @@ code must not re-shape a control with a local `rounded-*` className.
 - **`rounded-full` on a `<Button>` className overrides the primitive.** tailwind-merge keeps the last
   radius class, so a page-level `className="… rounded-full"` silently re-pills a control even after
   `button.tsx` is correct. Fixing the primitive is not enough — the override must be removed too.
+  This is how 29 pill buttons survived the 2026-07-12 fix — 27 in the setup wizard, 2 on the
+  login/MFA submits — plus 5 other pilled controls.
+- **`shadcn add <component>` resets the tier.** The ladder is applied by hand inside
+  `components/ui/`. After regenerating any primitive, re-apply its rung from the table above.
+- **`components/ui/sidebar.tsx` is deliberately untouched.** It is a vendor file with no import
+  anywhere in the app (verified 2026-08-10) and still carries stock shadcn radii. Apply the ladder
+  if it is ever wired up.
+- **`rounded-4xl` on cards is intentional**, not drift. Do not "fix" card radius to match controls;
+  cards are deliberately rounder. The controls moved up to meet them, not the other way round.
 - **Regression origin — commit `716228e` (PR #29, agent-generated).** It flipped `Button`,
   `Tabs`, and `DropdownMenu` off the scale (`rounded-md/lg` → `rounded-full/2xl/xl`), hardcoded
   `rounded-full` filter chips across pages, **and rewrote `docs/conventions/frontend.md` in the same
   diff to bless pills and forbid `rounded-md`** — which made the deviation look compliant in review.
   Reverted 2026-07-12. This is why the convention-integrity rule exists in `CODING_RULES.md`.
-- **`rounded-4xl` on cards is intentional**, not drift — it predates #29. Do not "fix" card radius to
-  match controls; cards are deliberately rounder than controls.
-- **The rule is honoured by the primitives, not yet by every call site.** Roughly 19 hardcoded
-  `rounded-xl`/`rounded-2xl` controls predate the 2026-07-12 revert and are still there:
-  `AccountForm`, `AddAccountModal` and `FinaryTab` selects, the `SettingsPage` /
-  `HoldingDetailModal` / `HoldingInsightSection` segmented controls, `AccessKeysSection` code
-  rows, and the setup layout. So `rounded-xl` on a select is what most of the app currently
-  *does*, while `rounded-md` is what the charter *says* — copying a neighbouring form is how a
-  new screen inherits the deviation, which is exactly how the property flow got it. Judge a new
-  control against this document, not against the file next to it. Fixing the backlog is a
-  separate sweep, deliberately not folded into feature branches.
-- **Don't hand-edit `frontend/src/components/ui/`** to change radius/sizing. Shape comes from the `--radius` theme
-  token; adjust the token, not the primitives.
+- **Judge a new control against this document, not against the file next to it.** Before 2026-08-10
+  roughly 19 hardcoded `rounded-xl`/`rounded-2xl` controls sat in `AccountForm`, `AddAccountModal`
+  and `FinaryTab` selects, the `SettingsPage` / `HoldingDetailModal` / `HoldingInsightSection`
+  segmented controls, `AccessKeysSection` code rows and the setup layout — so the deviation was what
+  most of the app *did* while the charter said otherwise, and each new screen inherited it by
+  copying a neighbouring form (that is how the property flow got it). **The sweep that applies this
+  ladder clears that backlog**; it does not clear the failure mode. Copying the file next to you is
+  still how drift restarts.
+- **Don't hand-edit `components/ui/` for anything but an app-wide, on-scale standard.** Changing one
+  primitive's radius for one screen is drift; assigning the whole app's control tier is a documented
+  standard (this note + the ADR).
 
 ## Tests
 
 - No dedicated unit test (pure styling). `frontend/src/components/layout/AppSidebar.test.tsx` and the
-  Playwright E2E suite exercise the components that consume these primitives.
-- Conformance is enforced by review + the grep-able Don'ts in `docs/conventions/frontend.md`
-  (no `rounded-full`/`rounded-xl`/`rounded-2xl` on interactive text controls). Review is the
-  only gate, and the backlog above is what it has let through — a lint rule would catch it,
-  but none exists today.
+  Playwright E2E suite exercise the components that consume these primitives. No test asserts on a
+  `rounded-*` class, so the ladder can be changed without breaking the suite — which is exactly why
+  it needs the review rule below.
+- Conformance is review-enforced but grep-able. Review is the only gate today (no lint rule exists),
+  and the pre-2026-08-10 backlog is what it let through. This should return only ladder classes:
+
+  ```bash
+  cd frontend && grep -rhoE "rounded(-[a-z0-9]+)*(-\[[^]]+\])?" src \
+    --include='*.tsx' --include='*.ts' | sort | uniq -c | sort -rn
+  ```
 
 ## Links
 
-- ADR: `docs/decisions/2026-07-12-ui-controls-follow-shadcn-theme-radius.md`
-- Convention: `docs/conventions/frontend.md` (§ Controls, § Don'ts)
+- ADR: `docs/decisions/2026-08-10-ui-radius-ladder.md` (current)
+- Superseded ADR: `docs/decisions/2026-07-12-ui-controls-follow-shadcn-theme-radius.md`
+- Convention: `docs/conventions/design-system.md` (§ 1 Shape, § 10 Don'ts)
 - Charter: `docs/CODING_RULES.md`
 - Related feature: `docs/features/theme-persistence.md` (theme tokens, dark/light)

--- a/docs/features/ui-control-shape-system.md
+++ b/docs/features/ui-control-shape-system.md
@@ -20,7 +20,9 @@ whole scale from it as multiples, which lands on an evenly-spaced ladder:
 |-------|----|----|----|----|----|----|----|
 | px    | 6  | 8  | 10 | 14 | 18 | 22 | 26 |
 
-Elements pick a rung by **what they are**; they never hardcode a pixel radius or a pill shape:
+Elements pick a rung by **what they are**; they never hardcode a pixel radius or a pill shape. The
+one exception is the chart-mark row below: under ~10px every rung reads as a circle, so
+`rounded-[2px]` is sanctioned there and nowhere else.
 
 | Tier | Class | ≈ px | Applies to |
 |------|-------|------|-----------|
@@ -30,7 +32,7 @@ Elements pick a rung by **what they are**; they never hardcode a pixel radius or
 | **Control** | `rounded-lg` | 10 | button, input, select, textarea, segment item, menu item, OTP slot, icon tile (`size-8`…`size-12`), single-line code-copy value |
 | **Micro** | `rounded-md` | 8 | skeleton default, `size-6` tile, treemap cell, small overlay chip |
 | **Hairline** | `rounded-sm` | 6 | checkbox, `size-4` logo |
-| **Circular** | `rounded-full` | — | avatar, switch, badge, status dot, progress bar, step bubble, color swatch, decorative empty-state icon bubble |
+| **Circular** | `rounded-full` | — | *identity* avatar (see the design system), switch, badge, status dot, progress bar, step bubble, color swatch, decorative empty-state icon bubble |
 | **Chart mark** | `rounded-[2px]` | 2 | chart swatches, legend squares, thin bar segments, tooltip arrow (≤ 10px marks) |
 
 The ladder is **concentric**: at every nesting step, the parent's radius equals the child's radius

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -20,7 +20,7 @@ src/
   features/         Domain slices: api.ts + hooks.ts per feature
   components/
     layout/         AppSidebar, AppLayout
-    ui/             shadcn/ui — DO NOT EDIT
+    ui/             shadcn/ui — generated, don't edit (one exception below)
     shared/         App-specific reusable (PageHeader, etc.)
   stores/           Zustand (auth-store, app-store)
   lib/              api-client.ts, utils.ts, constants.ts, query-client.ts
@@ -41,4 +41,20 @@ src/
 
 ## Conventions
 
-Full conventions (styling, icons, i18n, charts, state management details): see [`docs/conventions/frontend.md`](../docs/conventions/frontend.md)
+**Design — read first for any UI work:** [`docs/conventions/design-system.md`](../docs/conventions/design-system.md).
+The radius ladder, color tokens, type scale, spacing, elevation, motion, the component-picking
+table, the four data states, a11y, and the conformance greps. Compose the primitives and inherit —
+a class that sets radius/height/font-size/color on something a primitive already renders is a
+finding.
+
+**The one sanctioned edit inside `components/ui/`:** an **app-wide, on-scale** standard ratified in
+an ADR and written down in the design system — today that is only the radius ladder
+([ADR 2026-08-10](../docs/decisions/2026-08-10-ui-radius-ladder.md)), which assigns a rung to
+`button`, `input`, `input-otp`, `item`, `tabs`, `dropdown-menu`, `tooltip`, `chart`, `empty`,
+`partition-bar`, `progress` and `dialog`. A one-screen tweak never qualifies. Because these are
+generated files, **`shadcn add <component>` resets the rung — re-apply it from the ladder** rather
+than accepting the regenerated default. Everything else in `ui/` stays untouched: customize via the
+theme tokens in `index.css` or the shadcn CLI.
+
+**Code — state, hooks, API layer, routing, i18n wiring, types:**
+[`docs/conventions/frontend.md`](../docs/conventions/frontend.md)

--- a/frontend/src/demo/data/accounts.ts
+++ b/frontend/src/demo/data/accounts.ts
@@ -128,6 +128,7 @@ export const mockAccounts: Account[] = [
     color: '#a855f7',
     ticker: null,
     logoUrl: null,
+    logoKey: null,
     createdAt: '2023-06-01T08:00:00Z',
     realEstate: {
       purchasePrice: 320000,


### PR DESCRIPTION
> **Split from #87 on purpose.** `CODING_RULES.md` rule 0 forbids relaxing a convention in the same diff as the deviation the relaxation would legitimise — and this *does* relax one. Devin flagged it on #87 and the prescription is to land the rule change on its own, ratified for its own sake. This is that PR. #87 now carries only the code that conforms to it.
>
> **Stacked on #88** (one-line build fix on `main`) so CI is green; that commit disappears from this diff once #88 merges.

## The rule change under review

`CODING_RULES.md` rule 1 — *never hand-edit `components/ui/`* — gains **one** exception: an **app-wide, on-scale** standard that is ratified in an ADR and written into the convention. The radius ladder is the only instance; a one-screen tweak never qualifies. That is the substantive thing to accept or reject here. Everything else follows from it.

Why the exception is needed: there is no token knob for "controls use `lg` instead of `md`". `--radius` scales every rung together, so the *relative* mismatch it was meant to fix survives. Tier assignment is inherently per-primitive. The alternatives (leave primitives alone / lower the cards / raise `--radius`) are each weighed in the ADR, with the cost recorded — divergence from stock shadcn, and `shadcn add` resetting the rung.

## Two problems, one root cause

[ADR 2026-07-12](https://github.com/Zoeille/picsou-finance/blob/main/docs/decisions/2026-07-12-ui-controls-follow-shadcn-theme-radius.md) assigned rungs to *controls* only. Everything between a control and a card was unspecified, so each page picked:

| Element | Radii found in `frontend/src` |
|---|---|
| Inline alert strip | `md` (8), `lg` (10), `xl` (14) |
| Segmented control wrapper + item | `2xl`+`xl`, `lg`+`md`, or bare `md` with no wrapper |
| Select / text input | `md` (8) from the primitive, `xl` (14) hand-written |
| Code-copy value row | `rounded` (4), `lg` (10), `xl` (14) |
| Checkbox | `rounded` (4), `sm` (6), `md` (8) |
| Buttons | 34 surviving `rounded-full` overrides |

That ADR predicted the failure mode — *"we accept relying on the convention Don'ts and review to catch these"* — and those 34 pills are the measurement of how well it held.

The same gap was open on **every other visual axis**, because nothing told an author which color token, type rung, spacing step, elevation or component to reach for: 18 uses of `green-*` next to 45 of `emerald-*` for one signal, `shadow-*` mixed with `ring-1` for one job, hand-built controls beside the primitives that already exist.

## What lands

- **[ADR 2026-08-10](https://github.com/Zoeille/picsou-finance/blob/docs/ui-radius-ladder/docs/decisions/2026-08-10-ui-radius-ladder.md)** supersedes 2026-07-12 — a rung for every element, not just controls. Its principles carry over unchanged: no pills, shape derives from `--radius`, app code never re-shapes a control. Cards stay `rounded-4xl`; the previous ADR records that as deliberate, so controls move up to meet them rather than the reverse.
- **[`conventions/design-system.md`](https://github.com/Zoeille/picsou-finance/blob/docs/ui-radius-ladder/docs/conventions/design-system.md)** — new, and now the single visual authority: one rule (compose and inherit), tokens (shape/color/type/spacing/elevation/motion/icons), layout, the four data states every surface owes, a11y, an "I need to build X → use Y" table, grep-able don'ts, conformance checks.

Two things keep it honest:

- **Every number is measured, not invented** — the type scale, spacing band, icon sizes and elevation values are what the codebase actually uses (`text-sm` ×339, `size-4` ×82, `ring-1 ring-foreground/10`). It describes Picsou, not a generic design system.
- **§11 lists the five known deviations** — `PageHeader`'s off-scale `text-[28px]` and inline font weights, `transition-all` in four vendor files, the emerald/green split, the dead `ui/sidebar.tsx`, `ErrorState`'s hardcoded English — so the next author doesn't copy drift believing it's the rule.

**No second source of truth:** the design half of `conventions/frontend.md` is *moved*, not copied; it keeps only code-level concerns. Wired into `CODING_RULES.md` 1–2, `INDEX.md`, `CLAUDE.md`, `AGENTS.md` and `frontend/CLAUDE.md` — whose `ui/ — DO NOT EDIT` quick-ref would otherwise tell a reader to revert the ladder after `shadcn add` regenerates a primitive (Devin's other finding on #87).

## Scope

**No code changes of its own.** The one file under `frontend/src/` in this diff is the single-line `logoKey: null` from the stacked #88 build fix — it disappears from here the moment #88 merges. Everything this PR actually adds is documentation.

The sweep that applies the ladder to the codebase is #87, which should merge after this. All relative doc links verified to resolve.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added comprehensive design-system guidance covering UI shape, spacing, typography, colors, accessibility, layouts, states, charts, and component usage.
  - Documented a unified radius ladder for surfaces, panels, rows, controls, micro elements, and circular elements.
  - Updated frontend conventions, decision records, feature documentation, and navigation guidance to reflect the new standards.
  - Marked the previous control-radius decision as superseded and added the replacement decision record.

- **Chores**
  - Standardized mock account data to explicitly represent accounts without logos.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->