### PR TITLE
fix(ui): fix illegible dropdown options in dark mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -191,6 +191,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Dropdown options were unreadable in dark mode.** Native `<select>` popups
+  (account type, currency, bank country, CSV import mapping, property type…)
+  don't honour a translucent background — the browser falls back to an opaque
+  white popup while the option text stayed the light color meant for a dark
+  background, making the list nearly invisible. Every select now uses an
+  opaque background/text pair plus a `color-scheme` hint so the native popup
+  renders legibly in both themes.
 - **A PEA held through ETFs could display 0 €, graph included.** Picsou asked OpenFIGI
   which listings an ISIN maps to and picked one by exchange priority — but OpenFIGI
   returns every listing of an instrument and knows nothing about which one Yahoo quotes,

--- a/frontend/src/components/property/AddPropertyModal.tsx
+++ b/frontend/src/components/property/AddPropertyModal.tsx
@@ -32,7 +32,7 @@ const CATEGORIES: PropertyCategory[] = [
 ]
 
 const selectControlClassName =
-  'flex h-10 w-full rounded-md border border-input bg-input/20 px-4 text-sm outline-none dark:bg-input/30'
+  'flex h-10 w-full rounded-md border border-input bg-background text-foreground px-4 text-sm outline-none [color-scheme:light] dark:[color-scheme:dark]'
 
 const num = (v: string): number | undefined => (v.trim() === '' ? undefined : parseAmount(v))
 

--- a/frontend/src/components/property/PropertyMetadataForm.tsx
+++ b/frontend/src/components/property/PropertyMetadataForm.tsx
@@ -55,7 +55,7 @@ const propertySchema = z.object({
 type PropertyFormData = z.infer<typeof propertySchema>
 
 const selectControlClassName =
-  'flex h-10 w-full rounded-md border border-input bg-input/20 px-4 text-sm outline-none dark:bg-input/30'
+  'flex h-10 w-full rounded-md border border-input bg-background text-foreground px-4 text-sm outline-none [color-scheme:light] dark:[color-scheme:dark]'
 
 const PROPERTY_KINDS = ['HOUSE', 'APARTMENT', 'BUILDING', 'LAND', 'PARKING', 'COMMERCIAL'] as const
 const CATEGORIES = ['PRIMARY_RESIDENCE', 'SECONDARY_RESIDENCE', 'RENTAL', 'LAND', 'OTHER'] as const

--- a/frontend/src/components/shared/AccountForm.tsx
+++ b/frontend/src/components/shared/AccountForm.tsx
@@ -98,7 +98,7 @@ const EMPTY_DEFAULTS: AccountFormData = {
   endDate: '',
 }
 
-const selectControlClassName = "flex h-10 w-full rounded-xl border border-input bg-input/20 px-4 text-sm outline-none dark:bg-input/30"
+const selectControlClassName = "flex h-10 w-full rounded-xl border border-input bg-background text-foreground px-4 text-sm outline-none [color-scheme:light] dark:[color-scheme:dark]"
 
 export function AccountForm({ open, onOpenChange, onSubmit, defaultValues, title, loading, accounts = [] }: AccountFormProps) {
   const { t } = useTranslation()

--- a/frontend/src/components/shared/AddAccountModal.tsx
+++ b/frontend/src/components/shared/AddAccountModal.tsx
@@ -1242,7 +1242,7 @@ function FinaryWizard({ onDone, onBack }: { onDone: () => void; onBack: () => vo
 
                 {mappings[index]?.action === 'MAP_EXISTING' && (
                   <select
-                    className="h-10 w-full rounded-xl border border-input bg-input/20 px-4 text-sm outline-none dark:bg-input/30"
+                    className="h-10 w-full rounded-xl border border-input bg-background text-foreground px-4 text-sm outline-none [color-scheme:light] dark:[color-scheme:dark]"
                     value={mappings[index].targetAccountId ?? ''}
                     onChange={(e) => {
                       const val = e.target.value
@@ -1270,7 +1270,7 @@ function FinaryWizard({ onDone, onBack }: { onDone: () => void; onBack: () => vo
                     <div className="space-y-1">
                       <Label>{t('sync.exchanges.type')}</Label>
                       <select
-                        className="h-10 w-full rounded-xl border border-input bg-input/20 px-4 text-sm outline-none dark:bg-input/30"
+                        className="h-10 w-full rounded-xl border border-input bg-background text-foreground px-4 text-sm outline-none [color-scheme:light] dark:[color-scheme:dark]"
                         value={mappings[index].newAccount!.type}
                         onChange={(e) => updateNewAccountField(index, 'type', e.target.value)}
                       >

--- a/frontend/src/components/shared/BankCountrySelect.tsx
+++ b/frontend/src/components/shared/BankCountrySelect.tsx
@@ -56,7 +56,7 @@ export function BankCountrySelect({ value, onChange }: BankCountrySelectProps) {
         value={value}
         onChange={(e) => onChange(e.target.value)}
         aria-label={t('sync.banks.country')}
-        className="h-10 rounded-md border border-input bg-input/20 px-4 text-sm outline-none dark:bg-input/30"
+        className="h-10 rounded-md border border-input bg-background text-foreground px-4 text-sm outline-none [color-scheme:light] dark:[color-scheme:dark]"
       >
         {options.map((o) => (
           <option key={o.code} value={o.code}>{o.label}</option>

--- a/frontend/src/components/shared/ImportTransactionsModal.tsx
+++ b/frontend/src/components/shared/ImportTransactionsModal.tsx
@@ -34,7 +34,7 @@ const MAPPING_FIELDS: { key: MappingField; optional: boolean }[] = [
 ]
 
 const SELECT_CLASS =
-  'flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm focus:outline-none focus:ring-1 focus:ring-ring'
+  'flex h-9 w-full rounded-md border border-input bg-background text-foreground px-3 py-1 text-sm shadow-sm focus:outline-none focus:ring-1 focus:ring-ring [color-scheme:light] dark:[color-scheme:dark]'
 
 export function ImportTransactionsModal({ open, onOpenChange, accountId }: ImportTransactionsModalProps) {
   const { t } = useTranslation()

--- a/frontend/src/pages/sync/FinaryTab.tsx
+++ b/frontend/src/pages/sync/FinaryTab.tsx
@@ -667,7 +667,7 @@ function MappingCard({
 
         {mapping.action === 'MAP_EXISTING' && (
           <select
-            className="h-10 w-full rounded-xl border border-input bg-input/20 px-4 text-sm outline-none dark:bg-input/30"
+            className="h-10 w-full rounded-xl border border-input bg-background text-foreground px-4 text-sm outline-none [color-scheme:light] dark:[color-scheme:dark]"
             value={mapping.targetAccountId ?? ''}
             onChange={(e) => {
               const val = e.target.value
@@ -698,7 +698,7 @@ function MappingCard({
             <div className="space-y-1">
               <Label>{t('sync.exchanges.type')}</Label>
               <select
-                className="h-10 w-full rounded-xl border border-input bg-input/20 px-4 text-sm outline-none dark:bg-input/30"
+                className="h-10 w-full rounded-xl border border-input bg-background text-foreground px-4 text-sm outline-none [color-scheme:light] dark:[color-scheme:dark]"
                 value={mapping.newAccount.type}
                 onChange={(e) => onNewAccountField('type', e.target.value)}
               >


### PR DESCRIPTION
## Summary
- Native `<select>` popups don't render translucent backgrounds
  (`bg-input/20`, `bg-input/30`) opaquely — the browser falls back to a
  white popup while the option text kept the light color meant for a dark
  background, making the list nearly invisible in dark mode.
- Switched every select in the app (account type, currency, bank country,
  CSV import mapping, property type/category/energy class, Finary account
  mapping) to the opaque `bg-background`/`text-foreground` tokens, plus a
  `color-scheme` hint so the browser's native popup chrome matches the
  active theme.

## Test plan
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [x] `bunx vitest run` — 261/261 passing
- [x] `bun run build` passes
- [x] Verified visually in demo mode (`VITE_DEMO_MODE=true`): account type
      and currency dropdowns in the manual-account form are legible in
      dark mode
- [ ] `bun run test:e2e` — 13/15 fail on this branch, but the same 13 fail
      identically on `main` with no changes applied (verified via a
      separate worktree). Pre-existing flakiness unrelated to this change,
      not something this PR introduces or fixes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved readability of dropdown options in dark mode with theme-aware backgrounds and text colors.
  * Updated property, account, country, transaction, and account-mapping selectors for consistent light and dark theme appearance.
  * Added appropriate color-scheme handling to prevent transparent or low-contrast native dropdown menus.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->