### PR TITLE
fix(bourso-auth): skip insurance sections instead of failing the sync

### DIFF
--- a/docs/features/bourso-bank.md
+++ b/docs/features/bourso-bank.md
@@ -31,7 +31,7 @@ why.
 
 | Imported | Not imported |
 |---|---|
-| Current accounts → `CHECKING` | Loans (`data-summary-loan`) |
+| Current accounts → `CHECKING` | Loans (`data-summary-loan`), assurance-vie and insurance, `Bourso Protect` (`data-summary-insurance` / `data-summary-assurance`) |
 | Livrets → `LIVRET_A`, `LDDS`, `LEP`, `LIVRET_JEUNE`, `PEL`, `CEL`, else `SAVINGS` | Accounts BoursoBank aggregates from **other banks** |
 | PEA, PEA-PME → `PEA` | Transactions |
 | Compte-titres → `COMPTE_TITRES`, with positions | Orders, statements |
@@ -130,8 +130,11 @@ than falling back to DOM order, which is shuffled.
 
 `GET /dashboard/liste-comptes?rumroute=dashboard.new_accounts&_hinclude=1`
 returns HTML grouped into `data-summary-bank` / `-savings` / `-trading` /
-`-loan`. Balances come out of each card's `aria-label` (`Solde : 11 010,00 €`),
-negatives use U+2212 rather than an ASCII hyphen.
+`-loan` / `-insurance`. Balances come out of each card's `aria-label` (`Solde : 11 010,00 €`),
+negatives use U+2212 rather than an ASCII hyphen. Insurance sections are
+recognized so their cards can be skipped explicitly, the same way loans are:
+an unparsed card inside a known section still fails the sync, while a card in
+an unknown section keeps failing it too.
 
 Securities accounts then get:
 

--- a/docs/features/bourso-bank.md
+++ b/docs/features/bourso-bank.md
@@ -130,7 +130,7 @@ than falling back to DOM order, which is shuffled.
 
 `GET /dashboard/liste-comptes?rumroute=dashboard.new_accounts&_hinclude=1`
 returns HTML grouped into `data-summary-bank` / `-savings` / `-trading` /
-`-loan` / `-insurance`. Balances come out of each card's `aria-label` (`Solde : 11 010,00 €`),
+`-loan` / `-insurance` / `-assurance`. Balances come out of each card's `aria-label` (`Solde : 11 010,00 €`),
 negatives use U+2212 rather than an ASCII hyphen. Insurance sections are
 recognized so their cards can be skipped explicitly, the same way loans are:
 an unparsed card inside a known section still fails the sync, while a card in

--- a/services/bourso-auth/accounts_parser.py
+++ b/services/bourso-auth/accounts_parser.py
@@ -3,7 +3,7 @@
 Two upstream shapes are parsed here:
 
 * the account summary at `/dashboard/liste-comptes`, which is HTML grouped into
-  `data-summary-bank` / `-savings` / `-trading` / `-loan` sections;
+  `data-summary-bank` / `-savings` / `-trading` / `-loan` / `-insurance` sections;
 * the trading board's `accounts/summary/{id}` JSON, which carries the cash, the
   portfolio valuation, the account total and every open position.
 
@@ -38,13 +38,14 @@ MAX_ACCOUNTS = 60
 OWN_BANK_LABELS = {"BOURSOBANK", "BOURSORAMA", "BOURSORAMA BANQUE"}
 
 # `</ul>` for savings, `</div>` for the rest -- BoursoBank's own markup, mirrored
-# from the reference implementation. Loans are parsed so they can be counted and
-# skipped explicitly rather than silently missed.
+# from the reference implementation. Loans and insurance are parsed so they can
+# be counted and skipped explicitly rather than silently missed.
 SECTION_PATTERNS = {
     "banking": re.compile(r"data-summary-bank>(.*?)</div>", re.DOTALL),
     "savings": re.compile(r"data-summary-savings>(.*?)</ul>", re.DOTALL),
     "trading": re.compile(r"data-summary-trading>(.*?)</div>", re.DOTALL),
     "loans": re.compile(r"data-summary-loan>(.*?)</div>", re.DOTALL),
+    "insurance": re.compile(r"data-summary-(?:insurance|assurance)>(.*?)</div>", re.DOTALL),
 }
 
 _ACCOUNT_RE = re.compile(
@@ -276,9 +277,12 @@ def parse_dashboard(html: str) -> tuple[list[dict[str, Any]], int]:
                     continue
                 accounted_ids.add(account_id)
 
-                # Loans are out of scope but still have to be *seen*, or the
-                # completeness check below would read them as parse failures.
+                # Loans and insurance are out of scope but still have to be
+                # *seen*, or the completeness check below would read them as
+                # parse failures.
                 if section == "loans":
+                    continue
+                if section == "insurance":
                     continue
                 if not is_own_account(bank):
                     third_party += 1

--- a/services/bourso-auth/accounts_parser.py
+++ b/services/bourso-auth/accounts_parser.py
@@ -3,7 +3,8 @@
 Two upstream shapes are parsed here:
 
 * the account summary at `/dashboard/liste-comptes`, which is HTML grouped into
-  `data-summary-bank` / `-savings` / `-trading` / `-loan` / `-insurance` sections;
+  `data-summary-bank` / `-savings` / `-trading` / `-loan` / `-insurance` /
+  `-assurance` sections;
 * the trading board's `accounts/summary/{id}` JSON, which carries the cash, the
   portfolio valuation, the account total and every open position.
 

--- a/services/bourso-auth/test_accounts_parser.py
+++ b/services/bourso-auth/test_accounts_parser.py
@@ -153,6 +153,39 @@ class OwnAccountTest(unittest.TestCase):
         self.assertFalse(is_own_account("CIC"))
 
 
+def insurance_panel(marker, card_id, name, balance):
+    return f"""<div class="c-panel c-panel--primary">
+    <div class="c-panel__header ">
+        <span class="c-panel__title">
+            Mes assurances
+        </span>
+    </div>
+    <div class="c-panel__body ">
+        <div class="c-panel__no-animation-glitch ">
+            <ul class="c-info-box " role="list" data-brs-list-header {marker}>
+                <li class="c-panel__item c-info-box__item" data-brs-filterable>
+                    <a class="c-info-box__link-wrapper" href="/compte/assurance/{card_id}/"
+                        aria-label="Détails du compte {name} - Solde : {balance} €" title="{name}">
+                        <span class="c-info-box__account">
+                            <span class="c-info-box__account-label"
+                                data-account-label="{card_id}" data-brs-list-item-label>
+                                {name}
+                            </span>
+                            <span class="c-info-box__account-balance c-info-box__account-balance--positive">
+                                {balance} €
+                            </span>
+                        </span>
+                        <span class="c-info-box__account-sub-label" data-brs-list-item-label>
+                            BoursoBank
+                        </span>
+                    </a>
+                </li>
+            </ul>
+        </div>
+    </div>
+</div>"""
+
+
 class DashboardTest(unittest.TestCase):
     def test_parses_a_real_dashboard(self):
         accounts, third_party = parse_dashboard(DASHBOARD_HTML)
@@ -191,6 +224,47 @@ class DashboardTest(unittest.TestCase):
         with self.assertRaises(AccountsFormatError) as raised:
             parse_dashboard(foreign)
         self.assertEqual(raised.exception.code, INCOMPLETE)
+
+    def test_insurance_contracts_are_skipped_without_failing_the_sync(self):
+        # Assurance-vie and Bourso Protect cards are account-shaped links in
+        # their own sections. They are out of scope like loans, so they must
+        # not trip the completeness check that guards real format changes.
+        html = (
+            DASHBOARD_HTML
+            + insurance_panel(
+                "data-summary-insurance",
+                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                "Assurance Vie **01",
+                "45 210,30",
+            )
+            + insurance_panel(
+                "data-summary-assurance",
+                "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                "Bourso Protect",
+                "150,00",
+            )
+        )
+        accounts, third_party = parse_dashboard(html)
+        self.assertEqual(
+            [(account["type"], account["name"]) for account in accounts],
+            [
+                ("CHECKING", "BoursoBank"),
+                ("LDDS", "LIVRET DEVELOPPEMENT DURABLE SOLIDAIRE"),
+                ("PEA", "PEA DOE"),
+            ],
+        )
+        self.assertEqual(third_party, 2)
+
+    def test_a_section_with_an_unknown_marker_still_fails_the_sync(self):
+        html = DASHBOARD_HTML + insurance_panel(
+            "data-summary-foobar",
+            "cccccccccccccccccccccccccccccccc",
+            "Produit Inconnu",
+            "10,00",
+        )
+        with self.assertRaises(AccountsFormatError) as raised:
+            parse_dashboard(html)
+        self.assertEqual(raised.exception.code, FORMAT_CHANGED)
 
 
 class TradingSummaryTest(unittest.TestCase):


### PR DESCRIPTION
## Why

Dashboards with assurance-vie or Bourso Protect contracts fail the whole sync. Their cards produce account-shaped links outside the four known sections, so the completeness check reads them as a format change. Insurance is out of scope like loans, so the parser now recognizes its section and skips it explicitly. Fixes #104.

## Scope

- services/bourso-auth/accounts_parser.py adds an insurance entry to SECTION_PATTERNS (data-summary-insurance and data-summary-assurance) and skips it the same way loans are skipped, after the card is counted as seen.
- services/bourso-auth/test_accounts_parser.py adds a synthetic insurance fixture with two tests. One proves insurance cards sync without tripping the check. One proves an unknown marker still raises.
- docs/features/bourso-bank.md names insurance as not imported and states the fail-closed behavior.
- In scope: dashboard section recognition only. Out of scope: trading summaries, auth, Java.

## Blast Radius

parse_dashboard keeps its signature, so main.py and the backend need no change. Loans, third-party filtering, and all fail-closed guards behave as before. Without the fix, affected users cannot sync at all. With it, their banking, savings, and trading accounts import while insurance cards stay out.

## Verification

- python3 -m unittest test_accounts_parser in services/bourso-auth fails before the fix (2 account cards did not parse) and passes after (43 tests OK).
- python3 -m unittest test_accounts_parser test_virtual_pad passes (58 tests OK).
- test_main and test_lifecycle need fastapi and httpx, absent from this machine. They run in the built image.
- Two subagent reviewers returned SHIP with no blocking findings.

## Open decision

The insurance marker is inferred from the four known markers and the issue report, not from a captured page. The pattern covers data-summary-insurance and data-summary-assurance. The reporter offered a real account with this contract mix, so a run against it should confirm the marker before merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - BoursoBank synchronization now recognizes insurance sections on the dashboard and skips insurance products that are not imported.
  - Dashboard parsing continues to flag unrecognized sections or cards as format changes, helping detect unsupported updates.

- **Documentation**
  - Updated BoursoBank synchronization documentation to describe insurance sections and clarify which products are outside the supported import scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->