### PR TITLE
fix(tr-auth): refresh Trade Republic session with GET

### DIFF
--- a/services/tr-auth/main.py
+++ b/services/tr-auth/main.py
@@ -237,7 +237,7 @@ async def refresh_session(req: RefreshRequest):
     log.info("Refreshing TR session via tr_refresh token")
     async with httpx.AsyncClient(timeout=15) as client:
         try:
-            resp = await client.post(
+            resp = await client.get(
                 f"{TR_API}/api/v1/auth/web/refresh",
                 cookies={"tr_refresh": req.refreshToken},
                 headers={

--- a/services/tr-auth/test_refresh_method.py
+++ b/services/tr-auth/test_refresh_method.py
@@ -1,0 +1,42 @@
+"""Trade Republic moved its session refresh endpoint from POST to GET.
+
+Upstream answers POST with 405 and accepts GET. This test pins the
+outgoing method so a regression shows up before deploy.
+"""
+
+import ast
+import pathlib
+import unittest
+
+
+def refresh_calls():
+    source = pathlib.Path(__file__).with_name("main.py").read_text()
+    tree = ast.parse(source)
+    found = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == "refresh_session":
+            for child in ast.walk(node):
+                if isinstance(child, ast.Await) and isinstance(child.value, ast.Call):
+                    func = child.value.func
+                    if isinstance(func, ast.Attribute) and func.attr in ("get", "post"):
+                        for arg in child.value.args:
+                            if isinstance(arg, ast.JoinedStr):
+                                url = "".join(
+                                    part.value for part in arg.values
+                                    if isinstance(part, ast.Constant)
+                                )
+                                if "auth/web/refresh" in url:
+                                    found.append(func.attr)
+    return found
+
+
+class RefreshMethodTest(unittest.TestCase):
+    def test_refresh_uses_get_upstream(self):
+        self.assertIn("get", refresh_calls())
+
+    def test_refresh_no_longer_posts_upstream(self):
+        self.assertNotIn("post", refresh_calls())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Why

Trade Republic now answers POST on its refresh endpoint with 405. The sidecar loops on 405, and the backend reports the service as unavailable. Switch the outgoing call to GET. Fixes #113.

## Scope

- services/tr-auth/main.py refresh_session calls client.get on https://api.traderepublic.com/api/v1/auth/web/refresh with the tr_refresh cookie. Nothing else changes.
- services/tr-auth/test_refresh_method.py pins the upstream method. It asserts refresh_session uses get and no post remains for auth/web/refresh.
- In scope: the sidecar to Trade Republic call only. Out of scope: the internal POST /refresh sidecar route, /initiate, /complete.

## Blast Radius

One upstream HTTP call changes verb. The internal POST /refresh contract between TradeRepublicAdapter and the sidecar stays identical, so no Java change ships. /initiate and /complete still use POST upstream. The change is safe because GET carries no body and the cookie auth is unchanged. Without it, every stored-session refresh fails.

## Verification

- python3 -m unittest test_refresh_method in services/tr-auth fails before the fix (found post) and passes after (2 tests OK).
- python3 -m py_compile main.py test_refresh_method.py passes.
- mvn test -Dtest=TradeRepublicSyncServiceTest in backend passes (Tests run 8, Failures 0, Errors 0).
- Two subagent reviewers returned SHIP with no blocking findings.
- A live refresh against a real session still needs a run after the tr-auth image is rebuilt and redeployed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated session refresh requests to use the correct GET method, improving compatibility with the Trade Republic refresh service.

* **Tests**
  * Added automated coverage to verify that session refresh uses GET and does not send POST requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->