### PR TITLE
fix(sync): keep tab labels inside their pill on SyncPage

### DIFF
--- a/frontend/src/pages/sync/SyncPage.tsx
+++ b/frontend/src/pages/sync/SyncPage.tsx
@@ -22,17 +22,17 @@ export function SyncPage() {
     <div className="space-y-6">
       <PageHeader title={t('sync.title')} />
       <Tabs defaultValue={defaultTab}>
-        <TabsList>
-          <TabsTrigger value="banks">{t('sync.banks.title')}</TabsTrigger>
-          <TabsTrigger value="exchanges">{t('sync.exchanges.title')}</TabsTrigger>
-          <TabsTrigger value="wallets">{t('sync.wallets.title')}</TabsTrigger>
-          <TabsTrigger value="tr">{t('sync.tr.title')}</TabsTrigger>
-          <TabsTrigger value="bourso">{t('sync.bourso.title')}</TabsTrigger>
-          <TabsTrigger value="bourse-direct">{t('sync.bourseDirect.title')}</TabsTrigger>
-          <TabsTrigger value="degiro">{t('sync.degiro.title')}</TabsTrigger>
-          <TabsTrigger value="ibkr">{t('sync.ibkr.title')}</TabsTrigger>
-          <TabsTrigger value="amundi">{t('sync.amundi.title')}</TabsTrigger>
-          <TabsTrigger value="finary">{t('sync.finary.title')}</TabsTrigger>
+        <TabsList className="w-full justify-start">
+          <TabsTrigger value="banks" className="flex-none">{t('sync.banks.title')}</TabsTrigger>
+          <TabsTrigger value="exchanges" className="flex-none">{t('sync.exchanges.title')}</TabsTrigger>
+          <TabsTrigger value="wallets" className="flex-none">{t('sync.wallets.title')}</TabsTrigger>
+          <TabsTrigger value="tr" className="flex-none">{t('sync.tr.title')}</TabsTrigger>
+          <TabsTrigger value="bourso" className="flex-none">{t('sync.bourso.title')}</TabsTrigger>
+          <TabsTrigger value="bourse-direct" className="flex-none">{t('sync.bourseDirect.title')}</TabsTrigger>
+          <TabsTrigger value="degiro" className="flex-none">{t('sync.degiro.title')}</TabsTrigger>
+          <TabsTrigger value="ibkr" className="flex-none">{t('sync.ibkr.title')}</TabsTrigger>
+          <TabsTrigger value="amundi" className="flex-none">{t('sync.amundi.title')}</TabsTrigger>
+          <TabsTrigger value="finary" className="flex-none">{t('sync.finary.title')}</TabsTrigger>
         </TabsList>
         <TabsContent value="banks" className="mt-6">
           <BankSyncTab />


### PR DESCRIPTION
Scoped fix for #102.

- `TabsList`: `w-full justify-start` (overrides primitive `w-fit justify-center` via twMerge, keeps `flex-wrap`)
- 10x `TabsTrigger`: `flex-none` (overrides `flex-1`, so triggers size to content instead of 121.7px each)

No edit to `components/ui/tabs.tsx` per frontend conventions. Other Tabs usages (DistributionPie 2 tabs, GoalCalendar 3 tabs) keep default flex-1 behavior.

Verified: `bun run typecheck`, `bun run lint`, `bun run build` OK. Subagent review: APPROVE.

Fixes #102.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the sync page’s tab layout to span the available width and align tabs to the left.
  * Adjusted tab sizing so each tab maintains its intended width behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->