### PR TITLE
fix(demo): restore the frontend build broken by a semantic merge conflict

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,7 @@
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "format": "prettier --write \"**/*.{ts,tsx}\"",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc -b --noEmit",
     "test": "vitest run",
     "preview": "vite preview",
     "test:e2e": "playwright test"

--- a/frontend/src/demo/data/accounts.ts
+++ b/frontend/src/demo/data/accounts.ts
@@ -128,6 +128,7 @@ export const mockAccounts: Account[] = [
     color: '#a855f7',
     ticker: null,
     logoUrl: null,
+    logoKey: null,
     createdAt: '2023-06-01T08:00:00Z',
     realEstate: {
       purchasePrice: 320000,


### PR DESCRIPTION
`main` is currently red: the **Build & publish Docker images** run for #82 ([`183270f`](https://github.com/Zoeille/picsou-finance/commit/183270f)) fails at `RUN bun run build`, so no image was pushed.

```
src/demo/data/accounts.ts(116,3): error TS2741: Property 'logoKey' is missing ... but required in type 'Account'
```

### What happened

A semantic conflict, not a textual one. #83 made `logoKey` a required field on `Account` and filled it on all seven demo accounts. #82 had branched before that and added an eighth (the `REAL_ESTATE` demo property). The two sides never touched the same lines, so git merged them cleanly — into a tree that doesn't typecheck.

### Why CI didn't catch it

`typecheck` was `tsc --noEmit`, run against the root `frontend/tsconfig.json` — a *solution* file (`"files": []` plus `references`). Without `-b`, TypeScript doesn't follow project references, so **the step checked zero files** and exited 0 on every PR and every push. Only the Docker build, which uses `tsc -b`, was ever typechecking the app.

Demonstrated by stripping the `logoKey` lines and running both scripts on this branch:

| script | result |
| --- | --- |
| `tsc --noEmit` (old) | exit **0**, no output |
| `tsc -b --noEmit` (new) | exit **2**, all 7 errors reported |

### Changes

- `frontend/src/demo/data/accounts.ts` — `logoKey: null` on the demo property. `null` rather than a bundled key: `logoKey` selects a bank/broker asset from `lib/provider-logos.ts`, while real-estate cards get their glyph from `lib/property-icons.ts`.
- `frontend/package.json` — `typecheck` → `tsc -b --noEmit`, so the CI step covers the same files as the image build.

`Account.logoKey` deliberately stays required — it mirrors a backend DTO field that's always serialized; the demo fixture was the outlier.

### Verification

- `docker build -f docker/Dockerfile .` — full app image builds, exit 0 (frontend *and* backend stages)
- `bun run typecheck` — exit 0; reproduces the 7 errors when the fields are removed
- `bun run lint` — exit 0
- `bun run test` — 208 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved type-checking reliability during development and builds.

* **Bug Fixes**
  * Updated demo real-estate account data to handle accounts without a logo.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->