### PR TITLE
fix(transactions): disambiguate multi-year dates

### DIFF
--- a/docs/features/manual-transactions.md
+++ b/docs/features/manual-transactions.md
@@ -1,6 +1,6 @@
 # Feature: Manual Transactions
 
-> Last updated: 2026-07-08
+> Last updated: 2026-08-27
 
 ## Context
 
@@ -111,7 +111,9 @@ All sync services (`FinaryPersistenceHelper`, `BoursoSyncService`) now call `tra
 **Investment accounts (PEA, COMPTE_TITRES, CRYPTO):**
 - Date, BUY/SELL toggle, **Ticker ou ISIN** (a ticker like `IWDA.AS` or a 12-char ISIN like `IE00B4L5Y983`), Name (auto-filled from existing holdings when the ticker matches; otherwise resolved from the ISIN backend-side), Quantity, Price per unit, **Fees (optional, folded into the PMP)**, Total (read-only)
 
-The Transactions list shows a "Manuel" badge on manual entries and a delete button (only for manual entries).
+The Transactions list groups rows by booking date. Headings stay compact for a single-year list;
+when the visible list spans multiple calendar years, every heading includes its year. It also shows
+a manual-entry badge and a delete button, both only on manual entries.
 
 After submit, `useAddTransaction` / `useDeleteTransaction` hooks invalidate the `transactions`, `history`, `account`, and `dashboard` queries.
 
@@ -131,7 +133,7 @@ After submit, `useAddTransaction` / `useDeleteTransaction` hooks invalidate the 
 | `backend/src/main/java/com/picsou/controller/AccountController.java` | POST/DELETE `/accounts/{id}/transactions` |
 | `backend/src/main/java/com/picsou/repository/TransactionRepository.java` | `deleteByAccountIdAndIsManualFalse`, `sumAmountByAccountId`, `findByAccountIdAndTxTypeInOrderByDateAsc` |
 | `frontend/src/components/shared/AddTransactionModal.tsx` | Account-type-aware form modal |
-| `frontend/src/components/shared/TransactionsList.tsx` | Manuel badge + delete button |
+| `frontend/src/components/shared/TransactionsList.tsx` | Date grouping with unambiguous historical years, manual badge, and delete button |
 | `frontend/src/features/accounts/hooks.ts` | `useAddTransaction`, `useDeleteTransaction` |
 
 ## Technical choices

--- a/frontend/src/components/shared/TransactionsList.test.tsx
+++ b/frontend/src/components/shared/TransactionsList.test.tsx
@@ -1,0 +1,55 @@
+import '@testing-library/jest-dom'
+import { describe, expect, it, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { TransactionsList } from './TransactionsList'
+import type { Transaction } from '@/types/api'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { language: 'fr', resolvedLanguage: 'fr' },
+  }),
+}))
+
+function transaction(overrides: Partial<Transaction>): Transaction {
+  return {
+    id: 1,
+    date: '2026-03-04',
+    description: 'Transaction',
+    amount: 10,
+    type: null,
+    category: null,
+    nativeCurrency: 'EUR',
+    isManual: false,
+    txType: null,
+    ticker: null,
+    name: null,
+    quantity: null,
+    pricePerUnit: null,
+    fees: null,
+    ...overrides,
+  }
+}
+
+describe('TransactionsList', () => {
+  it('keeps single-year date headings compact', () => {
+    render(<TransactionsList transactions={[transaction({ description: 'Single year' })]} />)
+
+    expect(screen.getByText('Single year')).toBeInTheDocument()
+    expect(screen.queryByText(/2026/)).not.toBeInTheDocument()
+  })
+
+  it('includes the year in every heading when the list spans multiple years', () => {
+    render(
+      <TransactionsList
+        transactions={[
+          transaction({ description: 'Recent transaction' }),
+          transaction({ id: 2, date: '2025-03-04', description: 'Older transaction' }),
+        ]}
+      />,
+    )
+
+    expect(screen.getByText(/2026/)).toBeInTheDocument()
+    expect(screen.getByText(/2025/)).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/shared/TransactionsList.tsx
+++ b/frontend/src/components/shared/TransactionsList.tsx
@@ -25,6 +25,7 @@ export function TransactionsList({ transactions, onDelete, onEdit }: Transaction
         tr.description.toLowerCase().includes(search.toLowerCase())
       )
     : transactions
+  const showYear = new Set(filtered.map(tr => tr.date.slice(0, 4))).size > 1
 
   // Group by date
   const grouped = filtered.reduce<Record<string, Transaction[]>>((acc, tr) => {
@@ -54,7 +55,7 @@ export function TransactionsList({ transactions, onDelete, onEdit }: Transaction
           <div key={date}>
             {dateIdx > 0 && <Separator className="my-3" />}
             <p className="mb-2 text-sm font-medium text-muted-foreground">
-              {formatTransactionDate(date, locale)}
+              {formatTransactionDate(date, locale, showYear)}
             </p>
             <div className="space-y-0.5">
               {grouped[date].map((tr, rowIdx) => (
@@ -114,11 +115,13 @@ export function TransactionsList({ transactions, onDelete, onEdit }: Transaction
   )
 }
 
-function formatTransactionDate(date: string, locale: string): string {
+function formatTransactionDate(date: string, locale: string, showYear: boolean): string {
+  const transactionDate = new Date(`${date}T00:00:00`)
   const label = new Intl.DateTimeFormat(locale, {
     weekday: 'short',
     day: 'numeric',
     month: 'short',
-  }).format(new Date(date))
+    ...(showYear ? { year: 'numeric' } : {}),
+  }).format(transactionDate)
   return label.charAt(0).toLocaleUpperCase(locale) + label.slice(1)
 }


### PR DESCRIPTION
## Summary

- keep single-year transaction headings compact
- show the year on every heading when the visible list spans multiple calendar years
- parse date-only values at local midnight to avoid timezone date shifts
- document the behavior and cover it with focused component tests

## Validation

- bunx vitest run (39 files, 263 tests)
- bun run typecheck
- bun run lint
- bun run build

Closes #105

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Transaction lists now use compact date headings when all entries are from the same year.
  - When transactions span multiple years, headings include the year for clearer navigation.
  - Transaction dates are displayed consistently according to the local calendar date.

- **Documentation**
  - Updated the manual transactions documentation to describe date grouping, manual-entry labels, and available deletion controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->