### PR TITLE
fix(amundi): key holdings on codeFonds when codeIsin is not an ISIN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **An Amundi account holding two share classes of the same fund now syncs.**
+  Amundi does not always put an ISIN in `codeIsin` — on employer funds it holds
+  the AMF code — so the holding was keyed on a slug of the fund label, capped at
+  30 characters. Two share classes of one fund differ only in their last word, so
+  both truncated to the same key, the collision guard correctly refused to merge
+  two different funds, and the entire sync failed with `INVALID_DATA` on a
+  payload that was perfectly valid. The line's own `codeFonds` is now used
+  between the ISIN and the label, and the guard stays behind it.
+
 ### Added
 
 - **The French regulated passbooks each get their own account type.** Livret A,

--- a/backend/src/main/java/com/picsou/port/AmundiPort.java
+++ b/backend/src/main/java/com/picsou/port/AmundiPort.java
@@ -27,7 +27,7 @@ public interface AmundiPort {
      * salariale funds are French-domiciled and quoted in euros, and Amundi
      * reports the valuation itself rather than leaving it to be recomputed.
      */
-    record Position(String isin, String label, BigDecimal quantity,
+    record Position(String isin, String fundCode, String label, BigDecimal quantity,
                     BigDecimal unitValue, BigDecimal valueEur, BigDecimal pnlEur) {}
 
     /** One dispositif -- a PEG, PERCO, PER... -- and the lines held inside it. */

--- a/backend/src/main/java/com/picsou/service/AmundiSyncService.java
+++ b/backend/src/main/java/com/picsou/service/AmundiSyncService.java
@@ -612,9 +612,20 @@ public class AmundiSyncService {
 
     /**
      * FCPEs are not in OpenFIGI's universe and Yahoo cannot quote them, so no
-     * conversion is attempted: the ISIN is the ticker. Employer share funds
-     * sometimes carry no ISIN at all, and those fall back to their label --
-     * {@link #mergePositions} refuses to fuse two funds should that collide.
+     * conversion is attempted: the ISIN is the ticker when there is one.
+     *
+     * <p>There often is not. `codeIsin` carries the AMF code on employer funds
+     * (`990000093539`), which is not an ISIN and is rejected here. Falling
+     * straight to the label is what made that expensive: the slug is truncated to
+     * {@value #MAX_TICKER_LENGTH} characters, and two share classes of one fund
+     * differ only in their last word -- "EPARGNE SOLIDAIRE DYNAMIQUE THALES - A"
+     * and "- B" both slug to `EPARGNE-SOLIDAIRE-DYNAMIQUE-TH`. {@link
+     * #mergePositions} then correctly refuses to fuse them, and the whole sync
+     * fails on a payload that is perfectly valid.
+     *
+     * <p>So the fund's own `codeFonds` is tried first: short, stable, and unique
+     * per fund. The label stays as the last resort, and the collision guard in
+     * {@link #mergePositions} stays behind it.
      */
     private String resolveTicker(AmundiPort.Position position) {
         String isin = clean(position.isin());
@@ -624,16 +635,30 @@ public class AmundiSyncService {
                 return isin;
             }
         }
-        String label = clean(position.label());
+        String fundCode = slug(position.fundCode());
+        if (fundCode != null) {
+            return fundCode;
+        }
+        String label = slug(position.label());
         if (label == null) {
             throw error(AmundiErrorCode.INVALID_DATA, "Amundi returned a fund without any identifier", null);
         }
-        String fallback = label.toUpperCase(Locale.ROOT).replaceAll("[^A-Z0-9]+", "-");
-        fallback = fallback.replaceAll("^-+|-+$", "");
-        if (fallback.isEmpty()) {
-            throw error(AmundiErrorCode.INVALID_DATA, "Amundi returned a fund without any identifier", null);
+        return label;
+    }
+
+    /** Uppercase alphanumeric slug, capped at {@value #MAX_TICKER_LENGTH}, or null if nothing is left. */
+    private String slug(String value) {
+        String cleaned = clean(value);
+        if (cleaned == null) {
+            return null;
         }
-        return fallback.length() <= MAX_TICKER_LENGTH ? fallback : fallback.substring(0, MAX_TICKER_LENGTH);
+        String slug = cleaned.toUpperCase(Locale.ROOT)
+            .replaceAll("[^A-Z0-9]+", "-")
+            .replaceAll("^-+|-+$", "");
+        if (slug.isEmpty()) {
+            return null;
+        }
+        return slug.length() <= MAX_TICKER_LENGTH ? slug : slug.substring(0, MAX_TICKER_LENGTH);
     }
 
     private String clean(String value) {

--- a/backend/src/test/java/com/picsou/service/AmundiSyncServiceTest.java
+++ b/backend/src/test/java/com/picsou/service/AmundiSyncServiceTest.java
@@ -268,6 +268,49 @@ class AmundiSyncServiceTest {
     }
 
     @Test
+    void theFundCodeKeysTheHoldingWhenCodeIsinIsNotAnIsin() {
+        // Amundi puts the AMF code in codeIsin on employer funds.
+        arrangeCommittableSync(plan(position(
+            "990000093539", "4256", "Epargne Solidaire Dynamique ACME - A", "10", "100", "1000", "0"
+        )));
+
+        service.queueSync(7L);
+
+        verify(holdingRepository).saveAll(holdingsCaptor.capture());
+        assertThat(holdingsCaptor.getValue().getFirst().getTicker()).isEqualTo("4256");
+    }
+
+    @Test
+    void twoShareClassesSharingATruncatedLabelAreKeptApartByTheirFundCode() {
+        // Regression: both labels slug to the same 30 characters, so keying on the
+        // label refused this payload outright -- the share class is the last word.
+        String sharedPrefix = "Epargne Solidaire Dynamique ACME -";
+        arrangeCommittableSync(plan("2000",
+            position("990000093539", "4256", sharedPrefix + " A", "10", "100", "1000", "0"),
+            position("990000097329", "4286", sharedPrefix + " B", "10", "100", "1000", "0")
+        ));
+
+        service.queueSync(7L);
+
+        verify(holdingRepository).saveAll(holdingsCaptor.capture());
+        assertThat(holdingsCaptor.getValue())
+            .extracting(AccountHolding::getTicker)
+            .containsExactlyInAnyOrder("4256", "4286");
+    }
+
+    @Test
+    void aRealIsinStillWinsOverTheFundCode() {
+        arrangeCommittableSync(plan(position(
+            "FR0010405035", "4256", "Amundi Label Actions Solidaires", "10", "100", "1000", "0"
+        )));
+
+        service.queueSync(7L);
+
+        verify(holdingRepository).saveAll(holdingsCaptor.capture());
+        assertThat(holdingsCaptor.getValue().getFirst().getTicker()).isEqualTo("FR0010405035");
+    }
+
+    @Test
     void theSameFundListedTwiceIsMerged() {
         arrangeCommittableSync(plan("2000",
             position("FR0010405035", "Fonds", "10", "100", "1000", "100"),
@@ -499,8 +542,16 @@ class AmundiSyncServiceTest {
     private AmundiPort.Position position(
         String isin, String label, String quantity, String unitValue, String valueEur, String pnlEur
     ) {
+        return position(isin, null, label, quantity, unitValue, valueEur, pnlEur);
+    }
+
+    private AmundiPort.Position position(
+        String isin, String fundCode, String label,
+        String quantity, String unitValue, String valueEur, String pnlEur
+    ) {
         return new AmundiPort.Position(
             isin,
+            fundCode,
             label,
             new BigDecimal(quantity),
             unitValue == null ? null : new BigDecimal(unitValue),

--- a/docs/features/amundi-epargne-salariale.md
+++ b/docs/features/amundi-epargne-salariale.md
@@ -1,6 +1,6 @@
 # Feature: Amundi Épargne Salariale sync
 
-> Last updated: 2026-08-09
+> Last updated: 2026-08-24
 
 ## Context
 
@@ -42,7 +42,9 @@ listPositionsSalarieDispositifsDto[]          one entry per plan (dispositif)
   ├─ nomEntreprise                            employer
   ├─ mtBrut                                   plan total, EUR
   └─ positionsSalarieFondsDto[]               the plan's FUND CATALOGUE
-       ├─ libelleFonds, codeIsin              (always present)
+       ├─ libelleFonds, codeIsin, codeFonds   (always present -- but codeIsin
+       │                                       holds the AMF code on employer
+       │                                       funds, hence codeFonds)
        ├─ nbParts, vl                         units, unit value  ─┐ null unless
        ├─ mtBrut                              line valuation      ├ the fund is
        └─ mtPMV                               unrealized P&L     ─┘ actually held
@@ -140,9 +142,16 @@ See [the ADR](../decisions/2026-08-09-amundi-epargne-salariale-sidecar.md).
   `(mtBrut − mtPMV) / nbParts`. When Amundi reports no `mtPMV` the average buy-in
   is left null and the invested amount falls back to the plan total, rather than
   inventing a gain out of a missing field.
-- **Employer share funds sometimes have no ISIN.** Those fall back to a ticker
-  derived from the label. Two different funds whose labels collide on that
-  fallback are refused (`INVALID_DATA`) instead of being merged into one.
+- **`codeIsin` is not always an ISIN.** On employer funds Amundi puts the AMF
+  code there (`990000093539`), which fails the `[A-Z]{2}[A-Z0-9]{9}[0-9]` check.
+  The ticker therefore falls to `codeFonds`, and only then to a slug of the
+  label. Keying straight on the label was a real failure, not a theoretical one:
+  the slug is capped at 30 characters and two share classes of one fund differ
+  only in their last word, so `... THALES - A` and `... - B` both truncate to
+  `EPARGNE-SOLIDAIRE-DYNAMIQUE-TH` and the sync refused the whole account.
+  Two different funds still colliding on the label fallback are refused
+  (`INVALID_DATA`) rather than merged — that guard sits behind the cascade, not
+  in front of it.
 - **`positionsSalarieFondsDto` is a catalogue, not a portfolio.** It lists every
   fund the dispositif *offers*; one the employee does not hold carries nulls
   throughout. On the validation account 275 of 283 lines were catalogue entries,

--- a/services/amundi-auth/main.py
+++ b/services/amundi-auth/main.py
@@ -165,6 +165,7 @@ class PositionPayload(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     isin: str | None = Field(default=None, max_length=12)
+    fundCode: str | None = Field(default=None, max_length=20)
     label: str = Field(min_length=1, max_length=200)
     quantity: Decimal
     unitValue: Decimal | None = None

--- a/services/amundi-auth/positions_parser.py
+++ b/services/amundi-auth/positions_parser.py
@@ -130,6 +130,10 @@ def _parse_position(raw: Any) -> dict[str, Any] | None:
     isin = text_value(raw.get("codeIsin"), 12)
     return {
         "isin": isin.upper() if isin else None,
+        # Amundi's own identifier for the fund. Carried because `codeIsin` is not
+        # always an ISIN -- on employer funds it can hold the AMF code instead --
+        # and the backend then has nothing left but the label to key a holding on.
+        "fundCode": text_value(raw.get("codeFonds"), 20),
         "label": label,
         "quantity": quantity,
         "unitValue": decimal_value(raw.get("vl")),

--- a/services/amundi-auth/test_main.py
+++ b/services/amundi-auth/test_main.py
@@ -8,6 +8,7 @@ def fund(**overrides):
     line = {
         "libelleFonds": "Amundi Label Actions Solidaires",
         "codeIsin": "fr0010405035",
+        "codeFonds": "4256",
         "nbParts": 12.3456,
         "vl": 100.0,
         "mtBrut": 1234.56,
@@ -83,10 +84,29 @@ class ParsePlansTest(unittest.TestCase):
 
         [line] = parsed["positions"]
         self.assertEqual(line["isin"], "FR0010405035")
+        self.assertEqual(line["fundCode"], "4256")
         self.assertEqual(line["quantity"], Decimal("12.3456"))
         self.assertEqual(line["unitValue"], Decimal("100.0"))
         self.assertEqual(line["valueEur"], Decimal("1234.56"))
         self.assertEqual(line["pnlEur"], Decimal("34.56"))
+
+    def test_the_fund_code_is_carried_even_when_codeisin_is_not_an_isin(self):
+        # Employer funds carry the AMF code in codeIsin. The backend rejects it,
+        # and codeFonds is then the only stable identifier the line still has.
+        [parsed] = parse_plans(payload(plan(positionsSalarieFondsDto=[
+            fund(codeIsin="990000093539", codeFonds="4256")
+        ])))
+
+        [line] = parsed["positions"]
+        self.assertEqual(line["fundCode"], "4256")
+
+    def test_a_line_without_a_fund_code_is_still_accepted(self):
+        [parsed] = parse_plans(payload(plan(positionsSalarieFondsDto=[
+            fund(codeFonds=None)
+        ])))
+
+        [line] = parsed["positions"]
+        self.assertIsNone(line["fundCode"])
 
     def test_id_falls_back_to_iddispositif(self):
         [parsed] = parse_plans(payload(plan(codeDispositif=None, idDispositif="42")))


### PR DESCRIPTION
Amundi puts the AMF code in codeIsin on employer funds (990000093539), so resolveTicker rejected it and fell straight to a slug of the fund label, truncated to 30 characters. Two share classes of one fund differ only in their last word, so both slugged to EPARGNE-SOLIDAIRE-DYNAMIQUE-TH, mergePositions correctly refused to fuse two different funds, and the whole sync failed with INVALID_DATA on a valid payload.

Carry the line's own codeFonds through the sidecar contract and try it between the ISIN and the label. The label fallback and the collision guard behind it are unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Amundi holdings synchronization for funds with multiple share classes.
  * Fund identifiers are now prioritized correctly, preventing similarly named holdings from being merged or rejected.
  * Employer-fund holdings now sync correctly even when their identifier is not a standard ISIN.
* **Documentation**
  * Updated Amundi synchronization guidance to explain identifier handling and known naming limitations.
  * Refreshed the feature documentation date and payload details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->