### PR TITLE
feat(finary): import holdings, match existing accounts, and gate Docker on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
   push:
     branches: [main]
+    tags: ['[0-9]*', 'v[0-9]*']
 
 permissions:
   contents: read
@@ -107,3 +108,45 @@ jobs:
           --workdir /tests
           picsou-amundi-auth:test
           python -m unittest discover -v
+
+  e2e:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: oven-sh/setup-bun@v2
+      - name: Install
+        run: bun install --frozen-lockfile
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('frontend/bun.lock') }}
+      - name: Install Playwright Chromium
+        run: bunx playwright install --with-deps chromium
+      - name: Run Playwright E2E (demo mode)
+        env:
+          VITE_DEMO_MODE: 'true'
+        run: bun run test:e2e
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: frontend/playwright-report/
+          retention-days: 7
+
+  # Images are only published after every CI job is green, and only on a push
+  # to main or a version tag — not on pull requests.
+  docker:
+    needs: [backend, frontend, e2e, bourse-direct-sidecar, bourso-sidecar, amundi-sidecar]
+    if: github.event_name == 'push'
+    uses: ./.github/workflows/docker.yml
+    secrets: inherit
+    permissions:
+      contents: read
+      packages: write

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,9 +1,9 @@
 name: Build & publish Docker images
 
+# Called by CI after backend + frontend + e2e + sidecar are green.
+# workflow_dispatch remains an escape hatch (manual publish without re-running CI).
 on:
-  push:
-    branches: ['**']
-    tags: ['[0-9]*', 'v[0-9]*']
+  workflow_call:
   workflow_dispatch:
 
 env:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Track bank accounts, brokerage, crypto, and net worth — all in one place.
 
 [![License: Apache 2.0 + Commons Clause](https://img.shields.io/badge/License-Apache%202.0%20%2B%20Commons%20Clause-blue.svg)](LICENSE)
 
-[Getting started](#getting-started) · [Features](#features) · [Development](#development) · [Security](SECURITY.md)
+[Getting started](#getting-started) · [Features](#features) · [Another machine](#another-machine) · [Development](#development) · [Security](SECURITY.md)
 
 </div>
 
@@ -40,7 +40,7 @@ Track bank accounts, brokerage, crypto, and net worth — all in one place.
 - **Multi-member family** — One admin manages multiple profiles (children, spouse). Per-resource sharing (`NONE` / `ALL` / `MANUAL`), optional activation links to upgrade a managed profile to a full login.
 - **2FA + Remember Me** — Opt-in TOTP per user, 10 single-use recovery codes, 90-day "Remember Me" cookie with rotating tokens, "Trust this device" to skip TOTP, per-session revocation from settings.
 - **GDPR data export** — Self-service ZIP export (JSON + per-entity CSV) gated by re-authentication, rate-limited to 5/hour.
-- **Finary import** — CSV import or direct API sync
+- **Finary import** — XLSX upload or direct API sync (Clerk + TOTP). API sync imports cash, transactions, **and holdings** (securities, crypto, fonds euros) using Finary’s EUR `display_*` values. The mapping wizard matches existing Picsou accounts (external id, then unique name + type) instead of offering to create duplicates.
 - **i18n** — English and French
 - **Dark mode** — System/light/dark with flash-free theme switching
 
@@ -84,9 +84,19 @@ Track bank accounts, brokerage, crypto, and net worth — all in one place.
 
 ### 1. Clone
 
+Published releases:
+
 ```bash
 git clone https://github.com/Zoeille/picsou-finance.git
 cd picsou-finance
+```
+
+Unreleased work on this fork (Finary holdings, account matching, CI e2e, `/mcp` nginx proxy):
+
+```bash
+git clone https://github.com/christopheche/picsou-finance.git
+cd picsou-finance
+git checkout feature/finary-holdings-import
 ```
 
 ### 2. Run (zero-config)
@@ -357,6 +367,57 @@ openssl rsa -pubout -in docker/secrets/enablebanking.pem -out enablebanking_publ
 ```
 
 Upload `enablebanking_public.pem` to your Enable Banking dashboard.
+
+## Another machine
+
+Git has the **code** only. It does **not** contain your Postgres data, encryption keys, Finary session, or bank export zips (`data/` is untracked on purpose).
+
+| What | In git? | On the other Mac if you only clone |
+|------|---------|--------------------------------------|
+| `feature/finary-holdings-import` | yes | checkout that branch |
+| Accounts, holdings, transactions | no (`docker_pgdata`) | empty database |
+| `JWT_SECRET`, `CRYPTO_ENCRYPTION_KEY`, Postgres password | no (`docker_picsou_data`) | new secrets, wizard again |
+| Finary / bank logins | no (encrypted in DB) | reconnect + TOTP |
+| `data/*.zip` bank exports | no | not required to run |
+
+### Code only (fresh instance)
+
+`ghcr.io/zoeille/picsou-finance:latest` does **not** include this branch until the upstream PR is merged. Always **build from source**:
+
+```bash
+git clone https://github.com/christopheche/picsou-finance.git
+cd picsou-finance
+git checkout feature/finary-holdings-import
+docker compose -f docker/docker-compose.yml up --build -d
+```
+
+Open http://localhost:8080, complete the wizard, then Synchronisation → Finary (TOTP). Map **Fortuneo Assurance-vie (investments)** to the CTO, not the fonds-euros row; map **Main Brokerage (investments)** to the Trade Republic CTO, not the BTC account.
+
+### Same data as this Mac
+
+Compose project name must stay `docker` so volumes stay `docker_pgdata` and `docker_picsou_data`. Always use `-f docker/docker-compose.yml` from the repo root.
+
+**On this Mac** (source):
+
+```bash
+docker compose -f docker/docker-compose.yml stop
+docker run --rm -v docker_pgdata:/from -v "$PWD:/to" alpine tar czf /to/pgdata.tar.gz -C /from .
+docker run --rm -v docker_picsou_data:/from -v "$PWD:/to" alpine tar czf /to/picsou_data.tar.gz -C /from .
+```
+
+Copy `pgdata.tar.gz` and `picsou_data.tar.gz` (AirDrop, USB, `scp`). Do **not** commit them.
+
+**On the other Mac**, after clone + checkout, **before** the first `up`:
+
+```bash
+docker volume create docker_pgdata
+docker volume create docker_picsou_data
+docker run --rm -v docker_pgdata:/to -v "$PWD:/from" alpine tar xzf /from/pgdata.tar.gz -C /to
+docker run --rm -v docker_picsou_data:/to -v "$PWD:/from" alpine tar xzf /from/picsou_data.tar.gz -C /to
+docker compose -f docker/docker-compose.yml up --build -d
+```
+
+You must copy **both** archives. Restoring Postgres without `picsou_data` uses a new encryption key and Finary/bank secrets in the DB will not decrypt.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -378,7 +378,21 @@ bun install        # Install dependencies
 bun run dev        # HTTPS dev server on https://localhost:5173 (proxies /api/* → localhost:8080)
 bun run build      # TypeScript check + Vite build
 bunx vitest run    # Unit tests
+bun run test:e2e   # Playwright E2E (demo mode; starts Vite itself)
 ```
+
+### CI
+
+GitHub Actions (`.github/workflows/ci.yml`) runs on every pull request and every
+push to `main` or a version tag:
+
+- backend `mvn test` (Docker required for Flyway migration tests)
+- frontend lint, typecheck, Vitest
+- Playwright e2e in demo mode
+- Bourse Direct sidecar unit tests
+
+Docker images are published to GHCR **only after that suite is green**, and only
+on a push to `main` or a version tag — not on pull requests.
 
 #### 🔒 HTTPS in Development (Hybrid Mode)
 

--- a/backend/src/main/java/com/picsou/finary/FinaryAccountMatcher.java
+++ b/backend/src/main/java/com/picsou/finary/FinaryAccountMatcher.java
@@ -1,0 +1,112 @@
+package com.picsou.finary;
+
+import com.picsou.model.Account;
+import com.picsou.model.AccountType;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Suggests which existing Picsou account a Finary row should map to.
+ *
+ * <p>Lookup order: current API external id, legacy xlsx external id, then a
+ * unique (trimmed name + compatible type) pair. Already-claimed Picsou
+ * accounts are skipped so two Finary rows cannot steal the same target.
+ */
+public final class FinaryAccountMatcher {
+
+    private FinaryAccountMatcher() {}
+
+    public record Suggestion(Account account, String reason) {}
+
+    public static List<Optional<Suggestion>> suggestAll(
+            List<FinaryRow> rows, List<Account> existing) {
+        Set<Long> claimed = new HashSet<>();
+        List<Optional<Suggestion>> out = new ArrayList<>(rows.size());
+        for (FinaryRow row : rows) {
+            Optional<Suggestion> hit = matchOne(row, existing, claimed);
+            hit.ifPresent(s -> claimed.add(s.account().getId()));
+            out.add(hit);
+        }
+        return out;
+    }
+
+    static Optional<Suggestion> matchOne(FinaryRow row, List<Account> existing, Set<Long> claimed) {
+        String currentId = externalId(row.category(), row.finaryId());
+        Optional<Suggestion> byCurrent = byExternalId(currentId, existing, claimed, "externalId");
+        if (byCurrent.isPresent()) {
+            return byCurrent;
+        }
+
+        if (row.slug() != null && !row.slug().isBlank()) {
+            Optional<Suggestion> bySlug = byExternalId(
+                externalId(row.category(), row.slug()), existing, claimed, "legacySlug");
+            if (bySlug.isPresent()) {
+                return bySlug;
+            }
+        }
+
+        String needle = normalize(row.name());
+        if (needle.isEmpty()) {
+            return Optional.empty();
+        }
+        List<Account> nameHits = existing.stream()
+            .filter(a -> a.getId() != null && !claimed.contains(a.getId()))
+            .filter(a -> needle.equals(normalize(a.getName())))
+            .filter(a -> typesCompatible(row.category(), a.getType()))
+            .toList();
+        if (nameHits.size() == 1) {
+            return Optional.of(new Suggestion(nameHits.get(0), "name+type"));
+        }
+        return Optional.empty();
+    }
+
+    static String externalId(String category, String id) {
+        return "finary_" + category + "_" + id;
+    }
+
+    static boolean typesCompatible(String category, AccountType type) {
+        if (type == null || category == null) {
+            return false;
+        }
+        String cat = category.toLowerCase(Locale.ROOT).replace(' ', '_');
+        return switch (cat) {
+            case "checkings", "checking" -> type == AccountType.CHECKING;
+            case "savings", "fonds_euro", "fonds-euro" ->
+                type == AccountType.SAVINGS
+                    || type == AccountType.LIVRET_A
+                    || type == AccountType.LDDS
+                    || type == AccountType.LEP
+                    || type == AccountType.LIVRET_JEUNE
+                    || type == AccountType.PEL
+                    || type == AccountType.CEL;
+            case "investments" ->
+                type == AccountType.COMPTE_TITRES
+                    || type == AccountType.PEA
+                    || type == AccountType.EMPLOYEE_SAVINGS;
+            case "cryptos" -> type == AccountType.CRYPTO;
+            case "loans", "credits" -> type == AccountType.LOAN || type == AccountType.OTHER;
+            case "real_estates", "real-estate" -> type == AccountType.REAL_ESTATE;
+            default -> type == AccountType.OTHER;
+        };
+    }
+
+    private static Optional<Suggestion> byExternalId(
+            String externalId, List<Account> existing, Set<Long> claimed, String reason) {
+        return existing.stream()
+            .filter(a -> a.getId() != null && !claimed.contains(a.getId()))
+            .filter(a -> externalId.equals(a.getExternalAccountId()))
+            .findFirst()
+            .map(a -> new Suggestion(a, reason));
+    }
+
+    private static String normalize(String name) {
+        return name == null ? "" : name.trim().toLowerCase(Locale.ROOT);
+    }
+
+    public record FinaryRow(String finaryId, String name, String category, String slug) {}
+}

--- a/backend/src/main/java/com/picsou/finary/FinaryApiSyncService.java
+++ b/backend/src/main/java/com/picsou/finary/FinaryApiSyncService.java
@@ -60,6 +60,7 @@ public class FinaryApiSyncService {
     private final FamilyMemberRepository familyMemberRepository;
     private final FinarySessionRepository finarySessionRepository;
     private final FinaryPersistenceHelper persistenceHelper;
+    private final FinaryHoldingsImporter holdingsImporter;
 
     private final ConcurrentHashMap<String, SyncSessionData> cache = new ConcurrentHashMap<>();
 
@@ -230,29 +231,37 @@ public class FinaryApiSyncService {
                 .collect(Collectors.toList());
 
             // Fetch existing Picsou accounts for this member
-            List<AccountResponse> existing = accountRepository.findAllByMemberIdOrderByCreatedAtAsc(memberId).stream()
+            List<Account> existingAccounts = accountRepository.findAllByMemberIdOrderByCreatedAtAsc(memberId);
+            List<AccountResponse> existing = existingAccounts.stream()
                 .map(a -> AccountResponse.from(a, a.getCurrentBalance()))
                 .collect(Collectors.toList());
 
-            // Auto-mapping: check if all Finary accounts already have matching Picsou accounts
-            boolean allAutoMapped = true;
+            List<FinaryAccountMatcher.FinaryRow> rows = allAccounts.stream()
+                .map(categorizedAcc -> new FinaryAccountMatcher.FinaryRow(
+                    categorizedAcc.account().id(),
+                    categorizedAcc.account().name(),
+                    categorizedAcc.category(),
+                    categorizedAcc.account().slug()))
+                .toList();
+            List<Optional<FinaryAccountMatcher.Suggestion>> matches =
+                FinaryAccountMatcher.suggestAll(rows, existingAccounts);
+
+            boolean allAutoMapped = matches.stream().allMatch(Optional::isPresent);
             List<FinaryAccountMapping> suggestedMappings = new ArrayList<>();
-
-            for (CategorizedFinaryAccount categorizedAcc : allAccounts) {
-                FinaryAccountDto acc = categorizedAcc.account();
-                String category = categorizedAcc.category();
-                String externalId = "finary_" + category + "_" + acc.id();
-
-                Optional<Account> existingAccount = accountRepository.findByExternalAccountIdAndMemberId(externalId, memberId);
-                if (existingAccount.isPresent()) {
+            for (int i = 0; i < allAccounts.size(); i++) {
+                FinaryAccountDto acc = allAccounts.get(i).account();
+                String category = allAccounts.get(i).category();
+                Optional<FinaryAccountMatcher.Suggestion> match = matches.get(i);
+                if (match.isPresent()) {
                     suggestedMappings.add(new FinaryAccountMapping(
                         acc.id(), acc.name(), category, FinaryMappingAction.MAP_EXISTING,
-                        existingAccount.get().getId(), null
+                        match.get().account().getId(), null
                     ));
                 } else {
-                    allAutoMapped = false;
-                    suggestedMappings.clear();
-                    break;
+                    suggestedMappings.add(new FinaryAccountMapping(
+                        acc.id(), acc.name(), category, FinaryMappingAction.CREATE_NEW,
+                        null, null
+                    ));
                 }
             }
 
@@ -319,8 +328,7 @@ public class FinaryApiSyncService {
                 account = accountRepository.findByIdAndMemberId(mapping.targetAccountId(), memberId)
                     .orElseThrow(() -> new SyncException(
                         "Account " + mapping.targetAccountId() + " not found"));
-                account.setCurrentBalance(BigDecimal.valueOf(finaryAcc.balance() != null ? finaryAcc.balance() : 0));
-                account.setCurrency(finaryAcc.currency() != null ? finaryAcc.currency().code() : "EUR");
+                applyBalance(account, finaryAcc);
                 account.setLastSyncedAt(Instant.now());
                 account.setExternalAccountId(externalId);
                 accountRepository.save(account);
@@ -333,8 +341,7 @@ public class FinaryApiSyncService {
 
                 if (existingAccount != null) {
                     // Update existing account instead of creating duplicate
-                    existingAccount.setCurrentBalance(BigDecimal.valueOf(finaryAcc.balance() != null ? finaryAcc.balance() : 0));
-                    existingAccount.setCurrency(finaryAcc.currency() != null ? finaryAcc.currency().code() : "EUR");
+                    applyBalance(existingAccount, finaryAcc);
                     existingAccount.setLastSyncedAt(Instant.now());
                     account = accountRepository.save(existingAccount);
                     accountsMapped++;
@@ -346,8 +353,8 @@ public class FinaryApiSyncService {
                         .name(det.name())
                         .type(det.type())
                         .provider(det.provider() != null ? det.provider() : "Finary")
-                        .currency(det.currency())
-                        .currentBalance(BigDecimal.valueOf(finaryAcc.balance() != null ? finaryAcc.balance() : 0))
+                        .currency(displayCurrency(finaryAcc, det.currency()))
+                        .currentBalance(eurBalance(finaryAcc))
                         .isManual(true)
                         .color(det.color() != null ? det.color() : FinaryPersistenceHelper.defaultColorForType(det.type()))
                         .externalAccountId(externalId)
@@ -360,6 +367,9 @@ public class FinaryApiSyncService {
             }
 
             if (account != null) {
+                holdingsImporter.importHoldings(account, finaryAcc);
+                accountRepository.save(account);
+
                 // Import transactions for this account
                 List<FinaryTransactionDto> categoryTxs = session.transactionsByCategory().getOrDefault(category, List.of());
                 List<FinaryTransactionDto> accountTxs = categoryTxs.stream()
@@ -477,6 +487,36 @@ public class FinaryApiSyncService {
     }
 
     /**
+     * Prefer Finary's display-currency balance (EUR). Native {@code balance} on
+     * USD crypto wallets is the token valuation in USD and must not be stored
+     * as if it were already EUR.
+     */
+    static BigDecimal eurBalance(FinaryAccountDto acc) {
+        Double eur = acc.displayBalance() != null ? acc.displayBalance() : acc.balance();
+        return BigDecimal.valueOf(eur != null ? eur : 0);
+    }
+
+    static void applyBalance(Account account, FinaryAccountDto acc) {
+        account.setCurrentBalance(eurBalance(acc));
+        account.setCurrency(displayCurrency(acc, account.getCurrency()));
+    }
+
+    /**
+     * When Finary sends {@code display_balance}, the stored amount is already EUR
+     * — keep the account currency as EUR so later FX conversion does not apply
+     * a second time.
+     */
+    static String displayCurrency(FinaryAccountDto acc, String fallback) {
+        if (acc.displayBalance() != null) {
+            return "EUR";
+        }
+        if (acc.currency() != null && acc.currency().code() != null && !acc.currency().code().isBlank()) {
+            return acc.currency().code();
+        }
+        return fallback != null && !fallback.isBlank() ? fallback : "EUR";
+    }
+
+    /**
      * Adapt a Finary loan entry to the common {@link FinaryAccountDto} so loans flow through
      * the existing preview/execute pipeline (mapping, auto-mapping, account creation).
      *
@@ -490,7 +530,7 @@ public class FinaryApiSyncService {
     FinaryAccountDto toLoanAccountDto(FinaryLoanDto loan) {
         // Stored positive; aggregation negates (see LoanAmortizationService.computeRemainingBalance)
         Double balance = loan.outstandingAmount();
-        return new FinaryAccountDto(
+        return FinaryAccountDto.withoutHoldings(
             loan.id(),
             loan.name(),
             null,

--- a/backend/src/main/java/com/picsou/finary/FinaryHoldingsImporter.java
+++ b/backend/src/main/java/com/picsou/finary/FinaryHoldingsImporter.java
@@ -1,0 +1,307 @@
+package com.picsou.finary;
+
+import com.picsou.adapter.OpenFigiIsinConverter;
+import com.picsou.finary.dto.FinaryAccountDto;
+import com.picsou.finary.dto.FinaryAssetRefDto;
+import com.picsou.finary.dto.FinaryPositionDto;
+import com.picsou.finary.dto.FinarySecurityRefDto;
+import com.picsou.model.Account;
+import com.picsou.model.AccountHolding;
+import com.picsou.repository.AccountHoldingRepository;
+import com.picsou.service.HoldingDedup;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+/**
+ * Maps Finary account positions (securities, cryptos, fonds euro, …) onto
+ * {@link AccountHolding} rows and records leftover cash on the account.
+ *
+ * <p>XLSX import has no position payload, so this is a no-op when every list is
+ * null/empty. Cash-like lines (fiats, "Solde Espèces") are not persisted as
+ * holdings — they go into {@code account.cashBalance}.
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class FinaryHoldingsImporter {
+
+    static final int TICKER_MAX = 100;
+    static final int NAME_MAX = 255;
+
+    private static final Pattern CASH_NAME = Pattern.compile(
+        "(?i)solde\\s+esp[eè]ces|\\bcash\\b|^euro$");
+    private static final String BLANK_ISIN = "000000000000";
+
+    private final AccountHoldingRepository holdingRepository;
+    private final OpenFigiIsinConverter isinConverter;
+
+    public int importHoldings(Account account, FinaryAccountDto finaryAcc) {
+        List<FinaryPositionDto> positions = collectPositions(finaryAcc);
+        BigDecimal cash = sumCash(finaryAcc);
+
+        account.setCashBalance(cash.signum() == 0 ? null : cash);
+
+        if (positions.isEmpty()) {
+            holdingRepository.deleteByAccountId(account.getId());
+            return 0;
+        }
+
+        Instant now = Instant.now();
+        Map<String, HoldingDedup.HoldingAgg> deduped = new HashMap<>();
+        Map<String, ProviderVal> providerByTicker = new HashMap<>();
+
+        for (FinaryPositionDto position : positions) {
+            if (isCash(position)) {
+                continue;
+            }
+            BigDecimal qty = decimal(position.quantity());
+            if (qty == null || qty.signum() == 0) {
+                continue;
+            }
+            ResolvedInstrument instrument = resolveInstrument(position);
+            if (instrument.ticker() == null || instrument.ticker().isBlank()) {
+                log.warn("Skipping Finary position without a ticker on account {}: {}",
+                    account.getId(), instrument.name());
+                continue;
+            }
+
+            BigDecimal valueEur = eurValue(position);
+            BigDecimal pnlEur = eurPnl(position);
+            BigDecimal priceEur = eurPrice(position, qty, valueEur);
+            BigDecimal avgBuyIn = averageBuyIn(position, qty);
+
+            deduped.merge(
+                instrument.ticker(),
+                new HoldingDedup.HoldingAgg(qty, avgBuyIn, priceEur, instrument.name()),
+                HoldingDedup::vwapMerge);
+            providerByTicker.merge(
+                instrument.ticker(),
+                new ProviderVal(valueEur, pnlEur),
+                ProviderVal::add);
+        }
+
+        holdingRepository.deleteByAccountId(account.getId());
+        holdingRepository.flush();
+
+        int saved = 0;
+        for (Map.Entry<String, HoldingDedup.HoldingAgg> entry : deduped.entrySet()) {
+            HoldingDedup.HoldingAgg agg = entry.getValue();
+            if (agg.quantity().signum() == 0) {
+                continue;
+            }
+            ProviderVal provider = providerByTicker.getOrDefault(entry.getKey(), ProviderVal.EMPTY);
+            holdingRepository.save(AccountHolding.builder()
+                .account(account)
+                .ticker(entry.getKey())
+                .name(truncate(agg.name(), NAME_MAX))
+                .quantity(agg.quantity())
+                .averageBuyIn(agg.averageBuyIn())
+                .currentPrice(agg.currentPrice())
+                .quoteCurrency("EUR")
+                .providerValueEur(provider.valueEur())
+                .providerPnlEur(provider.pnlEur())
+                .lastSyncedAt(now)
+                .build());
+            saved++;
+        }
+        return saved;
+    }
+
+    static List<FinaryPositionDto> collectPositions(FinaryAccountDto acc) {
+        List<FinaryPositionDto> out = new ArrayList<>();
+        addAll(out, acc.securities());
+        addAll(out, acc.cryptos());
+        addAll(out, acc.fondsEuro());
+        addAll(out, acc.genericAssets());
+        addAll(out, acc.scpis());
+        addAll(out, acc.preciousMetals());
+        return out;
+    }
+
+    private static void addAll(List<FinaryPositionDto> out, List<FinaryPositionDto> src) {
+        if (src != null) {
+            out.addAll(src);
+        }
+    }
+
+    BigDecimal sumCash(FinaryAccountDto acc) {
+        BigDecimal cash = BigDecimal.ZERO;
+        if (acc.fiats() != null) {
+            for (FinaryPositionDto fiat : acc.fiats()) {
+                cash = cash.add(nvl(eurValue(fiat)));
+            }
+        }
+        for (FinaryPositionDto position : collectPositions(acc)) {
+            if (isCash(position)) {
+                cash = cash.add(nvl(eurValue(position)));
+            }
+        }
+        return cash;
+    }
+
+    static boolean isCash(FinaryPositionDto position) {
+        if (position == null) {
+            return false;
+        }
+        if (position.fiat() != null) {
+            return true;
+        }
+        String type = position.type();
+        if (type != null && type.toLowerCase(Locale.ROOT).contains("fiat")) {
+            return true;
+        }
+        FinarySecurityRefDto security = position.security();
+        if (security != null) {
+            if (BLANK_ISIN.equals(security.symbol()) || BLANK_ISIN.equals(security.isin())) {
+                return true;
+            }
+            if (security.isin() == null && CASH_NAME.matcher(nvl(security.name())).find()) {
+                return true;
+            }
+        }
+        return position.security() == null
+            && position.crypto() == null
+            && CASH_NAME.matcher(nvl(position.name())).find();
+    }
+
+    ResolvedInstrument resolveInstrument(FinaryPositionDto position) {
+        FinaryAssetRefDto crypto = position.crypto();
+        if (crypto != null) {
+            String code = firstNonBlank(crypto.code(), crypto.symbol());
+            return new ResolvedInstrument(
+                sanitizeTicker(firstNonBlank(code, crypto.name(), position.id())),
+                firstNonBlank(crypto.name(), code));
+        }
+
+        FinarySecurityRefDto security = position.security();
+        if (security != null) {
+            String isin = security.isin();
+            if (OpenFigiIsinConverter.isIsin(isin)) {
+                OpenFigiIsinConverter.TickerResult resolved = isinConverter.resolve(isin);
+                String ticker = firstNonBlank(resolved.ticker(), isin);
+                String name = firstNonBlank(resolved.name(), security.name(), ticker);
+                return new ResolvedInstrument(sanitizeTicker(ticker), name);
+            }
+            String fallback = firstNonBlank(isin, security.symbol(), security.slug(), security.name(), position.id());
+            return new ResolvedInstrument(
+                sanitizeTicker(fallback),
+                firstNonBlank(security.name(), fallback));
+        }
+
+        String name = firstNonBlank(position.name(), position.id());
+        return new ResolvedInstrument(sanitizeTicker("FINARY_" + name), name);
+    }
+
+    static String sanitizeTicker(String raw) {
+        if (raw == null || raw.isBlank()) {
+            return null;
+        }
+        String cleaned = raw.trim().toUpperCase(Locale.ROOT)
+            .replaceAll("[^A-Z0-9._-]", "_")
+            .replaceAll("_+", "_");
+        if (cleaned.startsWith("_")) {
+            cleaned = cleaned.substring(1);
+        }
+        if (cleaned.endsWith("_")) {
+            cleaned = cleaned.substring(0, cleaned.length() - 1);
+        }
+        if (cleaned.isBlank()) {
+            return null;
+        }
+        return truncate(cleaned, TICKER_MAX);
+    }
+
+    static BigDecimal eurValue(FinaryPositionDto position) {
+        return firstDecimal(position.displayCurrentValue(), position.currentValue());
+    }
+
+    static BigDecimal eurPnl(FinaryPositionDto position) {
+        return firstDecimal(position.displayUnrealizedPnl(), position.unrealizedPnl());
+    }
+
+    static BigDecimal eurPrice(FinaryPositionDto position, BigDecimal qty, BigDecimal valueEur) {
+        BigDecimal displayPrice = decimal(position.displayCurrentPrice());
+        if (displayPrice != null) {
+            return displayPrice;
+        }
+        if (valueEur != null && qty != null && qty.signum() != 0) {
+            return valueEur.divide(qty, 8, RoundingMode.HALF_UP);
+        }
+        return decimal(position.currentPrice());
+    }
+
+    static BigDecimal averageBuyIn(FinaryPositionDto position, BigDecimal qty) {
+        BigDecimal buyValue = firstDecimal(position.displayBuyingValue(), position.buyingValue());
+        if (buyValue != null && qty != null && qty.signum() != 0) {
+            return buyValue.divide(qty, 8, RoundingMode.HALF_UP);
+        }
+        return firstDecimal(position.buyingPrice(), null);
+    }
+
+    static BigDecimal firstDecimal(Double preferred, Double fallback) {
+        BigDecimal first = decimal(preferred);
+        return first != null ? first : decimal(fallback);
+    }
+
+    static BigDecimal decimal(Double value) {
+        return value == null ? null : BigDecimal.valueOf(value);
+    }
+
+    private static BigDecimal nvl(BigDecimal value) {
+        return value != null ? value : BigDecimal.ZERO;
+    }
+
+    private static String nvl(String value) {
+        return value != null ? value : "";
+    }
+
+    static String firstNonBlank(String... values) {
+        if (values == null) {
+            return null;
+        }
+        for (String value : values) {
+            if (value != null && !value.isBlank()) {
+                return value;
+            }
+        }
+        return null;
+    }
+
+    static String truncate(String value, int max) {
+        if (value == null || value.length() <= max) {
+            return value;
+        }
+        return value.substring(0, max);
+    }
+
+    record ResolvedInstrument(String ticker, String name) {}
+
+    record ProviderVal(BigDecimal valueEur, BigDecimal pnlEur) {
+        static final ProviderVal EMPTY = new ProviderVal(null, null);
+
+        ProviderVal add(ProviderVal other) {
+            return new ProviderVal(sum(valueEur, other.valueEur), sum(pnlEur, other.pnlEur));
+        }
+
+        private static BigDecimal sum(BigDecimal a, BigDecimal b) {
+            if (a == null) {
+                return b;
+            }
+            if (b == null) {
+                return a;
+            }
+            return a.add(b);
+        }
+    }
+}

--- a/backend/src/main/java/com/picsou/finary/dto/FinaryAccountDto.java
+++ b/backend/src/main/java/com/picsou/finary/dto/FinaryAccountDto.java
@@ -1,6 +1,10 @@
 package com.picsou.finary.dto;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record FinaryAccountDto(
@@ -11,5 +15,27 @@ public record FinaryAccountDto(
     Double organizationBalance,
     FinaryAccountInstitution institution,
     FinaryAccountCurrency currency,
-    boolean isManual
-) {}
+    boolean isManual,
+    @JsonProperty("display_balance") @JsonAlias("displayBalance") Double displayBalance,
+    List<FinaryPositionDto> securities,
+    List<FinaryPositionDto> cryptos,
+    @JsonProperty("fonds_euro") @JsonAlias("fondsEuro") List<FinaryPositionDto> fondsEuro,
+    List<FinaryPositionDto> fiats,
+    @JsonProperty("generic_assets") @JsonAlias("genericAssets") List<FinaryPositionDto> genericAssets,
+    List<FinaryPositionDto> scpis,
+    @JsonProperty("precious_metals") @JsonAlias("preciousMetals") List<FinaryPositionDto> preciousMetals
+) {
+    public static FinaryAccountDto withoutHoldings(
+            String id,
+            String name,
+            String slug,
+            Double balance,
+            Double organizationBalance,
+            FinaryAccountInstitution institution,
+            FinaryAccountCurrency currency,
+            boolean isManual) {
+        return new FinaryAccountDto(
+            id, name, slug, balance, organizationBalance, institution, currency, isManual,
+            null, null, null, null, null, null, null, null);
+    }
+}

--- a/backend/src/main/java/com/picsou/finary/dto/FinaryAssetRefDto.java
+++ b/backend/src/main/java/com/picsou/finary/dto/FinaryAssetRefDto.java
@@ -1,0 +1,13 @@
+package com.picsou.finary.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/** Nested crypto / fiat / generic asset reference on a Finary position. */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record FinaryAssetRefDto(
+    Long id,
+    String name,
+    String code,
+    String symbol,
+    String type
+) {}

--- a/backend/src/main/java/com/picsou/finary/dto/FinaryPositionDto.java
+++ b/backend/src/main/java/com/picsou/finary/dto/FinaryPositionDto.java
@@ -1,0 +1,30 @@
+package com.picsou.finary.dto;
+
+import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * One line on a Finary account (security, crypto, fonds euro, fiat, generic asset).
+ * {@code display_*} values are in the user's display currency (EUR). Native
+ * {@code current_value} / {@code buying_value} stay in the account currency.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record FinaryPositionDto(
+    String id,
+    String name,
+    String type,
+    Double quantity,
+    @JsonProperty("buying_price") @JsonAlias("buyingPrice") Double buyingPrice,
+    @JsonProperty("buying_value") @JsonAlias("buyingValue") Double buyingValue,
+    @JsonProperty("current_price") @JsonAlias("currentPrice") Double currentPrice,
+    @JsonProperty("current_value") @JsonAlias("currentValue") Double currentValue,
+    @JsonProperty("unrealized_pnl") @JsonAlias("unrealizedPnl") Double unrealizedPnl,
+    @JsonProperty("display_buying_value") @JsonAlias("displayBuyingValue") Double displayBuyingValue,
+    @JsonProperty("display_current_price") @JsonAlias("displayCurrentPrice") Double displayCurrentPrice,
+    @JsonProperty("display_current_value") @JsonAlias("displayCurrentValue") Double displayCurrentValue,
+    @JsonProperty("display_unrealized_pnl") @JsonAlias("displayUnrealizedPnl") Double displayUnrealizedPnl,
+    FinarySecurityRefDto security,
+    FinaryAssetRefDto crypto,
+    FinaryAssetRefDto fiat
+) {}

--- a/backend/src/main/java/com/picsou/finary/dto/FinarySecurityRefDto.java
+++ b/backend/src/main/java/com/picsou/finary/dto/FinarySecurityRefDto.java
@@ -1,0 +1,14 @@
+package com.picsou.finary.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/** Nested security reference on a Finary investment position. */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record FinarySecurityRefDto(
+    Long id,
+    String name,
+    String isin,
+    String symbol,
+    String slug,
+    String type
+) {}

--- a/backend/src/main/java/com/picsou/model/AccountHolding.java
+++ b/backend/src/main/java/com/picsou/model/AccountHolding.java
@@ -23,10 +23,10 @@ public class AccountHolding extends AuditableEntity {
     @JoinColumn(name = "account_id", nullable = false)
     private Account account;
 
-    @Column(nullable = false, length = 30)
+    @Column(nullable = false, length = 100)
     private String ticker;
 
-    @Column(length = 100)
+    @Column(length = 255)
     private String name;
 
     @Column(nullable = false, precision = 20, scale = 8)

--- a/backend/src/main/java/com/picsou/service/AccountService.java
+++ b/backend/src/main/java/com/picsou/service/AccountService.java
@@ -474,6 +474,13 @@ public class AccountService {
                 anyHoldingPriced = true;
             } else if (hasTicker) {
                 allHoldingsPriced = false;
+                // Aggregator-provided EUR valuation (Finary display_current_value,
+                // Bourse Direct snapshot) is better than dropping the line: Yomoni
+                // fonds, RealT tokens and fonds euros have no Yahoo ticker.
+                if (h.getProviderValueEur() != null) {
+                    liveValue = liveValue.add(h.getProviderValueEur());
+                    continue;
+                }
                 // Skipping is deliberate -- a held-but-unpriced asset must not be valued at a
                 // guess -- but it is not free: the balance (and any snapshot taken from it)
                 // silently shrinks by whatever those holdings were worth. Log it so the dip is

--- a/backend/src/main/java/com/picsou/service/FinaryImportService.java
+++ b/backend/src/main/java/com/picsou/service/FinaryImportService.java
@@ -1,6 +1,7 @@
 package com.picsou.service;
 
 import com.picsou.dto.*;
+import com.picsou.finary.FinaryAccountMatcher;
 import com.picsou.finary.FinaryPersistenceHelper;
 import com.picsou.model.*;
 import com.picsou.repository.AccountRepository;
@@ -80,13 +81,42 @@ public class FinaryImportService {
                 ))
                 .collect(Collectors.toList());
 
-            List<AccountResponse> existing = accountRepository.findAllByMemberIdOrderByCreatedAtAsc(memberId).stream()
+            List<Account> existingAccounts = accountRepository.findAllByMemberIdOrderByCreatedAtAsc(memberId);
+            List<AccountResponse> existing = existingAccounts.stream()
                 .map(a -> AccountResponse.from(a, a.getCurrentBalance()))
                 .collect(Collectors.toList());
 
+            List<FinaryAccountMatcher.FinaryRow> rows = parsed.accounts.stream()
+                .map(acc -> new FinaryAccountMatcher.FinaryRow(
+                    slugify(acc.category() + "_" + acc.name()),
+                    acc.name(),
+                    acc.category(),
+                    slugify(acc.name())))
+                .toList();
+            List<Optional<FinaryAccountMatcher.Suggestion>> matches =
+                FinaryAccountMatcher.suggestAll(rows, existingAccounts);
+            boolean allAutoMapped = !rows.isEmpty() && matches.stream().allMatch(Optional::isPresent);
+            List<FinaryAccountMapping> suggested = new ArrayList<>();
+            for (int i = 0; i < parsed.accounts.size(); i++) {
+                var acc = parsed.accounts.get(i);
+                String finaryId = slugify(acc.category() + "_" + acc.name());
+                var match = matches.get(i);
+                if (match.isPresent()) {
+                    suggested.add(new FinaryAccountMapping(
+                        finaryId, acc.name(), acc.category(),
+                        FinaryMappingAction.MAP_EXISTING,
+                        match.get().account().getId(), null));
+                } else {
+                    suggested.add(new FinaryAccountMapping(
+                        finaryId, acc.name(), acc.category(),
+                        FinaryMappingAction.CREATE_NEW,
+                        null, null));
+                }
+            }
+
             int totalTx = (int) parsed.transactions.stream().count();
 
-            return new FinaryPreviewResponse(previews, existing, totalTx, fileToken, false, List.of());
+            return new FinaryPreviewResponse(previews, existing, totalTx, fileToken, allAutoMapped, suggested);
 
         } catch (IOException e) {
             throw new IllegalArgumentException("That file isn't a valid Excel spreadsheet (.xlsx).", e);

--- a/backend/src/main/resources/db/migration/V80__widen_holding_ticker.sql
+++ b/backend/src/main/resources/db/migration/V80__widen_holding_ticker.sql
@@ -1,0 +1,8 @@
+-- Finary (and similar aggregators) can return instrument codes longer than 30
+-- characters (RealT property tokens, long slugs). Holdings would otherwise fail
+-- the unique (account_id, ticker) insert.
+ALTER TABLE account_holding
+    ALTER COLUMN ticker TYPE VARCHAR(100);
+
+ALTER TABLE account_holding
+    ALTER COLUMN name TYPE VARCHAR(255);

--- a/backend/src/test/java/com/picsou/finary/FinaryAccountMatcherTest.java
+++ b/backend/src/test/java/com/picsou/finary/FinaryAccountMatcherTest.java
@@ -1,0 +1,105 @@
+package com.picsou.finary;
+
+import com.picsou.model.Account;
+import com.picsou.model.AccountType;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class FinaryAccountMatcherTest {
+
+    @Test
+    void prefersExternalIdOverName() {
+        Account byId = account(1L, "Other name", AccountType.CHECKING, "finary_checkings_abc");
+        Account byName = account(2L, "MR CHERRIER", AccountType.CHECKING, null);
+
+        Optional<FinaryAccountMatcher.Suggestion> hit = FinaryAccountMatcher.suggestAll(
+            List.of(new FinaryAccountMatcher.FinaryRow("abc", "MR CHERRIER", "checkings", null)),
+            List.of(byId, byName)
+        ).get(0);
+
+        assertThat(hit).isPresent();
+        assertThat(hit.get().account().getId()).isEqualTo(1L);
+        assertThat(hit.get().reason()).isEqualTo("externalId");
+    }
+
+    @Test
+    void matchesTrimmedNameAndCompatibleType() {
+        Account lbp = account(10L, "MR CHERRIER CHRISTOPHE", AccountType.CHECKING, null);
+        Account pea = account(11L, "PEA banque Postale ", AccountType.PEA, null);
+
+        List<Optional<FinaryAccountMatcher.Suggestion>> hits = FinaryAccountMatcher.suggestAll(
+            List.of(
+                new FinaryAccountMatcher.FinaryRow("c1", "MR CHERRIER CHRISTOPHE", "checkings", null),
+                new FinaryAccountMatcher.FinaryRow("p1", "PEA banque Postale", "investments", null)
+            ),
+            List.of(lbp, pea)
+        );
+
+        assertThat(hits.get(0)).isPresent();
+        assertThat(hits.get(0).get().account().getId()).isEqualTo(10L);
+        assertThat(hits.get(1)).isPresent();
+        assertThat(hits.get(1).get().account().getId()).isEqualTo(11L);
+        assertThat(hits.get(1).get().reason()).isEqualTo("name+type");
+    }
+
+    @Test
+    void doesNotMapSamePicsouAccountTwice() {
+        Account only = account(1L, "Coinbase", AccountType.CRYPTO, null);
+
+        List<Optional<FinaryAccountMatcher.Suggestion>> hits = FinaryAccountMatcher.suggestAll(
+            List.of(
+                new FinaryAccountMatcher.FinaryRow("a", "Coinbase", "cryptos", null),
+                new FinaryAccountMatcher.FinaryRow("b", "Coinbase", "cryptos", null)
+            ),
+            List.of(only)
+        );
+
+        assertThat(hits.get(0)).isPresent();
+        assertThat(hits.get(1)).isEmpty();
+    }
+
+    @Test
+    void distinguishesFortuneoAvByType() {
+        Account titres = account(1L, "Fortuneo Assurance-vie", AccountType.COMPTE_TITRES, null);
+        Account fonds = account(2L, "Fortuneo Assurance-vie", AccountType.SAVINGS, null);
+
+        List<Optional<FinaryAccountMatcher.Suggestion>> hits = FinaryAccountMatcher.suggestAll(
+            List.of(
+                new FinaryAccountMatcher.FinaryRow("inv", "Fortuneo Assurance-vie", "investments", null),
+                new FinaryAccountMatcher.FinaryRow("fe", "Fortuneo Assurance-vie", "fonds_euro", null)
+            ),
+            List.of(titres, fonds)
+        );
+
+        assertThat(hits.get(0).orElseThrow().account().getId()).isEqualTo(1L);
+        assertThat(hits.get(1).orElseThrow().account().getId()).isEqualTo(2L);
+    }
+
+    @Test
+    void leavesAmbiguousSameTypeUnmatched() {
+        Account a = account(1L, "Livret A", AccountType.SAVINGS, null);
+        Account b = account(2L, "Livret A", AccountType.SAVINGS, null);
+
+        Optional<FinaryAccountMatcher.Suggestion> hit = FinaryAccountMatcher.suggestAll(
+            List.of(new FinaryAccountMatcher.FinaryRow("x", "Livret A", "savings", null)),
+            List.of(a, b)
+        ).get(0);
+
+        assertThat(hit).isEmpty();
+    }
+
+    private static Account account(Long id, String name, AccountType type, String externalId) {
+        Account acc = Account.builder()
+            .name(name)
+            .type(type)
+            .currency("EUR")
+            .externalAccountId(externalId)
+            .build();
+        acc.setId(id);
+        return acc;
+    }
+}

--- a/backend/src/test/java/com/picsou/finary/FinaryApiSyncServiceTest.java
+++ b/backend/src/test/java/com/picsou/finary/FinaryApiSyncServiceTest.java
@@ -47,6 +47,7 @@ class FinaryApiSyncServiceTest {
     @Mock FamilyMemberRepository familyMemberRepository;
     @Mock FinarySessionRepository finarySessionRepository;
     @Mock FinaryPersistenceHelper persistenceHelper;
+    @Mock FinaryHoldingsImporter holdingsImporter;
 
     @InjectMocks FinaryApiSyncService service;
 
@@ -126,7 +127,7 @@ class FinaryApiSyncServiceTest {
 
     @Test
     void preview_includesLoanAccountsFromLoansEndpoint() {
-        FinaryAccountDto checking = new FinaryAccountDto(
+        FinaryAccountDto checking = FinaryAccountDto.withoutHoldings(
             "chk-1", "Checking", null, 1000.0, 1000.0, null,
             new FinaryAccountCurrency("EUR", "€"), false);
         FinaryLoanDto loan = new FinaryLoanDto(
@@ -156,7 +157,7 @@ class FinaryApiSyncServiceTest {
 
     @Test
     void execute_createsLoanAccount_fromLoanMapping() {
-        FinaryAccountDto checking = new FinaryAccountDto(
+        FinaryAccountDto checking = FinaryAccountDto.withoutHoldings(
             "chk-1", "Checking", null, 1000.0, 1000.0, null,
             new FinaryAccountCurrency("EUR", "€"), false);
         FinaryLoanDto loan = new FinaryLoanDto(
@@ -178,9 +179,11 @@ class FinaryApiSyncServiceTest {
             service.execute(preview.fileToken(), List.of(loanMapping), 1L);
 
         assertThat(result.accountsCreated()).isEqualTo(1);
+        org.mockito.Mockito.verify(holdingsImporter)
+            .importHoldings(org.mockito.ArgumentMatchers.any(Account.class), org.mockito.ArgumentMatchers.any());
 
         ArgumentCaptor<Account> captor = ArgumentCaptor.forClass(Account.class);
-        org.mockito.Mockito.verify(accountRepository).save(captor.capture());
+        org.mockito.Mockito.verify(accountRepository, org.mockito.Mockito.atLeastOnce()).save(captor.capture());
         Account saved = captor.getValue();
         assertThat(saved.getType()).isEqualTo(AccountType.LOAN);
         assertThat(saved.getExternalAccountId()).isEqualTo("finary_loans_loan-1");
@@ -197,6 +200,19 @@ class FinaryApiSyncServiceTest {
 
         // Repo convention: LOAN balances stored positive; negated only at aggregation.
         assertThat(dto.balance()).isEqualTo(12000.0);
+    }
+
+    @Test
+    void eurBalance_prefersDisplayBalanceOverNativeUsd() {
+        FinaryAccountDto usdWallet = new FinaryAccountDto(
+            "w1", "Bitcoin bridge wallet", null, 9179.30, 9179.30, null,
+            new FinaryAccountCurrency("USD", "$"), false,
+            7920.94, null, null, null, null, null, null, null);
+
+        assertThat(FinaryApiSyncService.eurBalance(usdWallet))
+            .isEqualByComparingTo("7920.94");
+        assertThat(FinaryApiSyncService.displayCurrency(usdWallet, "USD"))
+            .isEqualTo("EUR");
     }
 
     @Test

--- a/backend/src/test/java/com/picsou/finary/FinaryHoldingsImporterTest.java
+++ b/backend/src/test/java/com/picsou/finary/FinaryHoldingsImporterTest.java
@@ -1,0 +1,210 @@
+package com.picsou.finary;
+
+import com.picsou.adapter.OpenFigiIsinConverter;
+import com.picsou.finary.dto.FinaryAccountCurrency;
+import com.picsou.finary.dto.FinaryAccountDto;
+import com.picsou.finary.dto.FinaryAssetRefDto;
+import com.picsou.finary.dto.FinaryPositionDto;
+import com.picsou.finary.dto.FinarySecurityRefDto;
+import com.picsou.model.Account;
+import com.picsou.model.AccountHolding;
+import com.picsou.model.AccountType;
+import com.picsou.repository.AccountHoldingRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class FinaryHoldingsImporterTest {
+
+    @Mock AccountHoldingRepository holdingRepository;
+    @Mock OpenFigiIsinConverter isinConverter;
+    @InjectMocks FinaryHoldingsImporter importer;
+
+    @Test
+    void importHoldings_persistsSecurityWithOpenFigiTickerAndSkipsCash() {
+        when(isinConverter.resolve("FR0000120628"))
+            .thenReturn(new OpenFigiIsinConverter.TickerResult("CS.PA", "AXA"));
+        when(holdingRepository.save(any(AccountHolding.class)))
+            .thenAnswer(inv -> inv.getArgument(0));
+
+        Account account = account();
+        FinaryAccountDto finary = accountDto(
+            List.of(
+                security("AXA", "FR0000120628", 54, 1892.052, 2420.28, 528.228),
+                cashSecurity(3447.07)
+            ),
+            null,
+            null,
+            List.of(fiat(3447.07))
+        );
+
+        int saved = importer.importHoldings(account, finary);
+
+        assertThat(saved).isEqualTo(1);
+        assertThat(account.getCashBalance()).isEqualByComparingTo("6894.14");
+
+        ArgumentCaptor<AccountHolding> captor = ArgumentCaptor.forClass(AccountHolding.class);
+        verify(holdingRepository).save(captor.capture());
+        AccountHolding holding = captor.getValue();
+        assertThat(holding.getTicker()).isEqualTo("CS.PA");
+        assertThat(holding.getName()).isEqualTo("AXA");
+        assertThat(holding.getQuantity()).isEqualByComparingTo("54");
+        assertThat(holding.getAverageBuyIn()).isEqualByComparingTo("35.038");
+        assertThat(holding.getProviderValueEur()).isEqualByComparingTo("2420.28");
+        assertThat(holding.getProviderPnlEur()).isEqualByComparingTo("528.228");
+        assertThat(holding.getQuoteCurrency()).isEqualTo("EUR");
+    }
+
+    @Test
+    void importHoldings_usesCryptoCodeAndDisplayEurValues() {
+        when(holdingRepository.save(any(AccountHolding.class)))
+            .thenAnswer(inv -> inv.getArgument(0));
+
+        Account account = account();
+        FinaryPositionDto btc = new FinaryPositionDto(
+            "h1", null, "user_crypto", 0.14427879,
+            57343.07, 8273.39, 63622.0, 9179.30, 905.91,
+            7139.22, 54900.27, 7920.94, 781.73,
+            null,
+            new FinaryAssetRefDto(1L, "Bitcoin", "BTC", null, "currency"),
+            null
+        );
+        FinaryAccountDto finary = accountDto(null, List.of(btc), null, null);
+
+        importer.importHoldings(account, finary);
+
+        ArgumentCaptor<AccountHolding> captor = ArgumentCaptor.forClass(AccountHolding.class);
+        verify(holdingRepository).save(captor.capture());
+        AccountHolding holding = captor.getValue();
+        assertThat(holding.getTicker()).isEqualTo("BTC");
+        assertThat(holding.getName()).isEqualTo("Bitcoin");
+        assertThat(holding.getProviderValueEur()).isEqualByComparingTo("7920.94");
+        assertThat(holding.getCurrentPrice()).isEqualByComparingTo("54900.27");
+        assertThat(account.getCashBalance()).isNull();
+    }
+
+    @Test
+    void importHoldings_sanitizesLongRealTCodesAndFondsEuroName() {
+        when(holdingRepository.save(any(AccountHolding.class)))
+            .thenAnswer(inv -> inv.getArgument(0));
+
+        String longCode = "REALTOKEN-S-4478-LILLIBRIDGE-ST-DETROIT-MI";
+        FinaryPositionDto realt = new FinaryPositionDto(
+            "h2", null, "user_crypto", 2.0,
+            null, 80.0, null, 101.42, 21.42,
+            70.0, null, 87.5, 17.5,
+            null,
+            new FinaryAssetRefDto(2L, "RealT Detroit", longCode, null, "currency"),
+            null
+        );
+        FinaryPositionDto fonds = new FinaryPositionDto(
+            "fe1", "FDS EUROS SURAVENIR RENDEMENT", "fonds_euro", 1.0,
+            null, 20876.93, null, 20876.93, 0.0,
+            20876.93, null, 20876.93, 0.0,
+            null, null, null
+        );
+        FinaryAccountDto finary = accountDto(null, List.of(realt), List.of(fonds), null);
+
+        int saved = importer.importHoldings(account(), finary);
+
+        assertThat(saved).isEqualTo(2);
+        ArgumentCaptor<AccountHolding> captor = ArgumentCaptor.forClass(AccountHolding.class);
+        verify(holdingRepository, org.mockito.Mockito.times(2)).save(captor.capture());
+        assertThat(captor.getAllValues())
+            .extracting(AccountHolding::getTicker)
+            .containsExactlyInAnyOrder(
+                longCode,
+                "FINARY_FDS_EUROS_SURAVENIR_RENDEMENT"
+            );
+        assertThat(longCode.length()).isLessThanOrEqualTo(FinaryHoldingsImporter.TICKER_MAX);
+    }
+
+    @Test
+    void importHoldings_clearsExistingWhenFinaryHasNoPositions() {
+        FinaryAccountDto empty = accountDto(null, null, null, null);
+
+        int saved = importer.importHoldings(account(), empty);
+
+        assertThat(saved).isZero();
+        verify(holdingRepository).deleteByAccountId(9L);
+        verify(holdingRepository, never()).save(any());
+    }
+
+    @Test
+    void isCash_detectsSoldeEspecesAndFiats() {
+        assertThat(FinaryHoldingsImporter.isCash(cashSecurity(10))).isTrue();
+        assertThat(FinaryHoldingsImporter.isCash(fiat(10))).isTrue();
+        assertThat(FinaryHoldingsImporter.isCash(
+            security("AXA", "FR0000120628", 1, 1, 1, 0))).isFalse();
+    }
+
+    @Test
+    void sanitizeTicker_uppercasesStripsAndTruncates() {
+        assertThat(FinaryHoldingsImporter.sanitizeTicker(" btc ")).isEqualTo("BTC");
+        assertThat(FinaryHoldingsImporter.sanitizeTicker("Foo Bar/Baz")).isEqualTo("FOO_BAR_BAZ");
+        String over = "A".repeat(120);
+        assertThat(FinaryHoldingsImporter.sanitizeTicker(over)).hasSize(100);
+    }
+
+    private static Account account() {
+        return Account.builder()
+            .id(9L)
+            .name("PEA")
+            .type(AccountType.PEA)
+            .currency("EUR")
+            .currentBalance(BigDecimal.ZERO)
+            .build();
+    }
+
+    private static FinaryAccountDto accountDto(
+            List<FinaryPositionDto> securities,
+            List<FinaryPositionDto> cryptos,
+            List<FinaryPositionDto> fondsEuro,
+            List<FinaryPositionDto> fiats) {
+        return new FinaryAccountDto(
+            "acc-1", "PEA", null, 1000.0, 1000.0, null,
+            new FinaryAccountCurrency("EUR", "€"), false,
+            1000.0, securities, cryptos, fondsEuro, fiats, null, null, null);
+    }
+
+    private static FinaryPositionDto security(
+            String name, String isin, double qty, double buy, double value, double pnl) {
+        return new FinaryPositionDto(
+            "s1", name, "user_security", qty,
+            buy / qty, buy, null, value, pnl,
+            buy, null, value, pnl,
+            new FinarySecurityRefDto(1L, name, isin, null, null, "security"),
+            null, null);
+    }
+
+    private static FinaryPositionDto cashSecurity(double value) {
+        return new FinaryPositionDto(
+            "cash", "Solde Espèces", "user_security", value,
+            1.0, value, 1.0, value, 0.0,
+            value, 1.0, value, 0.0,
+            new FinarySecurityRefDto(2L, "Solde Espèces", null, "000000000000", null, "security"),
+            null, null);
+    }
+
+    private static FinaryPositionDto fiat(double value) {
+        return new FinaryPositionDto(
+            "f1", "Euro", "user_fiat", value,
+            1.0, value, 1.0, value, 0.0,
+            value, 1.0, value, 0.0,
+            null, null,
+            new FinaryAssetRefDto(1L, "Euro", "EUR", "€", "currency"));
+    }
+}

--- a/backend/src/test/java/com/picsou/finary/dto/FinaryAccountHoldingsDtoTest.java
+++ b/backend/src/test/java/com/picsou/finary/dto/FinaryAccountHoldingsDtoTest.java
@@ -1,0 +1,62 @@
+package com.picsou.finary.dto;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class FinaryAccountHoldingsDtoTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    void accountEnvelope_parsesHoldingsAndDisplayBalance() throws Exception {
+        String json = """
+            {
+              "result": [
+                {
+                  "id": "acc-1",
+                  "name": "Yomoni PER",
+                  "balance": 245920.75,
+                  "display_balance": 245920.75,
+                  "currency": { "code": "EUR", "symbol": "€" },
+                  "securities": [
+                    {
+                      "quantity": 191.27,
+                      "buying_value": 21774.18,
+                      "current_value": 23187.66,
+                      "unrealized_pnl": 1413.48,
+                      "display_buying_value": 21774.18,
+                      "display_current_value": 23187.66,
+                      "display_unrealized_pnl": 1413.48,
+                      "security": {
+                        "name": "Yomoni Allocation ISR P",
+                        "isin": "FR0050000282",
+                        "symbol": "0P0001PK78"
+                      }
+                    }
+                  ],
+                  "fiats": [],
+                  "cryptos": [],
+                  "fonds_euro": []
+                }
+              ]
+            }
+            """;
+
+        FinaryEnvelope<List<FinaryAccountDto>> envelope = objectMapper.readValue(json,
+            objectMapper.getTypeFactory().constructParametricType(
+                FinaryEnvelope.class,
+                objectMapper.getTypeFactory().constructCollectionType(List.class, FinaryAccountDto.class)));
+
+        FinaryAccountDto acc = envelope.result().get(0);
+        assertThat(acc.displayBalance()).isEqualTo(245920.75);
+        assertThat(acc.securities()).hasSize(1);
+        FinaryPositionDto line = acc.securities().get(0);
+        assertThat(line.security().isin()).isEqualTo("FR0050000282");
+        assertThat(line.displayCurrentValue()).isEqualTo(23187.66);
+        assertThat(acc.fondsEuro()).isEmpty();
+    }
+}

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -54,6 +54,29 @@ server {
         proxy_set_header X-Forwarded-Port  $picsou_xfport;
     }
 
+    # Embedded MCP server (HTTP+SSE: GET /mcp stream + POST /mcp/message).
+    # Without this block, /mcp falls through to the SPA try_files and clients
+    # receive index.html instead of the Spring AI MCP transport.
+    location /mcp {
+        proxy_pass http://127.0.0.1:9090;
+        proxy_hide_header Strict-Transport-Security;   # see /api block
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $picsou_xfp;
+        proxy_set_header X-Forwarded-Host  $picsou_xfh;
+        proxy_set_header X-Forwarded-Port  $picsou_xfport;
+        # SSE: do not buffer the event stream; keep the connection open.
+        proxy_http_version 1.1;
+        proxy_set_header Connection '';
+        proxy_buffering off;
+        proxy_cache off;
+        chunked_transfer_encoding off;
+        proxy_connect_timeout 30s;
+        proxy_read_timeout 3600s;
+        proxy_send_timeout 3600s;
+    }
+
     # Cache static assets
     location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
         expires 1y;

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -64,7 +64,7 @@
 | Internationalization (FR/EN/DE/ES) | 2026-07-07 | [i18n.md](./features/i18n.md) |
 | MCP server + scoped access-keys | 2026-06-05 | [mcp-server.md](./features/mcp-server.md) |
 | Frontend utilities (lib/utils.ts) | 2026-08-07 | [frontend-utils.md](./features/frontend-utils.md) |
-| Demo mode | 2026-04-08 | [demo-mode.md](./features/demo-mode.md) |
+| Demo mode | 2026-08-17 | [demo-mode.md](./features/demo-mode.md) |
 | Theme (dark / light / system) + theme-adaptive rendering | 2026-06-02 | [theme-persistence.md](./features/theme-persistence.md) |
 | Dashboard — Time range isolation | 2026-04-13 | [dashboard-time-range-isolation.md](./features/dashboard-time-range-isolation.md) |
 | Dashboard — Liabilities separated from performance | 2026-07-08 | [dashboard-liabilities-separation.md](./features/dashboard-liabilities-separation.md) |
@@ -81,9 +81,9 @@
 | Savings goals | 2026-06-02 | [goals.md](./features/goals.md) |
 | Goals — Grid view (donuts) | 2026-06-02 | [goal-calendar-donut.md](./features/goal-calendar-donut.md) |
 | Price service | 2026-08-07 | [price-service.md](./features/price-service.md) |
-| Live prices (holdings) | 2026-05-19 | [live-prices-holdings.md](./features/live-prices-holdings.md) |
+| Live prices (holdings) | 2026-08-17 | [live-prices-holdings.md](./features/live-prices-holdings.md) |
 | Security Insight (asset type + ETF composition) | 2026-06-02 | [security-insight.md](./features/security-insight.md) |
-| Finary import + auto-sync | 2026-04-21 | [finary-import.md](./features/finary-import.md) |
+| Finary import + auto-sync | 2026-08-17 | [finary-import.md](./features/finary-import.md) |
 | CSV transaction import (investment accounts) | 2026-07-11 | [csv-transaction-import.md](./features/csv-transaction-import.md) |
 | Realized P&L on closed positions | 2026-07-11 | [realized-pnl.md](./features/realized-pnl.md) |
 | Manual transactions + holdings derivation | 2026-04-21 | [manual-transactions.md](./features/manual-transactions.md) |
@@ -91,7 +91,7 @@
 | Accounts overview (PnL chart + summary card + filters + card anatomy) | 2026-08-13 | [accounts-overview.md](./features/accounts-overview.md) |
 | Logos on account cards (catalog-resolved, bundled, wallet picker, property kind) | 2026-08-13 | [bank-logos.md](./features/bank-logos.md) |
 | Add Account modal (unified sync + manual) | 2026-08-13 | [add-account-modal.md](./features/add-account-modal.md) |
-| Docker deployment | 2026-07-19 | [docker-deployment.md](./features/docker-deployment.md) |
+| Docker deployment | 2026-08-17 | [docker-deployment.md](./features/docker-deployment.md) |
 | Navigation (sidebar + mobile bottom nav) | 2026-07-12 | [sidebar-navigation.md](./features/sidebar-navigation.md) |
 | UI control shape (shadcn theme radius) | 2026-08-10 | [ui-control-shape-system.md](./features/ui-control-shape-system.md) |
 | Multi-account family system | 2026-07-07 | [multi-account-family.md](./features/multi-account-family.md) |

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -91,7 +91,7 @@
 | Accounts overview (PnL chart + summary card + filters + card anatomy) | 2026-08-13 | [accounts-overview.md](./features/accounts-overview.md) |
 | Logos on account cards (catalog-resolved, bundled, wallet picker, property kind) | 2026-08-13 | [bank-logos.md](./features/bank-logos.md) |
 | Add Account modal (unified sync + manual) | 2026-08-13 | [add-account-modal.md](./features/add-account-modal.md) |
-| Docker deployment | 2026-08-17 | [docker-deployment.md](./features/docker-deployment.md) |
+| Docker deployment | 2026-09-04 | [docker-deployment.md](./features/docker-deployment.md) |
 | Navigation (sidebar + mobile bottom nav) | 2026-07-12 | [sidebar-navigation.md](./features/sidebar-navigation.md) |
 | UI control shape (shadcn theme radius) | 2026-08-10 | [ui-control-shape-system.md](./features/ui-control-shape-system.md) |
 | Multi-account family system | 2026-07-07 | [multi-account-family.md](./features/multi-account-family.md) |

--- a/docs/conventions/database.md
+++ b/docs/conventions/database.md
@@ -66,8 +66,10 @@ V{n}__description.sql
 | `V30__account_soft_delete.sql` | Soft-delete (`deleted_at`) on `account` |
 | `V31__price_cleanup_gate.sql` | Gate column controlling price-snapshot cleanup |
 | `V32__goal_history_start.sql` | `history_start` column anchoring goal trajectory charts |
+| … | Later numbered migrations continue sequentially (V37+) |
+| `V80__widen_holding_ticker.sql` | `account_holding.ticker` 30→100, `name` 100→255 (Finary RealT codes) |
 
-Note: V8 is absent by design (skipped — never rolled into another migration).
+Note: V8 is absent by design (skipped — never rolled into another migration). Numbering after V32 is not contiguous (V33–V36 unused).
 
 ### Writing a new migration
 

--- a/docs/conventions/testing.md
+++ b/docs/conventions/testing.md
@@ -140,11 +140,12 @@ unspecified, so otherwise the other tests may assert against post-mutation state
 ## Frontend tests
 
 - **Unit tests:** Vitest (`vitest`) with `@testing-library/react` and `jsdom`.
-- **E2E tests:** Playwright (`@playwright/test`).
+- **E2E tests:** Playwright (`@playwright/test`) against demo mode. CI runs them
+  in the `e2e` job (`bun run test:e2e` after `playwright install --with-deps chromium`).
 - Run commands:
   ```bash
   bunx vitest run         # unit tests
-  bun run test:e2e        # E2E tests
+  bun run test:e2e        # E2E tests (starts Vite with VITE_DEMO_MODE=true)
   ```
 
 ## Running tests

--- a/docs/features/demo-mode.md
+++ b/docs/features/demo-mode.md
@@ -1,6 +1,6 @@
 # Feature: Demo mode
 
-> Last updated: 2026-04-08
+> Last updated: 2026-08-17
 
 ## Context
 
@@ -55,4 +55,6 @@ VITE_DEMO_MODE=true
 
 ## Tests
 
-The Playwright suite (`frontend/e2e/*.spec.ts`, `bun run test:e2e`) runs entirely against demo mode — it is the de-facto regression net for the handler table. Not run in CI; run it locally against a dev server started with `VITE_DEMO_MODE=true`.
+The Playwright suite (`frontend/e2e/*.spec.ts`, `bun run test:e2e`) runs entirely against demo mode — it is the de-facto regression net for the handler table. `playwright.config.ts` forces `VITE_DEMO_MODE=true` on the Vite dev server it starts, so a missing `frontend/.env` still runs the suite in demo mode.
+
+CI (`.github/workflows/ci.yml` job `e2e`) installs Chromium, runs the same command, and uploads `playwright-report/` on failure. A red e2e job blocks the Docker publish job.

--- a/docs/features/docker-deployment.md
+++ b/docs/features/docker-deployment.md
@@ -1,6 +1,6 @@
 # Feature: Docker deployment
 
-> Last updated: 2026-08-17
+> Last updated: 2026-09-04
 
 ## Context
 
@@ -166,6 +166,14 @@ docker compose -f docker/docker-compose.yml up
 
 `/mcp` is the embedded MCP HTTP+SSE transport (access-key auth). It must be proxied like
 `/api`; if nginx only has SPA `try_files`, MCP clients get HTML instead of the protocol.
+
+### Moving the stack to another machine
+
+Git has the images’ source, not the live install. Postgres lives in the `pgdata` volume;
+JWT / encryption / DB password live in `picsou_data` (`/data/.secrets/`). Copy **both**
+or Finary and bank secrets in the database will not decrypt. Commands, volume names, and
+the “build this branch, do not `compose pull` GHCR `:latest`” warning are in the root
+[README — Another machine](../../README.md#another-machine).
 
 ### Building a release archive
 

--- a/docs/features/docker-deployment.md
+++ b/docs/features/docker-deployment.md
@@ -1,6 +1,6 @@
 # Feature: Docker deployment
 
-> Last updated: 2026-07-21 (Bourse Direct internal sidecar)
+> Last updated: 2026-08-17
 
 ## Context
 
@@ -150,7 +150,7 @@ fixed at create time, so the new value is never seen.
 - `docker/Caddyfile` — optional TLS terminator (profile `tls`)
 - `services/tr-auth/Dockerfile` — tr-auth sidecar image
 - `services/bourse-direct-auth/Dockerfile` — Bourse Direct sidecar image
-- `docker/nginx.conf` — Nginx reverse proxy config
+- `docker/nginx.conf` — Nginx reverse proxy config (`/api`, `/actuator`, `/mcp` → backend)
 - `docker/supervisord.conf` — supervisor (nginx + backend)
 - `docker/entrypoint.sh` — secret bootstrap + HSTS snippet + exec supervisord
 
@@ -158,11 +158,14 @@ fixed at create time, so the new value is never seen.
 
 ```
 docker compose -f docker/docker-compose.yml up
-  → picsou:latest  (nginx:8080 → backend:9090)
+  → picsou:latest  (nginx:8080 → backend:9090 for /api, /actuator, /mcp)
   → docker-tr-auth (uvicorn:8001)
   → bourse-direct-auth (uvicorn:8001, internal only)
   → postgres:16-alpine (:5432)
 ```
+
+`/mcp` is the embedded MCP HTTP+SSE transport (access-key auth). It must be proxied like
+`/api`; if nginx only has SPA `try_files`, MCP clients get HTML instead of the protocol.
 
 ### Building a release archive
 
@@ -178,9 +181,14 @@ docker load < picsou-release.tar.gz
 
 ### Pulling from GHCR
 
-All three images are published by `.github/workflows/docker.yml` on every push
-(matrix build, one entry per image). To deploy from the registry instead of
-building or loading a tar.gz:
+All three images are published by `.github/workflows/docker.yml` **only after
+CI is green** (backend tests, frontend lint/typecheck/unit, Playwright e2e,
+bourse-direct sidecar). `ci.yml` calls that workflow on a successful `push` to
+`main` or a version tag — not on pull requests, so a failing test never
+produces `nightly` / `latest` / semver. `workflow_dispatch` on `docker.yml`
+remains a manual escape hatch (publish the current ref without re-running CI).
+
+To deploy from the registry instead of building or loading a tar.gz:
 
 ```bash
 # Replace 1.0.0 with the desired tag (nightly, branch name, or semver).
@@ -190,9 +198,10 @@ docker pull ghcr.io/zoeille/picsou-finance/bourse-direct-auth:1.0.0
 ```
 
 Tag scheme:
-- `main` push → `nightly`
-- other branch push → branch name (e.g. `1.0.0`, `feature-foo`)
-- version tag (`1.0.0` or `v1.0.0`) → `latest` + semver (`1.0.0`, `1.0`, `1`)
+- `main` push (CI green) → `nightly` + `latest`
+- version tag (`1.0.0` or `v1.0.0`, CI green) → `latest` + semver (`1.0.0`, `1.0`, `1`)
+- feature-branch pushes no longer publish an image (open a PR to run CI; use
+  `workflow_dispatch` on the Docker workflow if you need a one-off image)
 
 ### Build version shown in the app
 

--- a/docs/features/finary-import.md
+++ b/docs/features/finary-import.md
@@ -1,6 +1,6 @@
 # Feature: Finary Import
 
-> Last updated: 2026-07-07
+> Last updated: 2026-08-17
 
 ## Context
 
@@ -24,7 +24,7 @@ Authenticates directly with Finary via Clerk (their auth provider) and fetches a
 - **Authentication**: `FinaryApiClient.authenticate()` performs a 6-step Clerk OAuth flow: GET environment, GET client, POST sign_ins, (optionally POST TOTP), POST session touch, POST tokens. Returns a JWT for API calls.
 - **TOTP/2FA handling**: When Clerk returns `needs_second_factor`, the backend throws `TotpRequiredException` → HTTP 403. The frontend detects 403 on the preview mutation, shows a TOTP input field, then retries with `?totp={code}` as query parameter.
 - **Preview**: `preview(totp)` authenticates, fetches accounts from all 10 portfolio categories **plus the dedicated `/loans` endpoint** (loans are not exposed as a portfolio category), fetches transactions (paginated, 200 per page), caches everything with a `syncToken`, returns previews.
-- **Execute**: `execute(syncToken, mappings)` retrieves cached data, applies user mappings, creates/updates accounts, imports transactions.
+- **Execute**: `execute(syncToken, mappings)` retrieves cached data, applies user mappings, creates/updates accounts, imports holdings (positions) and transactions.
 
 ### Account mapping
 
@@ -35,6 +35,19 @@ Both paths present the user with a mapping screen where they choose for each Fin
 - **CREATE_NEW** -- Create a new Picsou account with user-specified name, type, provider, and color.
 
 Type suggestions are auto-computed from the Finary category via `FinaryPersistenceHelper.suggestTypeFromDisplayCategory()` or `suggestTypeFromApiCategory()`.
+
+### Holdings (API sync only)
+
+On execute / auto-sync, `FinaryHoldingsImporter` reads positions already nested on each account DTO:
+
+| Finary list | Picsou |
+|---|---|
+| `securities` | holding; ISIN → OpenFIGI ticker, else ISIN / symbol / slug |
+| `cryptos` | holding; ticker = crypto `code` (BTC, REG, RealT slug…) |
+| `fonds_euro`, `generic_assets`, `scpis`, `precious_metals` | holding; ticker `FINARY_<sanitized name>` |
+| `fiats` + "Solde Espèces" | `account.cash_balance`, not a holding |
+
+Each holding stores Finary's EUR `display_current_value` / `display_unrealized_pnl` as `provider_value_eur` / `provider_pnl_eur`, so unlisted instruments still value on the dashboard. Account `currentBalance` is `display_balance` when Finary sends it (native `balance` on a USD wallet is USD).
 
 ### Cache and session management
 
@@ -68,6 +81,8 @@ Possible status values: `OK`, `NEEDS_MAPPING`, `TOTP_REQUIRED`, `NOT_CONNECTED`.
 - `backend/src/main/java/com/picsou/exception/TotpRequiredException.java` -- Thrown when 2FA is required but no TOTP provided (returns 403)
 - `backend/src/main/java/com/picsou/exception/FinaryServiceUnavailableException.java` -- Thrown when Clerk/Finary APIs are unreachable (network, timeout, DNS); returns 502
 - `backend/src/main/java/com/picsou/finary/FinaryPersistenceHelper.java` -- Shared helper: account creation, snapshot reconstruction, transaction import (preserves manual transactions), type suggestion
+- `backend/src/main/java/com/picsou/finary/FinaryHoldingsImporter.java` -- Maps Finary `securities` / `cryptos` / `fonds_euro` / generic assets onto `account_holding`, records leftover cash on `account.cash_balance`
+- `backend/src/main/java/com/picsou/finary/dto/FinaryPositionDto.java` -- One Finary position line (`display_*` = EUR)
 - `backend/src/main/java/com/picsou/controller/FinaryImportController.java` -- REST endpoints for xlsx upload
 - `backend/src/main/java/com/picsou/controller/FinaryApiSyncController.java` -- REST endpoints for API sync (`/preview`, `/execute`, `/auto`)
 - `backend/src/main/java/com/picsou/finary/dto/` -- 14 DTOs for Finary API responses (incl. `FinaryLoanDto`)
@@ -100,7 +115,7 @@ FinaryImportService.executeImport(fileToken + mappings)
         |       +-- MAP_EXISTING: update balance, set externalAccountId
         |       +-- CREATE_NEW: create account, set externalAccountId
         |       +-- Reconstruct balance snapshots from transactions
-        |       +-- Import transactions
+        |       +-- Import transactions (xlsx has no holdings payload)
         +-- Remove from cache
         +-- Return result (counts + imported accounts)
 
@@ -138,7 +153,10 @@ User reviews + maps accounts
 FinaryApiSyncService.execute(syncToken + mappings)
         |
         +-- Retrieve cached session
-        +-- Apply mappings + import transactions
+        +-- Apply mappings
+        +-- Persist holdings (ISIN → OpenFIGI ticker, crypto code as ticker)
+        +-- Store display_balance as EUR currentBalance (fixes USD crypto wallets)
+        +-- Import transactions
         +-- Remove from cache
         +-- Return result
 
@@ -173,7 +191,7 @@ POST /api/finary/api-sync/auto
 | `FinaryServiceUnavailableException` → 502 | Distinguishes upstream outage (Clerk/Finary unreachable) from data sync issues; frontend shows "service unavailable" message | Returning 502 for all sync errors (confusing, cannot distinguish cause) |
 | `SyncException` → 422 | Data/sync issues (bad response, mapping failures) are client errors, not gateway errors | 502 BAD_GATEWAY (semantically wrong for data processing failures) |
 | Retry with exponential backoff | Transient HTTP 5xx and network errors from Clerk/Finary are common; retry reduces false failures | No retry (fails on first attempt even for transient issues) |
-| Auto-mapping by name | Simple heuristic that works for most cases after first manual import | ML-based matching (unnecessary complexity) |
+| Per-account mapping suggestions | Match by current `finary_{category}_{id}`, then legacy slug id, then unique name+type. One new Finary row must not wipe the rest | Fail-all on first miss (old behaviour: wizard defaulted every row to CREATE_NEW) |
 
 ## Gotchas / Pitfalls
 
@@ -182,8 +200,13 @@ POST /api/finary/api-sync/auto
 - **TOTP is a query parameter**: The TOTP code is sent as `?totp={code}` on the POST preview request. This avoids body parsing complexity but means the code is visible in server access logs.
 - **Preview tokens expire quickly**: XLSX tokens expire after 30 minutes, API sync tokens after 10 minutes. Users must complete the mapping within that window or re-upload.
 - **Clerk API version is hardcoded**: The `__clerk_api_version` and `_clerk_js_version` query parameters are hardcoded in `FinaryApiClient`. If Clerk updates, these may need to be updated.
-- **Account name matching is case-insensitive but exact**: Auto-mapping matches Finary account name to Picsou account name. If the user renamed an account in Picsou, it won't match.
+- **Account name matching is case-insensitive, trimmed, and type-aware**: a Finary `investments` row can map to PEA / CTO / épargne salariale with the same name; `fonds_euro` maps to SAVINGS/livrets, not the CTO of the same label. Two Coinbase wallets of type CRYPTO stay unmatched (ambiguous). After the first successful MAP_EXISTING, `externalAccountId` is written so the next auto-sync skips the wizard.
 - **Transactions are per-category**: API sync fetches transactions only from checkings, savings, investments, and credits categories. Other categories (real estate, cryptos) do not have a transactions endpoint.
+- **Holdings come from the account payload, not a separate endpoint**: `/portfolio/{cat}/holdings` is 404. Positions live on each account as `securities`, `cryptos`, `fonds_euro`, `fiats`, `generic_assets`, `scpis`, `precious_metals`. `FinaryHoldingsImporter` reads those lists on execute/auto-sync. XLSX import still has no holdings.
+- **Use `display_*` for EUR, never native `balance` on FX accounts**: USD crypto wallets report `balance` / `current_value` in USD. `display_balance` / `display_current_value` are already in the user's display currency (EUR). Storing native USD as EUR is what used to inflate those wallets ~80×.
+- **Cash is not a holding**: fiats and "Solde Espèces" (`symbol`/`isin` `000000000000`) go to `account.cash_balance`. Everything else is replaced on each sync (same wipe-and-write as Bourse Direct / TR).
+- **Many Finary instruments have no Yahoo ticker**: Yomoni fonds, RealT tokens, fonds euros, Amundi `QS…` employee-savings codes. `provider_value_eur` / `provider_pnl_eur` keep the Finary valuation so the live balance does not collapse to cash-only.
+- **Ticker column is VARCHAR(100)** (V80): RealT property codes exceed the old 30-char limit. Names widened to 255. `V64` on `origin/main` is already `backfill_trade_republic_valuations`.
 - **External IDs use Finary category + ID**: Format is `finary_{category}_{finaryId}`. This means the same Finary account always maps to the same external ID, preventing duplicates across imports.
 - **Loans come from a separate endpoint (issue #11)**: loan/mortgage accounts are *not* returned by the portfolio `credits`/`credit_accounts` categories — they live on the dedicated `/loans` endpoint. The API sync fetches them via `FinaryApiClient.fetchLoans()` and adapts each entry to the common `FinaryAccountDto` under a synthetic `loans` category (external ID `finary_loans_{id}`), so they flow through the normal preview/mapping/execute pipeline and map to `AccountType.LOAN`. The outstanding amount is stored as a **negative** balance (a loan is a liability). Only the balance is imported — the loans payload does not expose the original principal or interest rate, so **no `Debt` row is created**; the imported LOAN account shows a static balance until the user fills in the loan parameters for the amortization view (see [loans.md](loans.md)). The exact `/loans` JSON shape and path are best-effort from the issue's sample (`type`, `name`, `outstanding_amount`, `monthly_repayment`, `start_date`, `end_date`); `FinaryLoanDto` maps the snake_case keys explicitly and accepts camelCase aliases as a fallback.
 - **Import mapping wizard type dropdown includes all account types (fix #17)**: The `CREATE_NEW` type selector in `FinaryTab` now uses `ACCOUNT_TYPES` from `@/lib/constants` instead of a hard-coded subset. This ensures `LOAN` and `REAL_ESTATE` are available in the dropdown, so loans imported from `/loans` are no longer forced into `OTHER` when the user overrides the backend suggestion.
@@ -193,8 +216,12 @@ POST /api/finary/api-sync/auto
 ## Tests
 
 - `FinaryImportServiceTest` -- unit tests for xlsx parsing, type suggestion, mapping
+- `FinaryAccountMatcherTest` -- external-id vs name+type, duplicate names, Fortuneo AV vs fonds euros
 - `FinaryApiSyncServiceTest` -- unit tests for API sync flow, incl. loans appearing in the preview and being created as LOAN accounts on execute
 - `FinaryLoanDtoTest` -- unit tests for parsing the `/loans` payload (snake_case + camelCase aliases)
+- `FinaryHoldingsImporterTest` -- securities / crypto / fonds-euro mapping, cash skip, ticker sanitizing
+- `FinaryAccountHoldingsDtoTest` -- Jackson parse of `display_balance` + nested positions
+- `FinaryApiSyncServiceTest.eurBalance_prefersDisplayBalanceOverNativeUsd` -- stored balance uses display EUR, not native USD
 - Manual integration testing with real Finary accounts
 
 ## Links

--- a/docs/features/live-prices-holdings.md
+++ b/docs/features/live-prices-holdings.md
@@ -1,6 +1,6 @@
 # Feature: Live Prices in Holdings
 
-> Last updated: 2026-08-10
+> Last updated: 2026-08-17
 
 ## Context
 
@@ -129,15 +129,16 @@ For each past date, both `total` and `invested` are read from `balance_snapshot`
 - **`useAccountHoldings` still exists**: The old hook is kept for the `usePortfolio` hook which fetches holdings for all accounts (portfolio view). Switching it to live prices would trigger many price API calls at once.
 - **No polling**: Prices refresh only on navigation (TanStack Query stale time of 2 min). There is no auto-refresh or polling interval.
 - **Yahoo Finance is unofficial**: See [price-service.md](./price-service.md) gotchas. A stored quote is displayed only with its explicit `quoteCurrency`; it is never multiplied as EUR when that currency is unknown.
-- **Bourse Direct and Trade Republic write an EUR fallback**: `provider_value_eur` is accepted only from a broker that quotes in EUR — Bourse Direct as part of a fully reconciled snapshot, Trade Republic because its portfolio stream is EUR-denominated by construction (the same assumption already behind `TrAccountData.balanceEur`). Connectors that expose native-currency values without an explicit `quoteCurrency` still return `null`.
+- **Bourse Direct, Trade Republic and Finary write an EUR fallback**: `provider_value_eur` is accepted from a broker/aggregator that quotes in EUR — Bourse Direct as part of a fully reconciled snapshot, Trade Republic because its portfolio stream is EUR-denominated, Finary from `display_current_value`. Connectors that expose native-currency values without an explicit `quoteCurrency` still return `null`.
 - **`liveBalanceEur()` falls back per holding**: when Yahoo has no live price, the holding is valued at `provider_value_eur` before being dropped. Dropping it is the last resort, and it is what makes the dashboard P&L wrong (see the asymmetry gotcha below).
-- **Value and invested must cover the same holdings**: `liveBalanceEur` may drop an unpriced holding, but `DashboardService` and `AccountService.calculateInvestedAmount` still count its full cost basis. Any holding dropped from the value side while its cost basis remains understates P&L by exactly that cost basis (GH issue #76). The `provider_value_eur` fallback closes this for Bourse Direct and Trade Republic; a connector that populates neither can still hit it.
+- **Value and invested must cover the same holdings**: `liveBalanceEur` may drop an unpriced holding, but `DashboardService` and `AccountService.calculateInvestedAmount` still count its full cost basis. Any holding dropped from the value side while its cost basis remains understates P&L by exactly that cost basis (GH issue #76). The `provider_value_eur` fallback closes this for Bourse Direct, Trade Republic and Finary; a connector that populates neither can still hit it.
 - **`AccountService.toResponse()` computes a live balance**: for Bourse Direct it falls back to the complete stored broker total if even one Yahoo price is unavailable.
 - **`liveBalanceEur()` triggers price lookups**: Each call fetches holdings then queries `PriceService` per ticker. Don't call in tight loops. The Dashboard pre-loads holdings into a map to avoid N+1; Goals calls it per-account in the goal's account list (typically small).
 - **The account detail page does not re-sum holdings**: it displays the backend's `currentBalanceEur`, avoiding disagreement with cash and broker fallback rules.
 
 ## Tests
 
+- `AccountServiceTest.liveBalanceEur_usesBrokerPositionValue_whenLivePriceIsUnavailable`
 - Manual: navigate to a PEA/CT/Crypto account, verify `/api/prices` call in network tab and live prices in table
 - Manual: navigate to a checking/savings account, verify no `/api/prices` call
 

--- a/docs/features/mcp-server.md
+++ b/docs/features/mcp-server.md
@@ -1,6 +1,6 @@
 # Feature: Embedded MCP server + scoped access-keys
 
-> Last updated: 2026-06-05
+> Last updated: 2026-08-13 (nginx proxies `/mcp` with SSE settings)
 
 ## Context
 
@@ -143,6 +143,11 @@ and GDPR data export.
   `POST /mcp/message` (messages). Both are under `/mcp/**` so Property A's prefix check covers them.
   Do not "upgrade" to Streamable HTTP without bumping Spring AI past 1.0.x (which conflicts with the
   Boot 3.4.9 / Spring 6.2 pins — see `pom.xml`).
+- **Nginx must proxy `/mcp`, not only `/api`.** The all-in-one image and the split-stack frontend
+  both serve the SPA via `try_files` for unmatched paths. Without an explicit `location /mcp`
+  block, clients receive `index.html` (HTTP 200 HTML) instead of the MCP transport. Both
+  `docker/nginx.conf` and `frontend/nginx.conf` proxy `/mcp` to the backend with SSE-friendly
+  settings (`proxy_buffering off`, long `proxy_read_timeout`).
 - **Property B lives in `UserContext`, not the filter.** The guard is the first statement in
   `getMemberIdOverride()`: if the current `Authentication` is an `AccessKeyAuthentication`, return
   `null` *before* `isAdmin()` can open the `?memberId=` override. Removing it would let an

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -45,6 +45,28 @@ server {
         proxy_set_header X-Forwarded-Port  $picsou_xfport;
     }
 
+    # Embedded MCP server (HTTP+SSE: GET /mcp stream + POST /mcp/message).
+    # Without this block, /mcp falls through to the SPA try_files and clients
+    # receive index.html instead of the Spring AI MCP transport.
+    location /mcp {
+        proxy_pass http://backend:8080;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $picsou_xfp;
+        proxy_set_header X-Forwarded-Host  $picsou_xfh;
+        proxy_set_header X-Forwarded-Port  $picsou_xfport;
+        # SSE: do not buffer the event stream; keep the connection open.
+        proxy_http_version 1.1;
+        proxy_set_header Connection '';
+        proxy_buffering off;
+        proxy_cache off;
+        chunked_transfer_encoding off;
+        proxy_connect_timeout 30s;
+        proxy_read_timeout 3600s;
+        proxy_send_timeout 3600s;
+    }
+
     # Cache static assets
     location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
         expires 1y;

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -6,7 +6,9 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
   workers: process.env.CI ? 1 : undefined,
-  reporter: 'html',
+  reporter: process.env.CI
+    ? [['github'], ['html', { open: 'never' }]]
+    : 'html',
   use: {
     baseURL: process.env.PLAYWRIGHT_BASE_URL || 'https://localhost:5173',
     ignoreHTTPSErrors: true,
@@ -24,5 +26,9 @@ export default defineConfig({
     ignoreHTTPSErrors: true,
     reuseExistingServer: !process.env.CI,
     timeout: 120000,
+    env: {
+      ...process.env,
+      VITE_DEMO_MODE: 'true',
+    },
   },
 })

--- a/frontend/src/components/shared/AddAccountModal.tsx
+++ b/frontend/src/components/shared/AddAccountModal.tsx
@@ -69,6 +69,7 @@ import {
   PiggyBank,
 } from 'lucide-react'
 import type { ExchangeType, ChainType, AccountRequest, FinaryPreviewResponse, FinaryAccountMapping, FinaryMappingAction, FinaryImportResultResponse, AccountType } from '@/types/api'
+import { initialFinaryMappings } from '@/features/sync/finary-mappings'
 import { SUPPORTED_CHAINS, SUPPORTED_EXCHANGES, exchangeRequiresApiSecret } from '@/types/api'
 
 // ---------------------------------------------------------------------------
@@ -1000,20 +1001,7 @@ function FinaryWizard({ onDone, onBack }: { onDone: () => void; onBack: () => vo
   }
 
   function initMappings(preview: FinaryPreviewResponse) {
-    setMappings(preview.accounts.map((account, i) => ({
-      finaryId: account.finaryId,
-      finaryName: account.finaryName,
-      finaryCategory: account.finaryCategory,
-      action: 'CREATE_NEW' as FinaryMappingAction,
-      targetAccountId: undefined,
-      newAccount: {
-        name: account.finaryName,
-        type: account.suggestedType,
-        provider: account.finaryInstitution,
-        currency: account.nativeCurrency,
-        color: ACCOUNT_COLORS[i % ACCOUNT_COLORS.length],
-      },
-    })))
+    setMappings(initialFinaryMappings(preview))
   }
 
   function onFileSelected(e: React.ChangeEvent<HTMLInputElement>) {

--- a/frontend/src/features/sync/finary-mappings.test.ts
+++ b/frontend/src/features/sync/finary-mappings.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from 'vitest'
+import { initialFinaryMappings, typesCompatible } from './finary-mappings'
+import type { Account, FinaryPreviewResponse } from '@/types/api'
+
+function preview(partial: Partial<FinaryPreviewResponse>): FinaryPreviewResponse {
+  return {
+    accounts: [],
+    existingPicsouAccounts: [],
+    totalTransactionCount: 0,
+    fileToken: 'tok',
+    ...partial,
+  }
+}
+
+function account(id: number, name: string, type: Account['type']): Account {
+  return {
+    id,
+    name,
+    type,
+    currency: 'EUR',
+    currentBalance: 0,
+    provider: 'Finary',
+  } as Account
+}
+
+describe('initialFinaryMappings', () => {
+  it('uses backend MAP_EXISTING suggestions', () => {
+    const mappings = initialFinaryMappings(
+      preview({
+        accounts: [
+          {
+            finaryId: 'c1',
+            finaryName: 'MR CHERRIER CHRISTOPHE',
+            finaryInstitution: 'La Banque Postale',
+            finaryCategory: 'checkings',
+            suggestedType: 'CHECKING',
+            currentBalance: 100,
+            nativeCurrency: 'EUR',
+            transactionCount: 1,
+          },
+        ],
+        suggestedMappings: [
+          {
+            finaryId: 'c1',
+            finaryName: 'MR CHERRIER CHRISTOPHE',
+            finaryCategory: 'checkings',
+            action: 'MAP_EXISTING',
+            targetAccountId: 42,
+          },
+        ],
+      }),
+    )
+    expect(mappings[0].action).toBe('MAP_EXISTING')
+    expect(mappings[0].targetAccountId).toBe(42)
+  })
+
+  it('falls back to unique name+type when backend sent CREATE_NEW', () => {
+    const mappings = initialFinaryMappings(
+      preview({
+        accounts: [
+          {
+            finaryId: 'c1',
+            finaryName: 'BOURSORAMA BANQUE',
+            finaryInstitution: 'BoursoBank',
+            finaryCategory: 'checkings',
+            suggestedType: 'CHECKING',
+            currentBalance: 50,
+            nativeCurrency: 'EUR',
+            transactionCount: 0,
+          },
+        ],
+        existingPicsouAccounts: [account(7, 'BOURSORAMA BANQUE', 'CHECKING')],
+        suggestedMappings: [
+          {
+            finaryId: 'c1',
+            finaryName: 'BOURSORAMA BANQUE',
+            finaryCategory: 'checkings',
+            action: 'CREATE_NEW',
+          },
+        ],
+      }),
+    )
+    expect(mappings[0].action).toBe('MAP_EXISTING')
+    expect(mappings[0].targetAccountId).toBe(7)
+  })
+
+  it('does not reset every row to CREATE_NEW when one Finary account is new', () => {
+    const mappings = initialFinaryMappings(
+      preview({
+        accounts: [
+          {
+            finaryId: 'old',
+            finaryName: 'Livret A',
+            finaryInstitution: 'LBP',
+            finaryCategory: 'savings',
+            suggestedType: 'SAVINGS',
+            currentBalance: 1,
+            nativeCurrency: 'EUR',
+            transactionCount: 0,
+          },
+          {
+            finaryId: 'new',
+            finaryName: 'Nouveau wallet',
+            finaryInstitution: 'Ethereum',
+            finaryCategory: 'cryptos',
+            suggestedType: 'CRYPTO',
+            currentBalance: 1,
+            nativeCurrency: 'EUR',
+            transactionCount: 0,
+          },
+        ],
+        existingPicsouAccounts: [account(3, 'Livret A', 'LIVRET_A')],
+      }),
+    )
+    expect(mappings[0].action).toBe('MAP_EXISTING')
+    expect(mappings[0].targetAccountId).toBe(3)
+    expect(mappings[1].action).toBe('CREATE_NEW')
+  })
+})
+
+describe('typesCompatible', () => {
+  it('maps PEA to investments and Livret A to savings', () => {
+    expect(typesCompatible('investments', 'PEA')).toBe(true)
+    expect(typesCompatible('savings', 'LIVRET_A')).toBe(true)
+    expect(typesCompatible('checkings', 'CRYPTO')).toBe(false)
+  })
+})

--- a/frontend/src/features/sync/finary-mappings.ts
+++ b/frontend/src/features/sync/finary-mappings.ts
@@ -1,0 +1,101 @@
+import { ACCOUNT_COLORS } from '@/lib/constants'
+import type { AccountType, FinaryAccountMapping, FinaryPreviewResponse } from '@/types/api'
+
+const INVESTMENT_TYPES = new Set<AccountType>(['PEA', 'COMPTE_TITRES', 'EMPLOYEE_SAVINGS'])
+const SAVINGS_TYPES = new Set<AccountType>([
+  'SAVINGS',
+  'LIVRET_A',
+  'LDDS',
+  'LEP',
+  'LIVRET_JEUNE',
+  'PEL',
+  'CEL',
+])
+
+export function typesCompatible(category: string, type: AccountType): boolean {
+  const cat = category.toLowerCase().replace(/ /g, '_')
+  switch (cat) {
+    case 'checkings':
+    case 'checking':
+      return type === 'CHECKING'
+    case 'savings':
+    case 'fonds_euro':
+    case 'fonds-euro':
+      return SAVINGS_TYPES.has(type)
+    case 'investments':
+      return INVESTMENT_TYPES.has(type)
+    case 'cryptos':
+      return type === 'CRYPTO'
+    case 'loans':
+    case 'credits':
+      return type === 'LOAN' || type === 'OTHER'
+    case 'real_estates':
+    case 'real-estate':
+      return type === 'REAL_ESTATE'
+    default:
+      return type === 'OTHER'
+  }
+}
+
+/**
+ * Prefers backend suggestedMappings (external-id or name match). Falls back to a
+ * unique name+type match against existing Picsou accounts. Unmatched rows stay
+ * CREATE_NEW so a single new Finary account no longer resets the whole wizard.
+ */
+export function initialFinaryMappings(preview: FinaryPreviewResponse): FinaryAccountMapping[] {
+  const claimed = new Set<number>()
+  const suggestedById = new Map(
+    (preview.suggestedMappings ?? [])
+      .filter((m) => m.finaryId)
+      .map((m) => [m.finaryId, m]),
+  )
+  const existing = preview.existingPicsouAccounts ?? []
+
+  return preview.accounts.map((account, i) => {
+    const suggested = suggestedById.get(account.finaryId)
+    if (suggested?.action === 'MAP_EXISTING' && suggested.targetAccountId != null) {
+      claimed.add(suggested.targetAccountId)
+      return { ...suggested }
+    }
+
+    const needle = account.finaryName.trim().toLowerCase()
+    const nameHits = existing.filter(
+      (acc) =>
+        !claimed.has(acc.id) &&
+        acc.name.trim().toLowerCase() === needle &&
+        typesCompatible(account.finaryCategory, acc.type),
+    )
+    if (nameHits.length === 1) {
+      claimed.add(nameHits[0].id)
+      return {
+        finaryId: account.finaryId,
+        finaryName: account.finaryName,
+        finaryCategory: account.finaryCategory,
+        action: 'MAP_EXISTING',
+        targetAccountId: nameHits[0].id,
+      }
+    }
+
+    return createNewMapping(account, i)
+  })
+}
+
+function createNewMapping(
+  account: FinaryPreviewResponse['accounts'][number],
+  index: number,
+): FinaryAccountMapping {
+  return {
+    finaryId: account.finaryId,
+    finaryName: account.finaryName,
+    finaryCategory: account.finaryCategory,
+    action: 'CREATE_NEW',
+    targetAccountId: undefined,
+    newAccount: {
+      name: account.finaryName,
+      type: account.suggestedType,
+      provider: account.finaryInstitution,
+      currency: account.nativeCurrency,
+      color: ACCOUNT_COLORS[index % ACCOUNT_COLORS.length],
+    },
+  }
+}

--- a/frontend/src/pages/sync/FinaryTab.tsx
+++ b/frontend/src/pages/sync/FinaryTab.tsx
@@ -32,6 +32,7 @@ import {
   useExecuteFinaryApiSync,
   useFinaryAutoSync,
 } from '@/features/sync/hooks'
+import { initialFinaryMappings } from '@/features/sync/finary-mappings'
 import type {
   Account,
   FinaryPreviewResponse,
@@ -262,21 +263,7 @@ export function FinaryTab() {
   // ----- Mapping -----
 
   function initMappings(preview: FinaryPreviewResponse) {
-    const initialMappings: FinaryAccountMapping[] = preview.accounts.map((account) => ({
-      finaryId: account.finaryId,
-      finaryName: account.finaryName,
-      finaryCategory: account.finaryCategory,
-      action: 'CREATE_NEW' as FinaryMappingAction,
-      targetAccountId: undefined,
-      newAccount: {
-        name: account.finaryName,
-        type: account.suggestedType,
-        provider: account.finaryInstitution,
-        currency: account.nativeCurrency,
-        color: ACCOUNT_COLORS[preview.accounts.indexOf(account) % ACCOUNT_COLORS.length],
-      },
-    }))
-    setMappings(initialMappings)
+    setMappings(initialFinaryMappings(preview))
   }
 
   function setMappingAction(index: number, action: FinaryMappingAction) {


### PR DESCRIPTION
## Summary
- Import Finary positions (securities, crypto, fonds euros) on API sync, using `display_*` EUR values, and widen holding tickers (V80) for RealT codes.
- Suggest `MAP_EXISTING` per Finary row (external id, then unique name+type) so one new account no longer resets the whole mapping wizard to « Créer un nouveau compte ».
- Run Playwright e2e in CI (demo mode) and publish GHCR images only after backend, frontend, e2e and sidecars are green, on push to `main` or a version tag.
- Proxy `/mcp` through nginx so MCP SSE is not swallowed by the SPA.

## Test plan
- [ ] `cd backend && mvn test -Dtest=FinaryHoldingsImporterTest,FinaryAccountMatcherTest,FinaryApiSyncServiceTest,FinaryAccountHoldingsDtoTest`
- [ ] `cd frontend && bunx vitest run src/features/sync/finary-mappings.test.ts`
- [ ] Finary sync mapping: existing LBP/Bourso checking accounts preselect « Mapper à un compte existant »
- [ ] After import, investment accounts have holdings and EUR balances (not native USD on crypto wallets)
- [ ] CI: e2e job runs; docker job is skipped on the PR and would run on merge to main

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Finary API sync now imports investment holdings, cash balances, and EUR valuations.
  * Finary account previews provide smarter automatic matching suggestions, including account type compatibility and ambiguity handling.
  * Added support for accessing the MCP endpoint through the web interface.
  * Finary imports support longer security and asset identifiers.

* **Bug Fixes**
  * Holdings without live market prices now retain available provider valuations.

* **Documentation**
  * Updated Finary, Docker, migration, testing, and multi-machine setup guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->