### PR TITLE
fix(transactions): label dividend and fee fallbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -191,6 +191,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Dividend and fee transactions no longer look like purchases.** When a ticker has
+  no supplied or resolved name, Picsou now derives the French fallback description
+  from the transaction type. `DIVIDEND` uses `Dividende` and `FEE` uses `Frais`,
+  while buy and sell labels stay unchanged (#108).
 - **Dropdown options were unreadable in dark mode.** Native `<select>` popups
   (account type, currency, bank country, CSV import mapping, property type…)
   don't honour a translucent background — the browser falls back to an opaque

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -191,10 +191,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **Dividend and fee transactions no longer look like purchases.** When a ticker has
-  no supplied or resolved name, Picsou now derives the French fallback description
-  from the transaction type. `DIVIDEND` uses `Dividende` and `FEE` uses `Frais`,
-  while buy and sell labels stay unchanged (#108).
+- **Dividend and fee transactions no longer look like purchases.** When a manual
+  transaction has a ticker but no supplied or resolved name, the frontend now derives
+  its translated fallback label from `txType`. The backend persists only the canonical
+  ticker or instrument name, so descriptions no longer embed French UI text (#108).
 - **Dropdown options were unreadable in dark mode.** Native `<select>` popups
   (account type, currency, bank country, CSV import mapping, property type…)
   don't honour a translucent background — the browser falls back to an opaque

--- a/backend/src/main/java/com/picsou/imports/TransactionRowMapper.java
+++ b/backend/src/main/java/com/picsou/imports/TransactionRowMapper.java
@@ -64,7 +64,7 @@ public class TransactionRowMapper {
         }
 
         InstrumentFieldResolver.ResolvedInstrument instrument =
-            instrumentFieldResolver.resolve(cell(row, mapping.tickerOrIsin()), cell(row, mapping.name()), side);
+            instrumentFieldResolver.resolve(cell(row, mapping.tickerOrIsin()), cell(row, mapping.name()));
         if (instrument == null) {
             throw new IllegalArgumentException("Missing ticker/ISIN");
         }

--- a/backend/src/main/java/com/picsou/service/InstrumentFieldResolver.java
+++ b/backend/src/main/java/com/picsou/service/InstrumentFieldResolver.java
@@ -6,8 +6,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 /**
- * Resolves the instrument fields (ticker, display name, description) of a BUY/SELL
- * transaction from a raw ticker-or-ISIN input. Single source of truth shared by the
+ * Resolves the instrument fields (ticker, display name, description) of a transaction
+ * carrying a ticker or ISIN. Single source of truth shared by the
  * manual-entry service and the CSV importer, so an ISIN row and the equivalent ticker
  * row always collapse to the same position.
  *
@@ -22,19 +22,18 @@ public class InstrumentFieldResolver {
 
     private final OpenFigiIsinConverter openFigiIsinConverter;
 
-    /** Resolved instrument fields for a BUY/SELL transaction. */
     public record ResolvedInstrument(String ticker, String name, String description) {}
 
     /**
-     * Resolves the instrument fields for a BUY/SELL transaction.
+     * Resolves the instrument fields for a transaction carrying a ticker or ISIN.
      *
      * @param tickerOrIsin the raw ticker or ISIN input
      * @param userName     an optional user-supplied display name (wins over the resolved one)
-     * @param side         the transaction side, used to build the fallback description
+     * @param type         the transaction type, used to build the fallback description
      * @return the resolved fields, or {@code null} when the input is blank (a cash transaction,
      *         for which the caller keeps its own description/ticker/name).
      */
-    public ResolvedInstrument resolve(String tickerOrIsin, String userName, TransactionType side) {
+    public ResolvedInstrument resolve(String tickerOrIsin, String userName, TransactionType type) {
         if (tickerOrIsin == null || tickerOrIsin.isBlank()) {
             return null; // cash transaction — no instrument
         }
@@ -54,9 +53,16 @@ public class InstrumentFieldResolver {
             ? userName.trim()
             : resolvedName;
 
+        String fallbackLabel = type == null ? "Achat" : switch (type) {
+            case DEPOSIT, WITHDRAWAL, BUY -> "Achat";
+            case SELL -> "Vente";
+            case DIVIDEND -> "Dividende";
+            case FEE -> "Frais";
+        };
+
         String description = effectiveName != null
             ? effectiveName
-            : (side == TransactionType.SELL ? "Vente " : "Achat ") + resolvedTicker;
+            : fallbackLabel + " " + resolvedTicker;
 
         return new ResolvedInstrument(resolvedTicker, effectiveName, description);
     }

--- a/backend/src/main/java/com/picsou/service/InstrumentFieldResolver.java
+++ b/backend/src/main/java/com/picsou/service/InstrumentFieldResolver.java
@@ -1,20 +1,21 @@
 package com.picsou.service;
 
 import com.picsou.adapter.OpenFigiIsinConverter;
-import com.picsou.model.TransactionType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 /**
- * Resolves the instrument fields (ticker, display name, description) of a transaction
- * carrying a ticker or ISIN. Single source of truth shared by the
- * manual-entry service and the CSV importer, so an ISIN row and the equivalent ticker
- * row always collapse to the same position.
+ * Resolves the ticker, display name, and language-neutral description of a transaction
+ * carrying a ticker or ISIN. This is the single source of truth shared by the manual-entry
+ * service and the CSV importer, so an ISIN row and the equivalent ticker row always collapse
+ * to the same position.
  *
  * <p>When the input is an ISIN it is resolved (via OpenFIGI) to a Yahoo ticker + display
  * name, so an ISIN entry and the equivalent ticker entry merge into one position and Yahoo
  * pricing works. A user-supplied {@code name} always wins over the resolved one. The
- * description is owned here so a raw ISIN never surfaces in the row.
+ * persisted description contains the effective name or canonical ticker, so a raw ISIN never
+ * surfaces in the row. The frontend combines the transaction type with the ticker when it needs
+ * a localized fallback label.
  */
 @Component
 @RequiredArgsConstructor
@@ -22,6 +23,13 @@ public class InstrumentFieldResolver {
 
     private final OpenFigiIsinConverter openFigiIsinConverter;
 
+    /**
+     * Canonical instrument fields ready for persistence.
+     *
+     * @param ticker      the canonical ticker
+     * @param name        the resolved or user-supplied display name, when available
+     * @param description the display name, or the canonical ticker when no name is available
+     */
     public record ResolvedInstrument(String ticker, String name, String description) {}
 
     /**
@@ -29,11 +37,10 @@ public class InstrumentFieldResolver {
      *
      * @param tickerOrIsin the raw ticker or ISIN input
      * @param userName     an optional user-supplied display name (wins over the resolved one)
-     * @param type         the transaction type, used to build the fallback description
      * @return the resolved fields, or {@code null} when the input is blank (a cash transaction,
      *         for which the caller keeps its own description/ticker/name).
      */
-    public ResolvedInstrument resolve(String tickerOrIsin, String userName, TransactionType type) {
+    public ResolvedInstrument resolve(String tickerOrIsin, String userName) {
         if (tickerOrIsin == null || tickerOrIsin.isBlank()) {
             return null; // cash transaction — no instrument
         }
@@ -53,16 +60,9 @@ public class InstrumentFieldResolver {
             ? userName.trim()
             : resolvedName;
 
-        String fallbackLabel = type == null ? "Achat" : switch (type) {
-            case DEPOSIT, WITHDRAWAL, BUY -> "Achat";
-            case SELL -> "Vente";
-            case DIVIDEND -> "Dividende";
-            case FEE -> "Frais";
-        };
-
         String description = effectiveName != null
             ? effectiveName
-            : fallbackLabel + " " + resolvedTicker;
+            : resolvedTicker;
 
         return new ResolvedInstrument(resolvedTicker, effectiveName, description);
     }

--- a/backend/src/main/java/com/picsou/service/ManualTransactionService.java
+++ b/backend/src/main/java/com/picsou/service/ManualTransactionService.java
@@ -119,11 +119,12 @@ public class ManualTransactionService {
     /**
      * Normalizes the instrument fields of a transaction carrying a ticker or ISIN by
      * delegating to {@link InstrumentFieldResolver}. No-op for cash transactions with no
-     * ticker, preserving the caller's description.
+     * ticker, preserving the caller's description. Instrument descriptions stay language-neutral;
+     * {@code txType} in the API response lets the frontend render a localized fallback label.
      */
     private void applyInstrumentFields(Transaction tx, TransactionRequest req) {
         InstrumentFieldResolver.ResolvedInstrument resolved =
-            instrumentFieldResolver.resolve(req.ticker(), req.name(), tx.getTxType());
+            instrumentFieldResolver.resolve(req.ticker(), req.name());
         if (resolved == null) {
             return; // cash transaction — leave description/ticker/name as-is
         }

--- a/backend/src/main/java/com/picsou/service/ManualTransactionService.java
+++ b/backend/src/main/java/com/picsou/service/ManualTransactionService.java
@@ -117,9 +117,9 @@ public class ManualTransactionService {
     }
 
     /**
-     * Normalizes the instrument fields of a BUY/SELL transaction by delegating to
-     * {@link InstrumentFieldResolver}. No-op for cash transactions (they carry no ticker),
-     * preserving the caller's description.
+     * Normalizes the instrument fields of a transaction carrying a ticker or ISIN by
+     * delegating to {@link InstrumentFieldResolver}. No-op for cash transactions with no
+     * ticker, preserving the caller's description.
      */
     private void applyInstrumentFields(Transaction tx, TransactionRequest req) {
         InstrumentFieldResolver.ResolvedInstrument resolved =

--- a/backend/src/test/java/com/picsou/imports/TransactionRowMapperTest.java
+++ b/backend/src/test/java/com/picsou/imports/TransactionRowMapperTest.java
@@ -37,7 +37,7 @@ class TransactionRowMapperTest {
     }
 
     private void stubResolver() {
-        lenient().when(instrumentFieldResolver.resolve(any(), any(), any()))
+        lenient().when(instrumentFieldResolver.resolve(any(), any()))
             .thenReturn(new InstrumentFieldResolver.ResolvedInstrument("AAPL", "Apple", "Apple"));
     }
 
@@ -156,7 +156,7 @@ class TransactionRowMapperTest {
 
     @Test
     void blankTicker_throws() {
-        when(instrumentFieldResolver.resolve(any(), any(), any())).thenReturn(null);
+        when(instrumentFieldResolver.resolve(any(), any())).thenReturn(null);
         List<String> row = List.of("2024-01-15", "BUY", "", "10", "85.20", "1.00");
 
         assertThatThrownBy(() -> mapper.map(row, mappingWithPrice(), dialect, null, false, account))

--- a/backend/src/test/java/com/picsou/service/InstrumentFieldResolverTest.java
+++ b/backend/src/test/java/com/picsou/service/InstrumentFieldResolverTest.java
@@ -1,11 +1,8 @@
 package com.picsou.service;
 
 import com.picsou.adapter.OpenFigiIsinConverter;
-import com.picsou.model.TransactionType;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -24,8 +21,8 @@ class InstrumentFieldResolverTest {
 
     @Test
     void blankInput_returnsNull() {
-        assertThat(resolver.resolve(null, null, TransactionType.BUY)).isNull();
-        assertThat(resolver.resolve("   ", "X", TransactionType.SELL)).isNull();
+        assertThat(resolver.resolve(null, null)).isNull();
+        assertThat(resolver.resolve("   ", "X")).isNull();
         verify(openFigiIsinConverter, never()).resolve(any());
     }
 
@@ -35,7 +32,7 @@ class InstrumentFieldResolverTest {
             .thenReturn(new OpenFigiIsinConverter.TickerResult("IWDA.AS", "iShares Core MSCI World UCITS ETF"));
 
         InstrumentFieldResolver.ResolvedInstrument r =
-            resolver.resolve("IE00B4L5Y983", null, TransactionType.BUY);
+            resolver.resolve("IE00B4L5Y983", null);
 
         // ISIN normalized to the Yahoo ticker so positions merge and pricing works.
         assertThat(r.ticker()).isEqualTo("IWDA.AS");
@@ -45,13 +42,13 @@ class InstrumentFieldResolverTest {
     }
 
     @Test
-    void plainTicker_uppercasedNoResolveAndAchatDescription() {
+    void plainTicker_uppercasedNoResolveAndNeutralDescription() {
         InstrumentFieldResolver.ResolvedInstrument r =
-            resolver.resolve("iwda.as", null, TransactionType.BUY);
+            resolver.resolve("iwda.as", null);
 
         assertThat(r.ticker()).isEqualTo("IWDA.AS");
         assertThat(r.name()).isNull();
-        assertThat(r.description()).isEqualTo("Achat IWDA.AS");
+        assertThat(r.description()).isEqualTo("IWDA.AS");
         verify(openFigiIsinConverter, never()).resolve(any());
     }
 
@@ -61,29 +58,11 @@ class InstrumentFieldResolverTest {
             .thenReturn(new OpenFigiIsinConverter.TickerResult("IWDA.AS", "resolved name"));
 
         InstrumentFieldResolver.ResolvedInstrument r =
-            resolver.resolve("IE00B4L5Y983", "My World ETF", TransactionType.BUY);
+            resolver.resolve("IE00B4L5Y983", "My World ETF");
 
         assertThat(r.ticker()).isEqualTo("IWDA.AS");
         assertThat(r.name()).isEqualTo("My World ETF");
         assertThat(r.description()).isEqualTo("My World ETF");
     }
 
-    @Test
-    void sellSide_buildsVenteDescriptionWhenNoName() {
-        InstrumentFieldResolver.ResolvedInstrument r =
-            resolver.resolve("aapl", null, TransactionType.SELL);
-
-        assertThat(r.description()).isEqualTo("Vente AAPL");
-    }
-
-    @ParameterizedTest
-    @CsvSource({
-        "DIVIDEND, Dividende AAPL",
-        "FEE, Frais AAPL"
-    })
-    void fallbackDescription_reflectsTransactionType(TransactionType type, String expectedDescription) {
-        InstrumentFieldResolver.ResolvedInstrument r = resolver.resolve("aapl", null, type);
-
-        assertThat(r.description()).isEqualTo(expectedDescription);
-    }
 }

--- a/backend/src/test/java/com/picsou/service/InstrumentFieldResolverTest.java
+++ b/backend/src/test/java/com/picsou/service/InstrumentFieldResolverTest.java
@@ -4,6 +4,8 @@ import com.picsou.adapter.OpenFigiIsinConverter;
 import com.picsou.model.TransactionType;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -72,5 +74,16 @@ class InstrumentFieldResolverTest {
             resolver.resolve("aapl", null, TransactionType.SELL);
 
         assertThat(r.description()).isEqualTo("Vente AAPL");
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "DIVIDEND, Dividende AAPL",
+        "FEE, Frais AAPL"
+    })
+    void fallbackDescription_reflectsTransactionType(TransactionType type, String expectedDescription) {
+        InstrumentFieldResolver.ResolvedInstrument r = resolver.resolve("aapl", null, type);
+
+        assertThat(r.description()).isEqualTo(expectedDescription);
     }
 }

--- a/backend/src/test/java/com/picsou/service/ManualTransactionServiceTest.java
+++ b/backend/src/test/java/com/picsou/service/ManualTransactionServiceTest.java
@@ -379,6 +379,8 @@ class ManualTransactionServiceTest {
 
         TransactionResponse result = manualTransactionService.addTransaction(2L, 10L, req);
 
+        assertThat(result.txType()).isEqualTo(TransactionType.BUY);
+        assertThat(result.description()).isEqualTo("AAPL");
         assertThat(result.fees()).isEqualByComparingTo("1.50");
         verify(holdingComputeService).recomputeHoldings(account);
     }

--- a/backend/src/test/java/com/picsou/service/TransactionImportServiceTest.java
+++ b/backend/src/test/java/com/picsou/service/TransactionImportServiceTest.java
@@ -88,7 +88,7 @@ class TransactionImportServiceTest {
     @Test
     void executeImport_savesRowsAndRecomputesOnce() {
         when(accountRepository.findByIdAndMemberId(2L, 10L)).thenReturn(Optional.of(pea()));
-        when(instrumentFieldResolver.resolve(any(), any(), any()))
+        when(instrumentFieldResolver.resolve(any(), any()))
             .thenReturn(new InstrumentFieldResolver.ResolvedInstrument("AAPL", "Apple", "Apple"));
 
         String token = service.preview(2L, 10L, file(CSV)).fileToken();
@@ -110,7 +110,7 @@ class TransactionImportServiceTest {
     @Test
     void executeImport_reportsPerRowErrorsAndStillImportsValidRows() {
         when(accountRepository.findByIdAndMemberId(2L, 10L)).thenReturn(Optional.of(pea()));
-        when(instrumentFieldResolver.resolve(any(), any(), any()))
+        when(instrumentFieldResolver.resolve(any(), any()))
             .thenReturn(new InstrumentFieldResolver.ResolvedInstrument("AAPL", "Apple", "Apple"));
 
         // second data row has a non-numeric quantity → skipped, first row imported

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -61,7 +61,7 @@
 
 | Feature | Last updated | Note |
 |---------|-------------|------|
-| Internationalization (FR/EN/DE/ES) | 2026-07-07 | [i18n.md](./features/i18n.md) |
+| Internationalization (FR/EN/DE/ES) | 2026-09-02 | [i18n.md](./features/i18n.md) |
 | MCP server + scoped access-keys | 2026-06-05 | [mcp-server.md](./features/mcp-server.md) |
 | Frontend utilities (lib/utils.ts) | 2026-08-07 | [frontend-utils.md](./features/frontend-utils.md) |
 | Demo mode | 2026-04-08 | [demo-mode.md](./features/demo-mode.md) |
@@ -86,7 +86,7 @@
 | Finary import + auto-sync | 2026-04-21 | [finary-import.md](./features/finary-import.md) |
 | CSV transaction import (investment accounts) | 2026-07-11 | [csv-transaction-import.md](./features/csv-transaction-import.md) |
 | Realized P&L on closed positions | 2026-07-11 | [realized-pnl.md](./features/realized-pnl.md) |
-| Manual transactions + holdings derivation | 2026-04-21 | [manual-transactions.md](./features/manual-transactions.md) |
+| Manual transactions + holdings derivation | 2026-09-02 | [manual-transactions.md](./features/manual-transactions.md) |
 | BoursoBank sync | 2026-08-13 | [bourso-bank.md](./features/bourso-bank.md) |
 | Accounts overview (PnL chart + summary card + filters + card anatomy) | 2026-08-13 | [accounts-overview.md](./features/accounts-overview.md) |
 | Logos on account cards (catalog-resolved, bundled, wallet picker, property kind) | 2026-08-13 | [bank-logos.md](./features/bank-logos.md) |

--- a/docs/features/i18n.md
+++ b/docs/features/i18n.md
@@ -1,6 +1,6 @@
 # Feature: Internationalization (i18n)
 
-> Last updated: 2026-07-08
+> Last updated: 2026-09-02
 
 ## Context
 
@@ -18,6 +18,10 @@ A single registry, `SUPPORTED_LOCALES` in `frontend/src/i18n/locales.ts`, is the
 (The sidebar deliberately has no language item since the 2026-07 sidebar redesign — language lives in Settings.)
 
 Date/number/currency formatting: `frontend/src/i18n/index.ts` mirrors the active language into `<html lang>` on every `languageChanged` event; `getLocale()` in `frontend/src/lib/utils.ts` reads it and maps it to the registry's `intlLocale` (e.g. `de` → `de-DE`) for all `Intl.*` calls. Components that must re-render on a language switch (charts, `CurrencyDisplay`, `PageHeader`…) use `localeFromLanguage(i18n.resolvedLanguage ?? i18n.language)` with the `useTranslation()` hook instead.
+
+Manual instrument transactions keep language-neutral descriptions in the backend. When no
+instrument name exists, `TransactionsList` maps the API's `txType` enum to an `accounts.*`
+translation and appends the canonical ticker. Synced transactions keep their provider description.
 
 ### Key files
 

--- a/docs/features/manual-transactions.md
+++ b/docs/features/manual-transactions.md
@@ -1,6 +1,6 @@
 # Feature: Manual Transactions
 
-> Last updated: 2026-07-08
+> Last updated: 2026-08-31
 
 ## Context
 
@@ -62,7 +62,7 @@ On an investment account, the instrument field accepts **either** a Yahoo ticker
 
 - an ISIN entry and the equivalent ticker entry merge into a **single position** (the grouping key is the resolved ticker, not the raw input — this is what kills duplicate positions);
 - Yahoo pricing works (`YahooFinancePriceProvider` rejects raw ISINs);
-- the raw ISIN never surfaces in the transaction row — the service owns the `description` for BUY/SELL (see Gotchas).
+- the resolver owns the description when a ticker or ISIN is supplied. A successfully resolved ISIN is replaced by the Yahoo ticker and never appears in the row (see Gotchas).
 
 A user-supplied "Nom" always wins over the resolved name. The same logic runs for both add and edit (`addTransaction` and `updateTransaction` share `applyInstrumentFields`).
 
@@ -124,7 +124,7 @@ After submit, `useAddTransaction` / `useDeleteTransaction` hooks invalidate the 
 | `backend/src/main/java/com/picsou/model/TransactionType.java` | Enum (DEPOSIT, WITHDRAWAL, BUY, SELL, DIVIDEND, FEE) |
 | `backend/src/main/java/com/picsou/service/HoldingComputeService.java` | Derives holdings (qty, VWAP, **name**) from BUY/SELL transactions |
 | `backend/src/main/java/com/picsou/service/ManualTransactionService.java` | Orchestrates add/edit/delete + re-derivation; persists `fees`; delegates ISIN/ticker/description to `InstrumentFieldResolver` |
-| `backend/src/main/java/com/picsou/service/InstrumentFieldResolver.java` | Shared ISIN→ticker/name + BUY/SELL description builder (reused by the CSV importer) |
+| `backend/src/main/java/com/picsou/service/InstrumentFieldResolver.java` | Shared ISIN→ticker/name resolver and French fallback descriptions by transaction type (reused by the CSV importer) |
 | `backend/src/main/java/com/picsou/imports/TransactionAmountCalculator.java` | Single source of truth for the signed `amount` incl. fees |
 | `backend/src/main/resources/db/migration/V53__transaction_fees.sql` | Adds `transaction.fees` (folds into the PMP) |
 | `backend/src/main/java/com/picsou/adapter/OpenFigiIsinConverter.java` | `isIsin()` detection + `resolve()` ISIN→ticker+name (shared with bank sync) |
@@ -148,7 +148,7 @@ After submit, `useAddTransaction` / `useDeleteTransaction` hooks invalidate the 
 - **Investment account balance is NOT recomputed** from manual transactions. Only the holdings (positions) are derived. The account's `currentBalance` is set by the price scheduler (qty × live price). This is intentional for investment accounts.
 - **Synced transactions cannot be deleted**: The DELETE endpoint checks `isManual`. Attempting to delete a synced transaction returns 403.
 - **Holdings recomputation is full**: Every add/delete triggers a full re-derivation for that account (all tickers). This is fast in practice since investment accounts rarely have hundreds of tickers.
-- **The backend owns the investment description**: For BUY/SELL, `ManualTransactionService` sets the row `description` from the effective name, or `Achat {TICKER}` / `Vente {TICKER}` when no name exists — overriding whatever the client sent. This is what stops a raw ISIN (entered in the Ticker field with a blank Nom) from leaking into the transaction row. Cash transactions keep the client-supplied description.
+- **The backend owns ticker-based descriptions.** `ManualTransactionService` sets the row `description` from the effective name. If no name exists, it uses a French fallback matching the instrument transaction type (`Achat`, `Vente`, `Dividende`, or `Frais`) plus the ticker. This value replaces the client-supplied description. Cash transactions with no ticker keep the client-supplied description.
 
 ## Tests
 

--- a/docs/features/manual-transactions.md
+++ b/docs/features/manual-transactions.md
@@ -62,7 +62,9 @@ On an investment account, the instrument field accepts **either** a Yahoo ticker
 
 - an ISIN entry and the equivalent ticker entry merge into a **single position** (the grouping key is the resolved ticker, not the raw input — this is what kills duplicate positions);
 - Yahoo pricing works (`YahooFinancePriceProvider` rejects raw ISINs);
-- the resolver owns the description when a ticker or ISIN is supplied. A successfully resolved ISIN is replaced by the Yahoo ticker and never appears in the row (see Gotchas).
+- the resolver persists the resolved name or canonical ticker as a language-neutral description.
+  A successfully resolved ISIN is replaced by the Yahoo ticker and never appears in the row.
+  `TransactionResponse.txType` lets the frontend add the localized transaction label (see Gotchas).
 
 A user-supplied "Nom" always wins over the resolved name. The same logic runs for both add and edit (`addTransaction` and `updateTransaction` share `applyInstrumentFields`).
 
@@ -113,7 +115,9 @@ All sync services (`FinaryPersistenceHelper`, `BoursoSyncService`) now call `tra
 
 The Transactions list groups rows by booking date. Headings stay compact for a single-year list;
 when the visible list spans multiple calendar years, every heading includes its year. It also shows
-a manual-entry badge and a delete button, both only on manual entries.
+a manual-entry badge and a delete button, both only on manual entries. For manual instrument rows
+without a name, it combines the `txType` enum with the canonical ticker through frontend i18n.
+Provider descriptions on synced transactions remain unchanged.
 
 After submit, `useAddTransaction` / `useDeleteTransaction` hooks invalidate the `transactions`, `history`, `account`, and `dashboard` queries.
 
@@ -126,14 +130,14 @@ After submit, `useAddTransaction` / `useDeleteTransaction` hooks invalidate the 
 | `backend/src/main/java/com/picsou/model/TransactionType.java` | Enum (DEPOSIT, WITHDRAWAL, BUY, SELL, DIVIDEND, FEE) |
 | `backend/src/main/java/com/picsou/service/HoldingComputeService.java` | Derives holdings (qty, VWAP, **name**) from BUY/SELL transactions |
 | `backend/src/main/java/com/picsou/service/ManualTransactionService.java` | Orchestrates add/edit/delete + re-derivation; persists `fees`; delegates ISIN/ticker/description to `InstrumentFieldResolver` |
-| `backend/src/main/java/com/picsou/service/InstrumentFieldResolver.java` | Shared ISIN→ticker/name resolver and French fallback descriptions by transaction type (reused by the CSV importer) |
+| `backend/src/main/java/com/picsou/service/InstrumentFieldResolver.java` | Shared ISIN→ticker/name resolver with language-neutral persisted descriptions (reused by the CSV importer) |
 | `backend/src/main/java/com/picsou/imports/TransactionAmountCalculator.java` | Single source of truth for the signed `amount` incl. fees |
 | `backend/src/main/resources/db/migration/V53__transaction_fees.sql` | Adds `transaction.fees` (folds into the PMP) |
 | `backend/src/main/java/com/picsou/adapter/OpenFigiIsinConverter.java` | `isIsin()` detection + `resolve()` ISIN→ticker+name (shared with bank sync) |
 | `backend/src/main/java/com/picsou/controller/AccountController.java` | POST/DELETE `/accounts/{id}/transactions` |
 | `backend/src/main/java/com/picsou/repository/TransactionRepository.java` | `deleteByAccountIdAndIsManualFalse`, `sumAmountByAccountId`, `findByAccountIdAndTxTypeInOrderByDateAsc` |
 | `frontend/src/components/shared/AddTransactionModal.tsx` | Account-type-aware form modal |
-| `frontend/src/components/shared/TransactionsList.tsx` | Date grouping with unambiguous historical years, manual badge, and delete button |
+| `frontend/src/components/shared/TransactionsList.tsx` | Localized transaction-type fallbacks, date grouping with unambiguous historical years, manual badge, and delete button |
 | `frontend/src/features/accounts/hooks.ts` | `useAddTransaction`, `useDeleteTransaction` |
 
 ## Technical choices
@@ -150,10 +154,14 @@ After submit, `useAddTransaction` / `useDeleteTransaction` hooks invalidate the 
 - **Investment account balance is NOT recomputed** from manual transactions. Only the holdings (positions) are derived. The account's `currentBalance` is set by the price scheduler (qty × live price). This is intentional for investment accounts.
 - **Synced transactions cannot be deleted**: The DELETE endpoint checks `isManual`. Attempting to delete a synced transaction returns 403.
 - **Holdings recomputation is full**: Every add/delete triggers a full re-derivation for that account (all tickers). This is fast in practice since investment accounts rarely have hundreds of tickers.
-- **The backend owns ticker-based descriptions.** `ManualTransactionService` sets the row `description` from the effective name. If no name exists, it uses a French fallback matching the instrument transaction type (`Achat`, `Vente`, `Dividende`, or `Frais`) plus the ticker. This value replaces the client-supplied description. Cash transactions with no ticker keep the client-supplied description.
+- **The backend never localizes ticker-based descriptions.** `ManualTransactionService` stores
+  the effective name, or the canonical ticker when no name exists. The API already exposes
+  `txType`; `TransactionsList` translates that enum for manual ticker rows with no name.
+  Cash transactions with no ticker and synced provider descriptions keep their supplied text.
 
 ## Tests
 
 - `HoldingComputeServiceTest` — 11 unit tests: BUY-only, multi-BUY VWAP, BUY+SELL, fully-sold position, null ticker/quantity skipping, multiple tickers, existing holding update, plus position name = newest transaction's name and name-preserved-when-transactions-have-none.
 - `ManualTransactionServiceTest` — 11 unit tests: manual cash add (balance + snapshots recomputed), synced cash add (transaction saved, balance/snapshots untouched), investment add (holdings recomputed, for both manual and synced accounts), non-owned account rejection, manual delete, synced-account delete (no reconstruct), synced-transaction delete rejection, not-found rejection, plus ISIN input → resolved ticker/name/description and plain-ticker uppercased with the user "Nom" winning.
+- `TransactionsList.test.tsx` — localized BUY, SELL, DIVIDEND, and FEE fallbacks, provider-description preservation, localized search, and date-heading behavior.
 - `OpenFigiIsinConverterTest` — 4 unit tests for the `isIsin()` detector: valid ISINs, case/whitespace normalization, rejects tickers/non-ISIN strings, rejects null/blank.

--- a/frontend/src/components/shared/AddTransactionModal.test.tsx
+++ b/frontend/src/components/shared/AddTransactionModal.test.tsx
@@ -45,7 +45,8 @@ describe('AddTransactionModal fees', () => {
 
     await waitFor(() => expect(onSubmit).toHaveBeenCalledOnce())
     expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({
-      txType: 'BUY', quantity: 10, pricePerUnit: 100, fees: 5, amount: -1005,
+      txType: 'BUY', ticker: 'AAPL', description: 'AAPL',
+      quantity: 10, pricePerUnit: 100, fees: 5, amount: -1005,
     }))
   })
 
@@ -58,6 +59,8 @@ describe('AddTransactionModal fees', () => {
     fireEvent.click(screen.getByRole('button', { name: 'common.create' }))
 
     await waitFor(() => expect(onSubmit).toHaveBeenCalledOnce())
-    expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({ txType: 'SELL', amount: 995, fees: 5 }))
+    expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({
+      txType: 'SELL', ticker: 'AAPL', description: 'AAPL', amount: 995, fees: 5,
+    }))
   })
 })

--- a/frontend/src/components/shared/AddTransactionModal.tsx
+++ b/frontend/src/components/shared/AddTransactionModal.tsx
@@ -121,16 +121,18 @@ function TransactionForm({ onOpenChange, accountId, accountType, onSubmit, isLoa
       const qty = parseAmount(quantity)
       const price = parseAmount(pricePerUnit)
       const feeVal = parseAmount(fees) || 0
+      const normalizedTicker = ticker.trim().toUpperCase()
+      const normalizedName = name.trim()
       // Sign convention mirrors the backend TransactionAmountCalculator: fees add to a BUY's
       // cash outflow and reduce a SELL's proceeds, and fold into the PMP cost basis.
       const amount = investType === 'BUY' ? -(qty * price + feeVal) : (qty * price - feeVal)
       data = {
         date,
-        description: name || (investType === 'BUY' ? `Achat ${ticker}` : `Vente ${ticker}`),
+        description: normalizedName || normalizedTicker,
         amount,
         txType: investType,
-        ticker: ticker.toUpperCase(),
-        name: name.trim() || undefined,
+        ticker: normalizedTicker,
+        name: normalizedName || undefined,
         quantity: qty,
         pricePerUnit: price,
         fees: feeVal || undefined,

--- a/frontend/src/components/shared/TransactionsList.test.tsx
+++ b/frontend/src/components/shared/TransactionsList.test.tsx
@@ -1,12 +1,18 @@
 import '@testing-library/jest-dom'
 import { describe, expect, it, vi } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 import { TransactionsList } from './TransactionsList'
 import type { Transaction } from '@/types/api'
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
-    t: (key: string) => key,
+    t: (key: string) =>
+      ({
+        'accounts.buy': 'Achat',
+        'accounts.sell': 'Vente',
+        'accounts.dividend': 'Dividende',
+        'accounts.fee': 'Frais',
+      })[key] ?? key,
     i18n: { language: 'fr', resolvedLanguage: 'fr' },
   }),
 }))
@@ -51,5 +57,68 @@ describe('TransactionsList', () => {
 
     expect(screen.getByText(/2026/)).toBeInTheDocument()
     expect(screen.getByText(/2025/)).toBeInTheDocument()
+  })
+
+  it.each([
+    ['BUY', 'Achat'],
+    ['SELL', 'Vente'],
+    ['DIVIDEND', 'Dividende'],
+    ['FEE', 'Frais'],
+  ] satisfies [NonNullable<Transaction['txType']>, string][])(
+    'renders the %s fallback through frontend i18n',
+    (txType, label) => {
+      render(
+        <TransactionsList
+          transactions={[
+            transaction({
+              isManual: true,
+              txType,
+              ticker: 'AAPL',
+              description: 'AAPL',
+            }),
+          ]}
+        />,
+      )
+
+      expect(screen.getByText(`${label} AAPL`)).toBeInTheDocument()
+    },
+  )
+
+  it('keeps a provider description on synced transactions', () => {
+    render(
+      <TransactionsList
+        transactions={[
+          transaction({
+            txType: 'DIVIDEND',
+            ticker: 'AAPL',
+            description: 'Provider dividend payment',
+          }),
+        ]}
+      />,
+    )
+
+    expect(screen.getByText('Provider dividend payment')).toBeInTheDocument()
+    expect(screen.queryByText('Dividende AAPL')).not.toBeInTheDocument()
+  })
+
+  it('searches the localized fallback description', () => {
+    render(
+      <TransactionsList
+        transactions={[
+          transaction({
+            isManual: true,
+            txType: 'DIVIDEND',
+            ticker: 'AAPL',
+            description: 'AAPL',
+          }),
+        ]}
+      />,
+    )
+
+    fireEvent.change(screen.getByPlaceholderText('common.search'), {
+      target: { value: 'Dividende' },
+    })
+
+    expect(screen.getByText('Dividende AAPL')).toBeInTheDocument()
   })
 })

--- a/frontend/src/components/shared/TransactionsList.tsx
+++ b/frontend/src/components/shared/TransactionsList.tsx
@@ -15,15 +15,31 @@ interface TransactionsListProps {
   onEdit?: (tx: Transaction) => void
 }
 
+type TransactionType = NonNullable<Transaction['txType']>
+
+const TRANSACTION_TYPE_LABEL_KEYS = {
+  DEPOSIT: 'accounts.deposit',
+  WITHDRAWAL: 'accounts.withdrawal',
+  BUY: 'accounts.buy',
+  SELL: 'accounts.sell',
+  DIVIDEND: 'accounts.dividend',
+  FEE: 'accounts.fee',
+} satisfies Record<TransactionType, string>
+
 export function TransactionsList({ transactions, onDelete, onEdit }: TransactionsListProps) {
   const { t, i18n } = useTranslation()
   const [search, setSearch] = useState('')
   const locale = localeFromLanguage(i18n.resolvedLanguage ?? i18n.language)
 
   const filtered = search
-    ? transactions.filter(tr =>
-        tr.description.toLowerCase().includes(search.toLowerCase())
-      )
+    ? transactions.filter(tr => {
+        const normalizedSearch = search.toLocaleLowerCase(locale)
+        const displayedDescription = transactionDescription(tr, t).toLocaleLowerCase(locale)
+        return (
+          displayedDescription.includes(normalizedSearch) ||
+          tr.description.toLocaleLowerCase(locale).includes(normalizedSearch)
+        )
+      })
     : transactions
   const showYear = new Set(filtered.map(tr => tr.date.slice(0, 4))).size > 1
 
@@ -68,7 +84,7 @@ export function TransactionsList({ transactions, onDelete, onEdit }: Transaction
                   )}
                 >
                   <div className="min-w-0 flex-1 flex items-center gap-2">
-                    <p className="truncate text-sm font-medium">{tr.description}</p>
+                    <p className="truncate text-sm font-medium">{transactionDescription(tr, t)}</p>
                     {tr.isManual && (
                       <span className="rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground shrink-0">
                         {t('accounts.manual')}
@@ -113,6 +129,15 @@ export function TransactionsList({ transactions, onDelete, onEdit }: Transaction
       </CardContent>
     </Card>
   )
+}
+
+/** Builds a localized fallback only for manual instrument rows that have no display name. */
+function transactionDescription(transaction: Transaction, translate: (key: string) => string): string {
+  if (!transaction.isManual || !transaction.ticker?.trim() || transaction.name?.trim() || transaction.txType === null) {
+    return transaction.description
+  }
+
+  return `${translate(TRANSACTION_TYPE_LABEL_KEYS[transaction.txType])} ${transaction.ticker}`
 }
 
 function formatTransactionDate(date: string, locale: string, showYear: boolean): string {

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -156,6 +156,8 @@
     "transactionDate": "Datum",
     "buy": "Kauf",
     "sell": "Verkauf",
+    "dividend": "Dividende",
+    "fee": "Gebühr",
     "deposit": "Einzahlung",
     "withdrawal": "Auszahlung",
     "description": "Beschreibung",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -158,6 +158,8 @@
     "transactionDate": "Date",
     "buy": "Buy",
     "sell": "Sell",
+    "dividend": "Dividend",
+    "fee": "Fee",
     "deposit": "Deposit",
     "withdrawal": "Withdrawal",
     "description": "Description",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -156,6 +156,8 @@
     "transactionDate": "Fecha",
     "buy": "Compra",
     "sell": "Venta",
+    "dividend": "Dividendo",
+    "fee": "Comisión",
     "deposit": "Depósito",
     "withdrawal": "Retirada",
     "description": "Descripción",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -158,6 +158,8 @@
     "transactionDate": "Date",
     "buy": "Achat",
     "sell": "Vente",
+    "dividend": "Dividende",
+    "fee": "Frais",
     "deposit": "Dépôt",
     "withdrawal": "Retrait",
     "description": "Description",


### PR DESCRIPTION
## Why

`InstrumentFieldResolver` treated every type except `SELL` as a purchase when neither a user name nor an OpenFIGI name was available. A `DIVIDEND` or `FEE` with a ticker therefore displayed `Achat <ticker>`.

## Scope

- Give `DIVIDEND` and `FEE` their own French fallback labels.
- Preserve user-supplied names, OpenFIGI names, and existing behavior for every other transaction type.
- Add focused regression coverage and update the manual transaction documentation and changelog.

Closes #108

## Tradeoffs

The exhaustive switch preserves the existing `Achat` fallback for a null type, `DEPOSIT`, and `WITHDRAWAL`. This PR leaves CSV side validation, amount calculations, and holding computation unchanged.

## Blast Radius

The shared resolver serves manual entry and CSV imports. Only generated descriptions change, and only when a `DIVIDEND` or `FEE` carries a ticker without a supplied or resolved name. `BUY` and `SELL` labels remain unchanged.

## Verification

- `mvn test -Dtest=InstrumentFieldResolverTest` passed 7 tests with no failures.
- `TZ=UTC mvn test` completed 1,246 tests with no failures and 33 Docker-gated skips.
- The default Europe/Paris run currently hits a month-end failure in `GoalServiceTest.isOnTrack_true_whenManualContributionCoversShortfall`. The same failure reproduces on untouched `upstream/main`, while the UTC run used by GitHub Actions passes.
- `git diff --check upstream/main...HEAD` passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Manual transactions on synced accounts no longer alter provider-managed holdings, balances, or snapshots.
  * CSV imports now accept investment accounts only when they are manual accounts.
  * Transaction descriptions now use consistent ticker or instrument names, with localized labels for nameless manual transactions.
  * Transaction search includes localized fallback descriptions.
  * Added localized dividend and fee labels in English, French, German, and Spanish.

* **Documentation**
  * Clarified manual transaction, localization, and import behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->